### PR TITLE
Add spinner when preparing import of projects

### DIFF
--- a/frontend/src/views/main/admin/settings/SettingsGeneral.vue
+++ b/frontend/src/views/main/admin/settings/SettingsGeneral.vue
@@ -288,7 +288,7 @@ async function initMLWorkerInfo() {
 }
 
 async function copyMLWorkerCommand() {
-  await copyToClipboard('giskard worker start -h ' + giskardAddress);
+  await copyToClipboard('giskard worker start -h ' + giskardAddress.value);
   mainStore.addNotification({content: 'Copied', color: '#262a2d'});
 }
 

--- a/frontend/src/views/main/project/ProjectsHome.vue
+++ b/frontend/src/views/main/project/ProjectsHome.vue
@@ -104,8 +104,7 @@
             <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn color="secondary" text @click="clearAndCloseDialog()">Cancel</v-btn>
-              <v-btn color="primary" text type="submit" :disabled="!file || preparingImport">Next</v-btn>
-              <v-progress-circular v-if="preparingImport" size="20" indeterminate color="primary"></v-progress-circular>
+              <v-btn color="primary" text type="submit" :disabled="!file" :loading="preparingImport">Next</v-btn>
             </v-card-actions>
           </v-form>
         </ValidationObserver>

--- a/frontend/src/views/main/project/ProjectsHome.vue
+++ b/frontend/src/views/main/project/ProjectsHome.vue
@@ -104,7 +104,8 @@
             <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn color="secondary" text @click="clearAndCloseDialog()">Cancel</v-btn>
-              <v-btn color="primary" text type="submit" :disabled="!file">Next</v-btn>
+              <v-btn color="primary" text type="submit" :disabled="!file || preparingImport">Next</v-btn>
+              <v-progress-circular v-if="preparingImport" size="20" indeterminate color="primary"></v-progress-circular>
             </v-card-actions>
           </v-form>
         </ValidationObserver>
@@ -220,6 +221,7 @@ const metadataDirectoryPath = ref<string>("");
 const loginsCurrentInstance = ref<string[]>([]);
 const loginsImportedProject = ref<string[]>([]);
 const mapLogins = ref<{ [key: string]: string }>({});
+const preparingImport = ref<boolean>(false);
 
 // template ref
 const dialogForm = ref<InstanceType<typeof ValidationObserver> | null>(null);
@@ -262,6 +264,7 @@ async function prepareImport() {
   if (!file.value) {
     return;
   }
+  preparingImport.value = true;
   let formData = new FormData();
   formData.append('file', file.value);
   return await api.prepareImport(formData)
@@ -280,6 +283,7 @@ async function prepareImport() {
         });
         newProjectKey.value = response.projectKey;
       })
+      .finally(() => preparingImport.value = false);
 }
 
 async function ImportIfNoConflictKey() {


### PR DESCRIPTION
## Description

Add a spinner and disable next button when preparing the import of a large project:
<img width="851" alt="image" src="https://user-images.githubusercontent.com/114553769/217569103-969b1a26-7074-4a3a-b6fa-fcf0a2c4ca58.png">

## Type of Change

- [x] 🥂 Improvement (non-breaking change which improves an existing feature)

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
