### PR TITLE
[GSK-829] Increase debounce timeout in Inspector

### DIFF
--- a/frontend/src/views/main/project/Inspector.vue
+++ b/frontend/src/views/main/project/Inspector.vue
@@ -108,6 +108,7 @@
               :predictionTask="model.modelType"
               :inputData="inputData"
               :modified="dirty || isInputNotOriginal"
+              :debouncingTimeout="debouncingTimeout"
               @result="setResult"
           />
           <v-card class="mb-4">
@@ -144,6 +145,7 @@
                                           :predictionTask="model.modelType"
                                           :inputData="inputData"
                                           :modelFeatures="modelFeatures"
+                                          :debouncingTimeout="debouncingTimeout"
                   />
                 </v-tab-item>
                 <v-tab-item v-if='textFeatureNames.length'>
@@ -195,6 +197,7 @@ export default class Inspector extends Vue {
   dataErrorMsg = ""
   classificationResult = null
   isClassification = isClassification
+  debouncingTimeout: number = 500;
 
   async mounted() {
     await this.loadMetaData();

--- a/frontend/src/views/main/project/PredictionExplanations.vue
+++ b/frontend/src/views/main/project/PredictionExplanations.vue
@@ -64,7 +64,7 @@ export default class PredictionExplanations extends Vue {
   @Prop() classificationLabels!: string[];
   @Prop({default: {}}) inputData!: object;
   @Prop() modelFeatures!: string[];
-  @Prop({default: 250}) debouncingTimeout!: number;
+  @Prop({default: 250}) debounceTime!: number;
 
 
   loading: boolean = false;
@@ -84,7 +84,7 @@ export default class PredictionExplanations extends Vue {
 
   private debouncedGetExplanation = _.debounce(async () => {
     await this.getExplanation();
-  }, this.debouncingTimeout);
+  }, this.debounceTime);
 
   private async getExplanation() {
     if (this.controller) {

--- a/frontend/src/views/main/project/PredictionExplanations.vue
+++ b/frontend/src/views/main/project/PredictionExplanations.vue
@@ -64,6 +64,8 @@ export default class PredictionExplanations extends Vue {
   @Prop() classificationLabels!: string[];
   @Prop({default: {}}) inputData!: object;
   @Prop() modelFeatures!: string[];
+  @Prop({default: 250}) debouncingTimeout!: number;
+
 
   loading: boolean = false;
   errorMsg: string = "";
@@ -82,7 +84,7 @@ export default class PredictionExplanations extends Vue {
 
   private debouncedGetExplanation = _.debounce(async () => {
     await this.getExplanation();
-  }, 250);
+  }, this.debouncingTimeout);
 
   private async getExplanation() {
     if (this.controller) {

--- a/frontend/src/views/main/project/PredictionResults.vue
+++ b/frontend/src/views/main/project/PredictionResults.vue
@@ -121,6 +121,8 @@ export default class PredictionResults extends Vue {
   @Prop() classificationLabels!: string[];
   @Prop() inputData!: { [key: string]: string };
   @Prop({default: false}) modified!: boolean;
+  @Prop({default: 250}) debouncingTimeout!: number;
+
 
   prediction: string | number | undefined = "";
   resultProbabilities: object = {};
@@ -149,7 +151,7 @@ export default class PredictionResults extends Vue {
 
   private debouncedSubmitPrediction = _.debounce(async () => {
     await this.submitPrediction();
-  }, 250);
+  }, this.debouncingTimeout);
 
   private async submitPrediction() {
     if (this.controller) {

--- a/frontend/src/views/main/project/PredictionResults.vue
+++ b/frontend/src/views/main/project/PredictionResults.vue
@@ -121,7 +121,7 @@ export default class PredictionResults extends Vue {
   @Prop() classificationLabels!: string[];
   @Prop() inputData!: { [key: string]: string };
   @Prop({default: false}) modified!: boolean;
-  @Prop({default: 250}) debouncingTimeout!: number;
+  @Prop({default: 250}) debounceTime!: number;
 
 
   prediction: string | number | undefined = "";
@@ -151,7 +151,7 @@ export default class PredictionResults extends Vue {
 
   private debouncedSubmitPrediction = _.debounce(async () => {
     await this.submitPrediction();
-  }, this.debouncingTimeout);
+  }, this.debounceTime);
 
   private async submitPrediction() {
     if (this.controller) {


### PR DESCRIPTION
## Description

This improvement aims to solve the problem when a user edits a feature value in the Inspector table.

1. Many requests were sent to the backend during this user interaction, so we're doubling the debounce time to alleviate that. 

2. Also, now we ensure that the PredictionResults and PredictionExplanations cards will always be requested at the same time, creating a single variable of debounce time to be used by both components.

## Related Issue

[Increase debounce timeout in Inspector (via Linear)](https://linear.app/giskard/issue/GSK-829/increase-debounce-timeout-in-inspector)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
