### PR TITLE
Hide threshold for non-binary classification models

### DIFF
--- a/frontend/src/views/main/project/PredictionResults.vue
+++ b/frontend/src/views/main/project/PredictionResults.vue
@@ -45,8 +45,11 @@
 
             </div>
             <div class="caption">
-              <div v-if="targetFeature">target: {{ targetFeature }}</div>
-              <div v-if="model && model.threshold">threshold: {{ model.threshold }}</div>
+                <div v-if="targetFeature">target: {{ targetFeature }}</div>
+                <div v-if="model && model.threshold && (model.modelType != ModelType.CLASSIFICATION || model.classificationLabels.length == 2)">
+                    threshold:
+                    {{ model.threshold }}
+                </div>
             </div>
           </div>
         </v-col>


### PR DESCRIPTION
## Description

Hides the threshold in AI debugger for non-binary classification models:
<img width="803" alt="image" src="https://github.com/Giskard-AI/giskard/assets/114553769/18237ef7-b785-4b8b-959f-acf364bfa17e">


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change


- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
