### PR TITLE
moved proba calculation from relative to absolute

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   workflow_dispatch:

--- a/python-client/giskard/ml_worker/testing/statistical_tests.py
+++ b/python-client/giskard/ml_worker/testing/statistical_tests.py
@@ -211,8 +211,8 @@ class StatisticalTests(AbstractTestCollection):
         protected_predictions = np.squeeze(model.run_predict(protected_ds).raw_prediction == positive_idx)
         unprotected_predictions = np.squeeze(model.run_predict(unprotected_ds).raw_prediction == positive_idx)
 
-        protected_proba = np.count_nonzero(protected_predictions)/len(protected_ds.df)
-        unprotected_proba = np.count_nonzero(unprotected_predictions)/len(unprotected_ds.df)
+        protected_proba = np.count_nonzero(protected_predictions)
+        unprotected_proba = np.count_nonzero(unprotected_predictions)
         disparate_impact_score = protected_proba/unprotected_proba
 
         messages = [TestMessage(

--- a/python-client/tests/test_statistical.py
+++ b/python-client/tests/test_statistical.py
@@ -110,4 +110,4 @@ def test_disparate_impact(german_credit_data, german_credit_model):
         model=german_credit_model,
         positive_outcome="Not default"
     )
-    assert results.passed, f"DI = {results.metric}"
+    assert not results.passed, f"DI = {results.metric}"


### PR DESCRIPTION
## Description

I had the disparate impact as ratio of average probabilities, while I believe it should be a sum of them instead.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 🥂 Improvement (non-breaking change which improves an existing feature)