### PR TITLE
Change "No external ML Worker is connected" color to warning

### DIFF
--- a/giskard-frontend/src/views/main/profile/UserProfile.vue
+++ b/giskard-frontend/src/views/main/profile/UserProfile.vue
@@ -267,7 +267,7 @@
                   </div>
                   <div v-show="externalWorkerSelected">
                     <v-alert
-                        color="primary"
+                        color="warning"
                         border="left"
                         outlined
                         colored-border


### PR DESCRIPTION
## Description

Change "No external ML Worker is connected" color to warning. UI nitpick.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
