### PR TITLE
Fix OverlayLoader's z-index being too high + rewrite w/ Composition API

### DIFF
--- a/frontend/src/components/OverlayLoader.vue
+++ b/frontend/src/components/OverlayLoader.vue
@@ -2,28 +2,32 @@
   <v-overlay :value="show" :absolute="absolute"
              :color="solid ? '#ffffff':'#cdcdcd90'" :opacity="solid ? 1: 0.46"
              :class="classes"
-             :z-index="1000">
+             :z-index="100">
     <v-progress-circular class="ma-2" :size="size" color="primary" indeterminate></v-progress-circular>
   </v-overlay>
 </template>
 
-<script lang="ts">
-import {Component, Prop, Vue} from 'vue-property-decorator';
+<script setup lang="ts">
+import {computed} from "vue";
 
-@Component
-export default class OverlayLoader extends Vue {
-  @Prop({default: 50}) size!: number;
-  @Prop({type: Boolean}) solid!: boolean;
-  @Prop({type: Boolean}) show!: boolean;
-  @Prop({type: Boolean}) absolute!: boolean;
-  @Prop({type: Boolean, default: false}) noFade!: boolean;
-
-  get classes() {
-    return {
-      'no-fade': this.noFade
-    }
-  }
+interface Props {
+  size: number,
+  solid: boolean,
+  show: boolean,
+  absolute: boolean,
+  noFade: boolean
 }
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 50,
+  noFade: false
+});
+
+const classes = computed(() => {
+  return {
+    'no-fade': props.noFade
+  }
+});
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Description

- [x] Fix OverlayLoader's z-index making it appear over dialogs
- [x] Rewrite OverlayLoader to use Composition API

## Related Issue

#590 
#432 
