### PR TITLE
Increase number of items per page in Feedback table

### DIFF
--- a/giskard-frontend/src/views/main/project/FeedbackList.vue
+++ b/giskard-frontend/src/views/main/project/FeedbackList.vue
@@ -62,6 +62,10 @@
           :items="feedbacks"
           :headers="tableHeaders"
           :search="search"
+          :items-per-page="25"
+          :footer-props="{
+            'items-per-page-options': [10, 25, 50, 100]
+          }"
           @click:row="openFeedback"
       >
         <!-- eslint-disable-next-line vue/valid-v-slot -->


### PR DESCRIPTION
## Description

The current default of 10 items give the wrong impression that there are not many feedback. It gives a negative effect in demos.

## Related Issue

[GSK-292](https://giskard.youtrack.cloud/issue/GSK-292/Increase-number-of-items-per-page-in-Feedback-table)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
