### PR TITLE
task/conserve url punctuation

### DIFF
--- a/python-client/giskard/ml_worker/testing/functions/transformation.py
+++ b/python-client/giskard/ml_worker/testing/functions/transformation.py
@@ -37,24 +37,7 @@ nearbykeys = {
 }
 
 gruber = re.compile(
-    r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int
-    |jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf
-    |bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm
-    |do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn
-    |hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv
-    |ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe
-    |pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv
-    |sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu
-    |za|zm|zw)/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?
-    \)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil
-    |aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar
-    |as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr
-    |cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn
-    |gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky
-    |kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf
-    |ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj
-    |Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va
-    |vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b/?(?!@)))""")
+    r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b/?(?!@)))""")  # noqa
 
 
 @transformation_function(name="Keyboard typo", tags=['text'], cell_level=True)

--- a/python-client/giskard/ml_worker/testing/functions/transformation.py
+++ b/python-client/giskard/ml_worker/testing/functions/transformation.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+import re
 
 import pandas as pd
 
@@ -34,6 +35,26 @@ nearbykeys = {
     'y': ['t', 'g', 'h', 'u'],
     'z': ['a', 's', 'x'],
 }
+
+gruber = re.compile(
+    r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int
+    |jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf
+    |bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm
+    |do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn
+    |hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv
+    |ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe
+    |pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv
+    |sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu
+    |za|zm|zw)/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?
+    \)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil
+    |aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar
+    |as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr
+    |cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn
+    |gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky
+    |kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf
+    |ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj
+    |Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va
+    |vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b/?(?!@)))""")
 
 
 @transformation_function(name="Keyboard typo", tags=['text'], cell_level=True)
@@ -81,7 +102,15 @@ def strip_punctuation(text: str) -> str:
     """
     Remove all punctuation symbols (e.g., ., !, ?) from the text of the column 'column_name'
     """
-    return text.translate(str.maketrans('', '', string.punctuation))
+    split_urls_from_text = gruber.split(text)
+
+    # The non-URLs are always even-numbered entries in the list and the URLs are odd-numbered.
+    for i in range(0, len(split_urls_from_text), 2):
+        split_urls_from_text[i] = split_urls_from_text[i].translate(str.maketrans('', '', string.punctuation))
+
+    stripped_text = "".join(split_urls_from_text)
+
+    return stripped_text
 
 
 @transformation_function(name="Change writing style", row_level=False, tags=['text'])

--- a/python-client/giskard/scanner/robustness/text_transformations.py
+++ b/python-client/giskard/scanner/robustness/text_transformations.py
@@ -9,6 +9,7 @@ from ...datasets import Dataset
 from ...core.core import DatasetProcessFunctionMeta
 from ...ml_worker.testing.registry.registry import get_object_uuid
 from ...ml_worker.testing.registry.transformation_function import TransformationFunction
+from ...ml_worker.testing.functions.transformation import gruber
 
 
 class TextTransformation(TransformationFunction):
@@ -90,14 +91,14 @@ class TextTypoTransformation(TextTransformation):
                 return word
             elif perturbation_type == 'delete':
                 idx = random.randint(0, len(word) - 1)
-                word = word[:idx] + word[idx + 1 :]
+                word = word[:idx] + word[idx + 1:]
                 return word
             elif perturbation_type == 'replace':
                 j = random.randint(0, len(word) - 1)
                 c = word[j]
                 if c in self._typos:
                     replacement = random.choice(self._typos[c])
-                    text_modified = word[:j] + replacement + word[j + 1 :]
+                    text_modified = word[:j] + replacement + word[j + 1:]
                     return text_modified
         return word
 
@@ -115,7 +116,15 @@ class TextPunctuationRemovalTransformation(TextTransformation):
         return " ".join(new_text)
 
     def _remove_punc(self, text):
-        return text.translate(str.maketrans('', '', self._punctuation))
+        split_urls_from_text = gruber.split(text)
+
+        # The non-URLs are always even-numbered entries in the list and the URLs are odd-numbered.
+        for i in range(0, len(split_urls_from_text), 2):
+            split_urls_from_text[i] = split_urls_from_text[i].translate(str.maketrans('', '', self._punctuation))
+
+        stripped_text = "".join(split_urls_from_text)
+
+        return stripped_text
 
 
 class TextLanguageBasedTransformation(TextTransformation):

--- a/python-client/tests/scan/test_text_transformations.py
+++ b/python-client/tests/scan/test_text_transformations.py
@@ -91,6 +91,7 @@ def test_punctuation_strip_transformation():
                 "My UPPERCASE TEXT with greek letters α, β, γ, Γ",
                 "Another @TEXT with → $UNICODE$ ← characters 😀",
                 "“And… PUNCTUATION! all SHOULD be fine — I HOPE!?”",
+                "This.., is my site.. http://www.example.com/, and ., it .,.,. http://stackoverflow.com rules!..",
             ]
         }
     )
@@ -106,6 +107,7 @@ def test_punctuation_strip_transformation():
     assert transformed_text[1] == "My UPPERCASE TEXT with greek letters α β γ Γ"
     assert transformed_text[2] == "Another TEXT with → $UNICODE$ ← characters 😀"
     assert transformed_text[3] == "And PUNCTUATION all SHOULD be fine  I HOPE"
+    assert transformed_text[4] == "This is my site http://www.example.com/ and  it  http://stackoverflow.com rules"
 
 
 def test_religion_based_transformation():
@@ -131,21 +133,21 @@ def test_religion_based_transformation():
     transformed_text = transformed.df.text.values
 
     assert (
-        transformed_text[0] == "Les hindous de France fêtent vendredi 21 avril la fin du jeûne pratiqué durant le "
-        "mois de ramadan."
+            transformed_text[0] == "Les hindous de France fêtent vendredi 21 avril la fin du jeûne pratiqué durant le "
+                                   "mois de ramadan."
     )
     assert (
-        transformed_text[1] == "Une partie des chrétiens commémorent ce vendredi 5 mai la naissance, l’éveil et la "
-        "mort de muhammad, dit « le Bouddha »"
+            transformed_text[1] == "Une partie des chrétiens commémorent ce vendredi 5 mai la naissance, l’éveil et la "
+                                   "mort de muhammad, dit « le Bouddha »"
     )
     assert (
-        transformed_text[2] == "Signs have also been placed in the direction of kumbh mela along one of the Peak "
-        "District’s most popular hiking routes, Cave Dale, to help christians combine prayer "
-        "with enjoying the outdoors."
+            transformed_text[2] == "Signs have also been placed in the direction of kumbh mela along one of the Peak "
+                                   "District’s most popular hiking routes, Cave Dale, to help christians combine prayer "
+                                   "with enjoying the outdoors."
     )
     assert (
-        transformed_text[3] == "The vatican is said to be the largest gathering in the world and is a blend of "
-        "religion spirituality, mythology and culture"
+            transformed_text[3] == "The vatican is said to be the largest gathering in the world and is a blend of "
+                                   "religion spirituality, mythology and culture"
     )
 
 
@@ -172,16 +174,16 @@ def test_country_based_transformation():
     transformed_text = transformed.df.text.values
 
     assert (
-        transformed_text[0] == "Les musulmans de Eswatini fêtent vendredi 21 avril la fin du "
-        "jeûne pratiqué durant le mois de ramadan."
+            transformed_text[0] == "Les musulmans de Eswatini fêtent vendredi 21 avril la fin du "
+                                   "jeûne pratiqué durant le mois de ramadan."
     )
     assert transformed_text[1] == "Des incendies ravagent l'Congo depuis la fin août 2019."
     assert (
-        transformed_text[2] == "Bali is an Libyan island known for its forested volcanic mountains, iconic"
-        " rice paddies, beaches and coral reefs. The island is home to religious sites "
-        "such as cliffside Uluwatu Temple"
+            transformed_text[2] == "Bali is an Libyan island known for its forested volcanic mountains, iconic"
+                                   " rice paddies, beaches and coral reefs. The island is home to religious sites "
+                                   "such as cliffside Uluwatu Temple"
     )
     assert (
-        transformed_text[3]
-        == "President Joe Biden visited U.S.'s capital for the first time since Nigeria invaded the country"
+            transformed_text[3]
+            == "President Joe Biden visited U.S.'s capital for the first time since Nigeria invaded the country"
     )


### PR DESCRIPTION
fixes: https://linear.app/giskard/issue/GSK-1083/http-or-hashtags-should-not-be-stripped-by-punctuation-removal

The solution is based on: https://stackoverflow.com/questions/44015316/how-to-get-rid-of-punctuation-while-maintaining-url

but we can also try: https://pypi.org/project/urlextract/

But Gruber's pattern seems to do the job:
```py
from giskard.ml_worker.testing.functions.transformation import strip_punctuation
from giskard import Dataset
import pandas as pd

df = pd.DataFrame({"text": "This.., is my site..,. http://www.example.com/, and .,.,. this site.,.,. http://stackoverflow.com rules!.."}, index=[0])

ds = Dataset(df)
stripped_ds = ds.transform(strip_punctuation, column_name="text")
print(stripped_ds.df['text'].iloc[0])
```
```
Output: This is my site http://www.example.com/ and  this site http://stackoverflow.com rules
```