### PR TITLE
Overview always has a teal color even when it's not selected #610

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -58,7 +58,7 @@ export default new Router({
                             },
                             children: [
                                 {
-                                    path: '',
+                                    path: 'overview',
                                     name: 'project-overview',
                                     component: () => import('./views/main/project/ProjectOverview.vue'),
                                     props: (route) => {


### PR DESCRIPTION
## Description
Overview wasn't changing color to light grey when not selected.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
#610 #621 
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)

