### PR TITLE
Fix Giskard dev installation on Windows (no WSL)

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -65,3 +65,12 @@ it will use the default `pip` available in the environment. To install `giskard`
 ```shell
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/Giskard-AI/giskard-client/main/scripts/install-giskard-client-dev.sh)" - /path/to/pip
 ```
+
+
+## Windows caveats
+
+There are some extra steps required to use Giskard on Windows.
+
+If you get this error: `'EntryPoints' object has no attribute 'get'`
+Then please run:
+> pip install importlib-metadata==4.1F3.0

--- a/backend/src/main/resources/config/application-dev.yml
+++ b/backend/src/main/resources/config/application-dev.yml
@@ -110,4 +110,4 @@ jhipster:
 # ===================================================================
 
 giskard:
-  home: ${HOME}/giskard-home
+  home: ${user.home}/giskard-home

--- a/backend/src/main/resources/config/application-preprod.yml
+++ b/backend/src/main/resources/config/application-preprod.yml
@@ -108,4 +108,4 @@ jhipster:
 # ===================================================================
 
 giskard:
-  home: ${HOME}/giskard-home
+  home: ${user.home}/giskard-home

--- a/backend/src/test/resources/config/application.yml
+++ b/backend/src/test/resources/config/application.yml
@@ -120,5 +120,5 @@ giskard:
   invitation-token-validity-in-days: 3
   ml-worker-host: localhost
   ml-worker-port: 50051
-  home: ${HOME}/giskard-home
+  home: ${user.home}/giskard-home
   auth: true


### PR DESCRIPTION
This branch is meant to make a Giskard dev install work seamlessly when installing on Windows.

Here are the fixes it implements:

- Change giskard-home to be equal to `${user.home}/giskard-home` instead of `${HOME}/giskard-home` => user.home is provided by Spring and is compatible with all operating systems, HOME does not exist by default on Windows
- Add some documentation for common Python errors (working on making it happen by default instead of be in documentation at the moment....)