### PR TITLE
task/Numpy encoder for classification_labels

### DIFF
--- a/python-client/giskard/models/base/__init__.py
+++ b/python-client/giskard/models/base/__init__.py
@@ -24,6 +24,7 @@ from giskard.datasets.base import Dataset
 from giskard.ml_worker.utils.logging import Timer
 from giskard.path_utils import get_size
 from giskard.settings import settings
+from ..utils import numpy_encoder
 
 MODEL_CLASS_PKL = "ModelClass.pkl"
 
@@ -111,7 +112,7 @@ class BaseModel(ABC):
             name=name if name is not None else self.__class__.__name__,
             model_type=model_type,
             feature_names=list(feature_names) if feature_names else None,
-            classification_labels=classification_labels,
+            classification_labels=numpy_encoder(classification_labels),
             loader_class=self.__class__.__name__,
             loader_module=self.__module__,
             classification_threshold=classification_threshold,

--- a/python-client/giskard/models/base/__init__.py
+++ b/python-client/giskard/models/base/__init__.py
@@ -24,7 +24,7 @@ from giskard.datasets.base import Dataset
 from giskard.ml_worker.utils.logging import Timer
 from giskard.path_utils import get_size
 from giskard.settings import settings
-from ..utils import numpy_encoder
+from ..utils import np_types_to_native
 
 MODEL_CLASS_PKL = "ModelClass.pkl"
 
@@ -112,7 +112,7 @@ class BaseModel(ABC):
             name=name if name is not None else self.__class__.__name__,
             model_type=model_type,
             feature_names=list(feature_names) if feature_names else None,
-            classification_labels=numpy_encoder(classification_labels),
+            classification_labels=np_types_to_native(classification_labels),
             loader_class=self.__class__.__name__,
             loader_module=self.__module__,
             classification_threshold=classification_threshold,

--- a/python-client/giskard/models/utils.py
+++ b/python-client/giskard/models/utils.py
@@ -1,5 +1,7 @@
 import itertools
 from collections.abc import Iterator
+from typing import List
+import numpy as np
 
 
 def map_to_tuples(data: Iterator):
@@ -10,3 +12,12 @@ def map_to_tuples(data: Iterator):
         return data
 
     return map(lambda x: (x,), data)
+
+
+def numpy_encoder(l: List):
+    e = l[0]
+    if isinstance(e, np.integer):
+        return [int(i) for i in l]
+    if isinstance(e, np.floating):
+        return [float(i) for i in l]
+    return l

--- a/python-client/giskard/models/utils.py
+++ b/python-client/giskard/models/utils.py
@@ -14,10 +14,10 @@ def map_to_tuples(data: Iterator):
     return map(lambda x: (x,), data)
 
 
-def numpy_encoder(l: List):
-    if l is not None:
-        if isinstance(l[0], np.integer):
-            return [int(i) for i in l]
-        if isinstance(l[0], np.floating):
-            return [float(i) for i in l]
-    return l
+def numpy_encoder(some_list: List):
+    if some_list is not None:
+        if isinstance(some_list[0], np.integer):
+            return [int(i) for i in some_list]
+        if isinstance(some_list[0], np.floating):
+            return [float(i) for i in some_list]
+    return some_list

--- a/python-client/giskard/models/utils.py
+++ b/python-client/giskard/models/utils.py
@@ -15,9 +15,9 @@ def map_to_tuples(data: Iterator):
 
 
 def numpy_encoder(l: List):
-    e = l[0]
-    if isinstance(e, np.integer):
-        return [int(i) for i in l]
-    if isinstance(e, np.floating):
-        return [float(i) for i in l]
+    if l is not None:
+        if isinstance(l[0], np.integer):
+            return [int(i) for i in l]
+        if isinstance(l[0], np.floating):
+            return [float(i) for i in l]
     return l

--- a/python-client/giskard/models/utils.py
+++ b/python-client/giskard/models/utils.py
@@ -14,10 +14,7 @@ def map_to_tuples(data: Iterator):
     return map(lambda x: (x,), data)
 
 
-def numpy_encoder(some_list: List):
+def np_types_to_native(some_list: List):
     if some_list is not None:
-        if isinstance(some_list[0], np.integer):
-            return [int(i) for i in some_list]
-        if isinstance(some_list[0], np.floating):
-            return [float(i) for i in some_list]
+        return [i.item() if isinstance(i, np.generic) else i for i in some_list]
     return some_list


### PR DESCRIPTION
Solves the `Object of type int64 is not JSON serializable` issue mainly encountered in `sklearn` and `catboost` models where `.classes_` is a numpy array.