### PR TITLE
[GSK-1194] Fix redirect issues

### DIFF
--- a/frontend/src/views/main/Main.vue
+++ b/frontend/src/views/main/Main.vue
@@ -63,12 +63,7 @@
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item :to="{
-              name: 'project-testing',
-              params: {
-                id: projectStore.currentProjectId
-              }
-            }" value="testing">
+            <v-list-item value="testing" @click="redirectToTesting" link>
               <v-list-item-content>
                 <v-icon>mdi-list-status</v-icon>
                 <div class="caption">Testing</div>
@@ -144,6 +139,7 @@ import { useUserStore } from "@/stores/user";
 import { useMainStore } from "@/stores/main";
 import { useProjectStore } from "@/stores/project";
 import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
+import { useTestSuitesStore } from "@/stores/test-suites";
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from 'vue-router/composables';
 import moment from "moment/moment";
@@ -154,6 +150,7 @@ const mainStore = useMainStore();
 const userStore = useUserStore();
 const projectStore = useProjectStore();
 const debuggingSessionsStore = useDebuggingSessionsStore();
+const testSuitesStore = useTestSuitesStore();
 
 let warningMessage = ref<string>()
 
@@ -203,6 +200,19 @@ async function redirectToDebugger() {
   debuggingSessionsStore.setCurrentDebuggingSessionId(null);
   await router.push({
     name: 'project-debugger',
+    params: {
+      projectId: projectStore.currentProjectId.toString()
+    }
+  });
+}
+
+async function redirectToTesting() {
+  if (projectStore.currentProjectId === null) {
+    return;
+  }
+  testSuitesStore.setCurrentTestSuiteId(null);
+  await router.push({
+    name: 'project-testing',
     params: {
       projectId: projectStore.currentProjectId.toString()
     }

--- a/frontend/src/views/main/Main.vue
+++ b/frontend/src/views/main/Main.vue
@@ -63,7 +63,7 @@
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item :to="{ 
+            <v-list-item :to="{
               name: 'project-testing',
               params: {
                 id: projectStore.currentProjectId
@@ -75,23 +75,7 @@
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item v-if="debuggingSessionsStore.currentDebuggingSessionId !== null" :to="{
-              name: 'inspection',
-              params: {
-                id: projectStore.currentProjectId,
-                inspectionId: debuggingSessionsStore.currentDebuggingSessionId,
-              }
-            }" value="debugger">
-              <v-list-item-content>
-                <v-icon>mdi-shield-search</v-icon>
-                <div class="caption">Debugger</div>
-              </v-list-item-content>
-            </v-list-item>
-            <v-list-item v-else :to="{
-              name: 'project-debugger', params: {
-                id: projectStore.currentProjectId,
-              }
-            }" value="debugger">
+            <v-list-item value="debugger" @click="redirectToDebugger" link>
               <v-list-item-content>
                 <v-icon>mdi-shield-search</v-icon>
                 <div class="caption">Debugger</div>
@@ -161,10 +145,11 @@ import { useMainStore } from "@/stores/main";
 import { useProjectStore } from "@/stores/project";
 import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
 import { computed, ref, watch } from "vue";
-import { useRoute } from 'vue-router/composables';
+import { useRoute, useRouter } from 'vue-router/composables';
 import moment from "moment/moment";
 
 const route = useRoute();
+const router = useRouter();
 const mainStore = useMainStore();
 const userStore = useUserStore();
 const projectStore = useProjectStore();
@@ -209,6 +194,19 @@ watch(() => route.name, async (name) => {
 
 async function logout() {
   await userStore.userLogout();
+}
+
+async function redirectToDebugger() {
+  if (projectStore.currentProjectId === null) {
+    return;
+  }
+  debuggingSessionsStore.setCurrentDebuggingSessionId(null);
+  await router.push({
+    name: 'project-debugger',
+    params: {
+      projectId: projectStore.currentProjectId.toString()
+    }
+  });
 }
 </script>
 

--- a/frontend/src/views/main/project/Project.vue
+++ b/frontend/src/views/main/project/Project.vue
@@ -207,6 +207,7 @@ watch(() => route.fullPath, async () => {
 
 onMounted(async () => {
   await projectStore.getProject({ id: props.id });
+  projectStore.setCurrentProjectId(props.id);
   await mainStore.getCoworkers();
   updateCurrentTab();
   await projectArtifactsStore.setProjectId(props.id, false);

--- a/frontend/src/views/main/project/ProjectsHome.vue
+++ b/frontend/src/views/main/project/ProjectsHome.vue
@@ -348,7 +348,7 @@ async function updateCurrentProject(projectId: number) {
   projectStore.setCurrentProjectId(projectId);
   await testSuitesStore.loadTestSuites(projectId);
   await debuggingSessionsStore.loadDebuggingSessions(projectId);
-  await router.push({ name: defaultRoute, params: { id: projectId } });
+  await router.push({ name: defaultRoute, params: { id: projectId.toString() } });
 }
 </script>
 


### PR DESCRIPTION
## Description

Fix all problems related to routing/tabs.

- When a Test Suite is opened, if the user clicks on "Testing" tab it should display the list of Test suites
- When a Debugging Session is opened, if the user clicks on "Debugger" tab it should display the list of Debugging sessions
- When refreshing the page with a project opened, it should keep displaying the tabs as enabled. At the moment it's displaying as disabled after refreshing.
- If a project is opened, going to Settings should keep still possible to navigate to the other tabs.
- Creating a new Debugging session from Debugger tab should redirect to this session
- Creating a new Debugging session from Catalog/Models tab should redirect to this session
- Creating a new Test suite from Testing tab should redirect to this suite.

## Related Issue

[GSK-1194 (available on Linear)](https://linear.app/giskard/issue/GSK-1194/fix-redirect-issues)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
