### PR TITLE
Task/gsk 311 remove actual and reference slices in the output of tests in the documentation

### DIFF
--- a/giskard-server/src/main/resources/aitest/code_test_templates/data_drift.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/data_drift.yml
@@ -28,10 +28,6 @@ items:
       #                Threshold value for PSI
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of rows with given categorical feature in actual slice
-      #            reference_slices_size:
-      #                Length of rows with given categorical feature in reference slice
       #            metric:
       #                The total psi score between the actual and reference datasets
       #            passed:
@@ -72,10 +68,6 @@ items:
       #                Threshold for p-value of chi-square
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of rows with given categorical feature in actual slice
-      #            reference_slices_size:
-      #                Length of rows with given categorical feature in reference slice
       #            metric:
       #                The pvalue of chi square test
       #            passed:
@@ -116,10 +108,6 @@ items:
       #                Threshold for p-value of KS test
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of rows with given numerical feature in actual slice
-      #            reference_slices_size:
-      #                Length of rows with given numerical feature in reference slice
       #            metric:
       #                The pvalue of KS test
       #            passed:
@@ -160,10 +148,6 @@ items:
       #                Threshold for earth movers distance
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of rows with given numerical feature in actual slice
-      #            reference_slices_size:
-      #                Length of rows with given numerical feature in reference slice
       #            metric:
       #                The earth movers distance
       #            passed:

--- a/giskard-server/src/main/resources/aitest/code_test_templates/heuristic.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/heuristic.yml
@@ -32,8 +32,6 @@ items:
       #              Threshold for the percentage of passed rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metrics:
       #              The ratio of rows with the right classification label over the total of rows in the slice
       #          passed:
@@ -81,8 +79,6 @@ items:
       #              Threshold for the percentage of passed rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metrics:
       #              The proportion of rows in the right range inside the slice
       #          passed:
@@ -128,8 +124,6 @@ items:
       #              Threshold for the percentage of passed rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metrics:
       #              The proportion of rows in the right range inside the slice
       #          passed:

--- a/giskard-server/src/main/resources/aitest/code_test_templates/metamorphic.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/metamorphic.yml
@@ -34,8 +34,6 @@ items:
       #              Threshold of the ratio of invariant rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -110,8 +108,6 @@ items:
       #              Critical quantile above which the null hypothesis that the populations are different cannot be rejected
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -187,8 +183,6 @@ items:
       #              Critical quantile above which the null hypothesis that the populations are different cannot be rejected
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -266,8 +260,6 @@ items:
       #              regression if the ratio is above the output_sensitivity of 0.1
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -342,8 +334,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -418,8 +408,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -495,8 +483,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -568,8 +554,6 @@ items:
       #              Threshold of the ratio of increasing rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -643,8 +627,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -715,8 +697,6 @@ items:
       #              Threshold of the ratio of decreasing rows
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -791,8 +771,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:
@@ -867,8 +845,6 @@ items:
       #              One specific label value from the target column
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          message:
       #              Test result message
       #          metric:

--- a/giskard-server/src/main/resources/aitest/code_test_templates/performance.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/performance.yml
@@ -28,8 +28,6 @@ items:
       #              Threshold value of AUC metrics
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The AUC performance metric
       #          passed:
@@ -67,8 +65,6 @@ items:
       #              Threshold value for F1 Score
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The F1 score metric
       #          passed:
@@ -111,10 +107,6 @@ items:
       #              Threshold value for F1 Score difference
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The F1 Score difference  metric
       #          passed:
@@ -157,10 +149,6 @@ items:
       #          threshold(float):
       #              Threshold value for F1 Score difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The F1 Score difference  metric
       #          passed:
@@ -198,8 +186,6 @@ items:
       #          threshold(float):
       #              Threshold value for Accuracy
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The Accuracy metric
       #          passed:
@@ -240,10 +226,6 @@ items:
       #          threshold(float):
       #              Threshold value for Accuracy Score difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The Accuracy difference  metric
       #          passed:
@@ -286,10 +268,6 @@ items:
       #          threshold(float):
       #              Threshold value for Accuracy difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The Accuracy difference  metric
       #          passed:
@@ -327,8 +305,6 @@ items:
       #              Threshold value for Precision
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The Precision metric
       #          passed:
@@ -369,10 +345,6 @@ items:
       #          threshold(float):
       #              Threshold value for Precision difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The Precision difference  metric
       #          passed:
@@ -410,8 +382,6 @@ items:
       #              Threshold value for Recall
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The Recall metric
       #          passed:
@@ -453,10 +423,6 @@ items:
       #              Threshold value for Recall difference
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The Recall difference  metric
       #          passed:
@@ -493,8 +459,6 @@ items:
       #              Threshold value for RMSE
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The RMSE metric
       #          passed:
@@ -534,10 +498,6 @@ items:
       #          threshold(float):
       #              Threshold value for RMSE difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The RMSE difference  metric
       #          passed:
@@ -579,10 +539,6 @@ items:
       #          threshold(float):
       #              Threshold value for RMSE difference
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The RMSE difference  metric
       #          passed:
@@ -619,10 +575,6 @@ items:
       #              Threshold value for MAE
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
-      #          reference_slices_size:
-      #              Length of reference_slice tested
       #          metric:
       #              The MAE metric
       #          passed:
@@ -658,8 +610,6 @@ items:
       #              Threshold value for R-Squared
       #
       #      Returns:
-      #          actual_slices_size:
-      #              Length of actual_slice tested
       #          metric:
       #              The R-Squared metric
       #          passed:

--- a/giskard-server/src/main/resources/aitest/code_test_templates/prediction_drift.yml
+++ b/giskard-server/src/main/resources/aitest/code_test_templates/prediction_drift.yml
@@ -32,10 +32,6 @@ items:
       #                Threshold value for PSI
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric <= threshold
       #            metric:
@@ -80,10 +76,6 @@ items:
       #                Threshold value for Chi-Square
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric > threshold
       #            metric:
@@ -128,10 +120,6 @@ items:
       #                Threshold for p-value Kolmogorov-Smirnov test
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric >= threshold
       #            metric:
@@ -179,10 +167,6 @@ items:
       #                One specific label value from the target column for classification model
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric >= threshold
       #            metric:
@@ -228,10 +212,6 @@ items:
       #                Threshold for p-value Earth Mover’s Distance test
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric >= threshold
       #            metric:
@@ -277,10 +257,6 @@ items:
       #                Threshold for p-value Earth Mover’s Distance
       #
       #        Returns:
-      #            actual_slices_size:
-      #                Length of actual slice tested
-      #            reference_slices_size:
-      #                Length of reference slice tested
       #            passed:
       #                TRUE if metric >= threshold
       #            metric:


### PR DESCRIPTION
## Description

Removed actual and reference slices in the output of tests in the documentation

## Type of Change
- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
