### PR TITLE
Prevent range filter from breaking when range > table size

### DIFF
--- a/backend/src/main/java/ai/giskard/service/DatasetService.java
+++ b/backend/src/main/java/ai/giskard/service/DatasetService.java
@@ -98,7 +98,7 @@ public class DatasetService {
     public Table getRows(@NotNull Long id, @NotNull int rangeMin, @NotNull int rangeMax) {
         Table table = readTableByDatasetId(id);
         table.addColumns(IntColumn.indexColumn(GISKARD_DATASET_INDEX_COLUMN_NAME, table.rowCount(), 0));
-        return table.inRange(rangeMin, rangeMax);
+        return table.inRange(rangeMin, Math.min(table.rowCount(), rangeMax));
     }
 
     @Transactional


### PR DESCRIPTION
## Description

Tablesaw does not handle ranges bigger than tables so this just adds a small check. I found no other unprotected usages of inRange in our code.
