### PR TITLE
#387 - Make LIME categories searchable

### DIFF
--- a/frontend/docs/vue2-vue3-migration.md
+++ b/frontend/docs/vue2-vue3-migration.md
@@ -126,3 +126,23 @@ const myRef = ref<MyType | null>(null);
 The [documentation](https://vuejs.org/guide/typescript/composition-api.html#typing-template-refs) notes:
 > Note that for strict type safety, it is necessary to use optional chaining or type guards when accessing el.value. This is because the initial ref value is null until the component is mounted, and it can also be set to null if the referenced element is unmounted by v-if.
 
+### Migrating store, router
+
+Vue 2
+```ts
+// In vue 2 you would use the store or router using
+this.$store/*.commit ... */;
+this.$route/*.query ...*/;
+```
+
+Vue 3
+```ts
+// However in Vue 3, `this` is not available so we declare references at the top of the file.
+import store from "@/store"; // this unlocks using the store later in the file
+import {useRoute, useRouter} from "vue-router/composables";
+
+const route = useRoute();
+const router = useRouter();
+
+// route.query... 
+```

--- a/frontend/docs/vue2-vue3-migration.md
+++ b/frontend/docs/vue2-vue3-migration.md
@@ -1,0 +1,82 @@
+// BEFORE MERGE: Is this documentation needed on the GitHub ? Should it be here ? 
+
+# Vue 2 > Vue 3 migration notes
+
+These are my notes on how to migrate between Vue 2 and Vue 3
+
+This guide is only valid in the context of Vue 2 SFC using TypeScript with `vue-property-decorator`
+It is mostly made of examples, I assume the reader read Vue's docs before to understand concepts.
+
+## Components
+
+### Migrating data
+
+Vue 2 uses a simple syntax to create reactive data. This block would be in a `<script lang="ts">` tag 
+```ts
+@Component()
+export default class MyComponent extends Vue {
+    myData: boolean = false;
+    
+    myFunction() {
+        myData = true;
+    }
+}
+```
+
+Vue 3 on the other hand uses ref declaration. The following block would be in a `<script setup lang="ts">` tag.
+```ts
+import { ref } from "vue";
+
+const myData = ref<boolean>(false);
+
+function myFunction() {
+    myData.value = true;
+}
+```
+
+### Migrating props
+
+Vue 2
+
+```ts
+@Prop({default: "hello world", required: true}) 
+myProp!: string;
+```
+
+Vue 3 - using defineProps (this does not cover defaults)
+```ts
+const props = defineProps<{
+  myProp: {type: String, required: true }
+}>();
+```
+
+Vue 3 - using defineProps with defaults
+```ts
+// The interface can also be used in the previous example, the ? operator makes things optional 
+interface Props {
+  myProp: string,
+  myNonRequiredProp?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  myProp: 'hello world'
+});
+```
+
+### Migrating watchers
+
+Vue 2 
+```ts
+@Watch("myData")
+watchMyData() {
+  this.loading = false;
+}
+```
+
+Vue 3
+```ts
+watch(() => myData, (oldValue, newValue) => {
+  loading.value = false;
+})
+```
+

--- a/frontend/docs/vue2-vue3-migration.md
+++ b/frontend/docs/vue2-vue3-migration.md
@@ -1,16 +1,15 @@
-// BEFORE MERGE: Is this documentation needed on the GitHub ? Should it be here ? 
-
 # Vue 2 > Vue 3 migration notes
 
-These are my notes on how to migrate between Vue 2 and Vue 3
-
 This guide is only valid in the context of Vue 2 SFC using TypeScript with `vue-property-decorator`
-It is mostly made of examples, I assume the reader read Vue's docs before to understand concepts.
+It is mostly made of examples, we assume the reader read Vue's docs before to understand concepts.
 
+## Useful links
+
+- [Vue 3's documentation](https://vuejs.org/guide/introduction.html)
+- [Vue 3's TypeScript documentation](https://vuejs.org/guide/typescript/overview.html)
+- 
 ## Components
-
 ### Migrating data
-
 Vue 2 uses a simple syntax to create reactive data. This block would be in a `<script lang="ts">` tag 
 ```ts
 @Component()
@@ -39,8 +38,10 @@ function myFunction() {
 Vue 2
 
 ```ts
-@Prop({default: "hello world", required: true}) 
-myProp!: string;
+class X { // ignore this class, it's just to it renders nicely
+    @Prop({default: "hello world", required: true})
+    myProp!: string;
+}
 ```
 
 Vue 3 - using defineProps (this does not cover defaults)
@@ -52,7 +53,7 @@ const props = defineProps<{
 
 Vue 3 - using defineProps with defaults
 ```ts
-// The interface can also be used in the previous example, the ? operator makes things optional 
+// The interface can also be used in the previous example, the ? operator marks as not required. 
 interface Props {
   myProp: string,
   myNonRequiredProp?: string
@@ -67,9 +68,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 Vue 2 
 ```ts
-@Watch("myData")
-watchMyData() {
-  this.loading = false;
+class X { // ignore this class, it's just to it renders nicely
+    @Watch("myData")
+    watchMyData() {
+        this.loading = false;
+    }
 }
 ```
 
@@ -79,4 +82,47 @@ watch(() => myData, (oldValue, newValue) => {
   loading.value = false;
 })
 ```
+
+### Migrating computed properties
+
+Vue 2
+```ts
+class X { // ignore this class it's just so it renders nicely.
+    public get myComputed(): string[] {
+        return helloWorld.split(' ');
+    }
+}
+```
+
+Vue 3
+```ts
+const myComputed = computed(() => {
+    return helloWorld.split(' ');
+});
+```
+
+### Migrating template refs
+
+Vue 2
+```ts
+// In the template, you could have ...
+// <input ref="myRef" />
+
+class X { // ignore this class, it's just to it renders nicely
+    $refs!: {
+        myRef: InstanceType<typeof MyType>;
+    };
+}
+```
+
+Vue 3
+```ts
+// In the template, you could have ...
+// <input ref="myRef" />
+
+const myRef = ref<MyType | null>(null);
+```
+
+The [documentation](https://vuejs.org/guide/typescript/composition-api.html#typing-template-refs) notes:
+> Note that for strict type safety, it is necessary to use optional chaining or type guards when accessing el.value. This is because the initial ref value is null until the component is mounted, and it can also be set to null if the referenced element is unmounted by v-if.
 

--- a/frontend/docs/vue2-vue3-migration.md
+++ b/frontend/docs/vue2-vue3-migration.md
@@ -78,7 +78,7 @@ class X { // ignore this class, it's just to it renders nicely
 
 Vue 3
 ```ts
-watch(() => myData, (oldValue, newValue) => {
+watch(() => myData, (value, oldValue) => {
   loading.value = false;
 })
 ```

--- a/frontend/src/views/main/project/TextExplanation.vue
+++ b/frontend/src/views/main/project/TextExplanation.vue
@@ -18,12 +18,12 @@
             <p class="caption secondary--text text--lighten-2 my-1">
               Classification Label
             </p>
-            <v-select
+            <v-autocomplete
                 dense
                 solo
                 v-model="selectedLabel"
                 :items="classificationLabels"
-            ></v-select>
+            ></v-autocomplete>
           </v-col>
           <v-col cols="2" class="d-flex align-center">
             <v-btn

--- a/frontend/src/views/main/project/TextExplanation.vue
+++ b/frontend/src/views/main/project/TextExplanation.vue
@@ -66,7 +66,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  inputData: () => {}
+  inputData: () => ({})
 });
 
 const loading = ref<boolean>(false);
@@ -76,7 +76,7 @@ const errorMsg = ref<string>("");
 const result = ref<{ [key: string]: string }>({});
 const submitted = ref<boolean>(false);
 
-watch(() => props.classificationResult, (value, oldValue) => {
+watch(() => props.classificationResult, (value) => {
   if (value && props.classificationLabels.includes(value)) {
     selectedLabel.value = value;
   } else {

--- a/frontend/src/views/main/project/TextExplanation.vue
+++ b/frontend/src/views/main/project/TextExplanation.vue
@@ -76,9 +76,9 @@ const errorMsg = ref<string>("");
 const result = ref<{ [key: string]: string }>({});
 const submitted = ref<boolean>(false);
 
-watch(() => props.classificationResult, (old, newVal) => {
-  if (newVal && props.classificationLabels.includes(newVal)) {
-    selectedLabel.value = newVal;
+watch(() => props.classificationResult, (value, oldValue) => {
+  if (value && props.classificationLabels.includes(value)) {
+    selectedLabel.value = value;
   } else {
     selectedLabel.value = props.classificationLabels[0];
   }

--- a/frontend/src/views/main/project/TextExplanation.vue
+++ b/frontend/src/views/main/project/TextExplanation.vue
@@ -2,7 +2,7 @@
   <div>
     <OverlayLoader :show="loading" absolute solid/>
     <v-container>
-      <p v-if="textFeatureNames.length == 0" class="text-center">None</p>
+      <p v-if="textFeatureNames.length === 0" class="text-center">None</p>
       <div v-else>
         <v-row>
           <v-col cols="5" v-if='textFeatureNames.length>1'>
@@ -50,80 +50,72 @@
   </div>
 </template>
 
-<script lang="ts">
-import {Component, Prop, Vue, Watch} from 'vue-property-decorator';
-import OverlayLoader from '@/components/OverlayLoader.vue';
-import {api} from '@/api';
+<script lang="ts" setup>
+import {ref, watch} from "vue";
 import mixpanel from "mixpanel-browser";
+import {api} from "@/api";
+import OverlayLoader from "@/components/OverlayLoader.vue";
 
-@Component({
-  components: {OverlayLoader},
+interface Props {
+  modelId: number,
+  datasetId: number,
+  textFeatureNames: string[],
+  classificationLabels: string[]
+  inputData?: object,
+  classificationResult: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  inputData: () => {}
+});
+
+const loading = ref<boolean>(false);
+const selectedFeature = ref<string>(props.textFeatureNames[0]);
+const selectedLabel = ref<string>(props.classificationResult || props.classificationLabels[0]);
+const errorMsg = ref<string>("");
+const result = ref<{ [key: string]: string }>({});
+const submitted = ref<boolean>(false);
+
+watch(() => props.classificationResult, (old, newVal) => {
+  if (newVal && props.classificationLabels.includes(newVal)) {
+    selectedLabel.value = newVal;
+  } else {
+    selectedLabel.value = props.classificationLabels[0];
+  }
+});
+
+watch([selectedFeature, props.inputData], () => {
+  submitted.value = false;
+  result.value = {};
+  errorMsg.value = "";
 })
-export default class TextExplanation extends Vue {
-  @Prop({required: true}) modelId!: number;
-  @Prop({required: true}) datasetId!: number;
-  @Prop({required: true}) textFeatureNames!: string[];
-  @Prop({required: true}) classificationLabels!: string[];
-  @Prop({default: {}}) inputData!: object;
-  @Prop() classificationResult!: string;
 
-  loading: boolean = false;
-  originalInputData = {}; // used for the watcher to trigger the explanation call
-  selectedFeature = "";
-  selectedLabel = this.classificationResult || this.classificationLabels[0];
-  errorMsg: string = "";
-  result: { [key: string]: string } = {};
-  submitted = false;
-
-  mounted() {
-    this.selectedFeature = this.textFeatureNames[0];
-  }
-
-  @Watch("classificationResult")
-  setSelectedLabel() {
-    if (this.classificationResult && this.classificationLabels.includes(this.classificationResult)) {
-      this.selectedLabel = this.classificationResult;
-    } else {
-      this.selectedLabel = this.classificationLabels[0];
+async function getExplanation() {
+  mixpanel.track('Run text explanation', {
+    modelId: props.modelId,
+    datasetId: props.datasetId
+  });
+  if (selectedFeature.value && props.inputData[selectedFeature.value].length) {
+    try {
+      loading.value = true;
+      errorMsg.value = "";
+      result.value = await api.explainText(
+          props.modelId,
+          props.datasetId,
+          props.inputData,
+          selectedFeature.value
+      );
+      submitted.value = true;
+    } catch (error) {
+      result.value = {};
+      errorMsg.value = error.response.data.detail;
+    } finally {
+      loading.value = false;
     }
-  }
-
-  public async getExplanation() {
-    mixpanel.track('Run text explanation', {
-      modelId: this.modelId,
-      datasetId: this.datasetId
-    });
-    if (this.selectedFeature && this.inputData[this.selectedFeature].length) {
-      try {
-        this.loading = true;
-        this.errorMsg = "";
-        const response = await api.explainText(
-            this.modelId,
-            this.datasetId,
-            this.inputData,
-            this.selectedFeature
-        );
-        this.result = response;
-        this.submitted = true;
-      } catch (error) {
-        this.result = {};
-        this.errorMsg = error.response.data.detail;
-      } finally {
-        this.loading = false;
-      }
-    } else {
-      // reset
-      this.errorMsg = "";
-      this.result = {};
-    }
-  }
-
-  @Watch("selectedFeature")
-  @Watch("inputData", {deep: true})
-  reset() {
-    this.submitted = false;
-    this.result = {};
-    this.errorMsg = "";
+  } else {
+    // reset
+    errorMsg.value = "";
+    result.value = {};
   }
 }
 </script>


### PR DESCRIPTION
## Description

- [x] Convert `<v-select>` to `<v-autocomplete>` to add simple search to LIME Categories
- [x] Migrate TeamExplanation.vue to use the Composition API
- [x] Add a small doc to help with component migration in the future

## Related Issue

#387 
#432 => Tick TeamExplanation.vue when merged

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
