### PR TITLE
Fixed error related to tooltip in the inspector

### DIFF
--- a/frontend/src/views/main/project/Inspector.vue
+++ b/frontend/src/views/main/project/Inspector.vue
@@ -122,14 +122,14 @@
                   Global
                 </v-tab>
 
-                <v-tooltip bottom :disabled="textFeatureNames.length">
+                <v-tooltip bottom :disabled="textFeatureNames.length !== 0">
                   <template v-slot:activator="{ on, attrs }">
                     <div class="d-flex" v-on="on" v-bind="attrs">
-                      <v-tab :disabled="!textFeatureNames.length"> 
+                      <v-tab :disabled="!textFeatureNames.length">
                         <v-icon left>text_snippet</v-icon>
                         Text
                       </v-tab>
-                    </div>  
+                    </div>
                   </template>
                   <span>Text explanation is not available because your model does not contain any text features</span>
                 </v-tooltip>


### PR DESCRIPTION
## Description

Fixed an error in the console and not allowing the disabled text tab tooltip's explaination:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/114553769/220976906-37329be9-af66-4a60-9333-93f9eafee5a2.png">


## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
