### PR TITLE
Bug/gsk 277 change default threshold for prediction drift chi square and earthmover

### DIFF
--- a/giskard-ml-worker/ml_worker/testing/drift_tests.py
+++ b/giskard-ml-worker/ml_worker/testing/drift_tests.py
@@ -446,7 +446,7 @@ class DriftTests(AbstractTestCollection):
                                          actual_slice: GiskardDataset,
                                          model: GiskardModel,
                                          max_categories: int = 10,
-                                         threshold: float = None,
+                                         threshold: float = 0.05,
                                          chi_square_contribution_percent: float = 0.2):
         """
         Test if the Chi Square value between the reference and actual datasets is below the threshold

--- a/giskard-ml-worker/ml_worker/testing/drift_tests.py
+++ b/giskard-ml-worker/ml_worker/testing/drift_tests.py
@@ -315,7 +315,7 @@ class DriftTests(AbstractTestCollection):
                                          reference_ds: GiskardDataset,
                                          actual_ds: GiskardDataset,
                                          column_name: str,
-                                         threshold: float = None) -> SingleTestResult:
+                                         threshold: float = 0.2) -> SingleTestResult:
         """
         Test if the earth movers distance between the actual and expected datasets is
         below the threshold for a given numerical feature
@@ -591,7 +591,7 @@ class DriftTests(AbstractTestCollection):
                                                     actual_slice: GiskardDataset,
                                                     model: GiskardModel,
                                                     classification_label=None,
-                                                    threshold=None) -> SingleTestResult:
+                                                    threshold=0.2) -> SingleTestResult:
         """
         Test if the Earth Mover’s Distance value between the reference and actual datasets is
         below the threshold for the classification labels predictions for classification

--- a/giskard-server/src/main/resources/aitest/code_test_templates/data_drift.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/data_drift.yml
@@ -174,5 +174,5 @@ items:
           actual_ds=actual_ds,
           reference_ds=reference_ds,
           column_name='{{NUMERIC FEATURE NAME}}',
-          threshold=0.1
+          threshold=0.2
       )

--- a/giskard-server/src/main/resources/aitest/code_test_templates/prediction_drift.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/prediction_drift.yml
@@ -96,7 +96,7 @@ items:
           actual_slice=actual_ds.slice(lambda df: df.head(len(df)//2)),
           reference_slice=reference_ds.slice(lambda df: df.tail(len(df)//2)),
           model=model,
-          threshold=0.2
+          threshold=0.05
       )
   - id: drift_reg_output_ks
     title: Regression Output drift (Kolmogorov–Smirnov)


### PR DESCRIPTION
## Description

- Default Threshold for chi square  prediction drift set to  0.05

- For all Earthmovers test threshold value set to  0.2

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
