### PR TITLE
[GSK-1099] Disable components when no ML Worker connected

### DIFF
--- a/backend/src/main/java/ai/giskard/service/ml/MLWorkerService.java
+++ b/backend/src/main/java/ai/giskard/service/ml/MLWorkerService.java
@@ -68,7 +68,7 @@ public class MLWorkerService {
         }
     }
 
-    private boolean isExternalWorkerConnected() {
+    public boolean isExternalWorkerConnected() {
         return mlWorkerTunnelService.getInnerServerDetails().isPresent();
     }
 

--- a/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
+++ b/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
@@ -1,6 +1,5 @@
 package ai.giskard.web.rest.controllers;
 
-import ai.giskard.domain.MLWorkerType;
 import ai.giskard.ml.MLWorkerClient;
 import ai.giskard.service.ml.MLWorkerService;
 import ai.giskard.web.dto.config.MLWorkerInfoDTO;
@@ -19,12 +18,10 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;

--- a/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
+++ b/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
@@ -77,18 +77,8 @@ public class MLWorkerController {
         }
     }
 
-    @GetMapping("/availability/{workerType}")
-    public boolean isWorkerRunning(@PathVariable @NotNull MLWorkerType workerType) {
-        boolean isInternal = "internal".equalsIgnoreCase(String.valueOf(workerType));
-        if (isInternal) {
-            try {
-                List<MLWorkerInfoDTO> mlWorkerInfo = getMLWorkerInfo();
-                return mlWorkerInfo.stream().anyMatch(info -> !info.isRemote());
-            } catch (Exception e) {
-                return false;
-            }
-        } else {
-            return mlWorkerService.isExternalWorkerConnected();
-        }
+    @GetMapping("/external/connected")
+    public boolean isExternalWorkerConnected() {
+        return mlWorkerService.isExternalWorkerConnected();
     }
 }

--- a/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
+++ b/backend/src/main/java/ai/giskard/web/rest/controllers/MLWorkerController.java
@@ -1,5 +1,6 @@
 package ai.giskard.web.rest.controllers;
 
+import ai.giskard.domain.MLWorkerType;
 import ai.giskard.ml.MLWorkerClient;
 import ai.giskard.service.ml.MLWorkerService;
 import ai.giskard.web.dto.config.MLWorkerInfoDTO;
@@ -76,9 +77,9 @@ public class MLWorkerController {
         }
     }
 
-    @GetMapping("/availability/{workerType}") // workerType = 'INTERNAL' | 'EXTERNAL'
-    public boolean isWorkerRunning(@PathVariable @NotNull String workerType) {
-        boolean isInternal = "internal".equalsIgnoreCase(workerType);
+    @GetMapping("/availability/{workerType}")
+    public boolean isWorkerRunning(@PathVariable @NotNull MLWorkerType workerType) {
+        boolean isInternal = "internal".equalsIgnoreCase(String.valueOf(workerType));
         if (isInternal) {
             try {
                 List<MLWorkerInfoDTO> mlWorkerInfo = getMLWorkerInfo();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -210,8 +210,8 @@ export const api = {
       },
     });
   },
-  async checkIfMLWorkerIsRunning(workerType: MLWorkerType) {
-    return apiV2.get<unknown, MLWorkerInfoDTO>(`/ml-workers/availability/${workerType}`);
+  async isExternalMLWorkerConnected() {
+    return apiV2.get<unknown, boolean>(`/ml-workers/external/connected`);
   },
   async getRunningWorkerJobs() {
     return apiV2.get<unknown, JobDTO[]>(`/jobs/running`);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -211,7 +211,7 @@ export const api = {
     });
   },
   async checkIfMLWorkerIsRunning(workerType: MLWorkerType) {
-    return apiV2.get<unknown, MLWorkerInfoDTO>(`/ml-workers/availabity/${workerType}`);
+    return apiV2.get<unknown, MLWorkerInfoDTO>(`/ml-workers/availability/${workerType}`);
   },
   async getRunningWorkerJobs() {
     return apiV2.get<unknown, JobDTO[]>(`/jobs/running`);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,7 +7,7 @@ import {
   AdminUserDTO,
   AppConfigDTO,
   CatalogDTO,
-    ComparisonClauseDTO,
+  ComparisonClauseDTO,
   CreateFeedbackDTO,
   CreateFeedbackReplyDTO,
   DatasetDTO,
@@ -28,6 +28,7 @@ import {
   ManagedUserVM,
   MessageDTO,
   MLWorkerInfoDTO,
+  MLWorkerType,
   ModelDTO,
   ParameterizedCallableDTO,
   PasswordResetRequest,
@@ -41,7 +42,7 @@ import {
   RoleDTO,
   RowFilterDTO,
   SetupDTO,
-    SlicingFunctionDTO,
+  SlicingFunctionDTO,
   SuiteTestDTO,
   TestSuiteCompleteDTO,
   TestSuiteDTO,
@@ -209,6 +210,9 @@ export const api = {
       },
     });
   },
+  async checkIfMLWorkerIsRunning(workerType: MLWorkerType) {
+    return apiV2.get<unknown, MLWorkerInfoDTO>(`/ml-workers/availabity/${workerType}`);
+  },
   async getRunningWorkerJobs() {
     return apiV2.get<unknown, JobDTO[]>(`/jobs/running`);
   },
@@ -328,15 +332,21 @@ export const api = {
   async peekDataFile(datasetId: string) {
     return this.getDatasetRows(datasetId, 0, 10);
   },
-  async getDatasetRows(datasetId: string, offset: number, size: number,
-                       filtered: RowFilterDTO = {}, sample: boolean = true, shuffle: boolean = false) {
+  async getDatasetRows(
+    datasetId: string,
+    offset: number,
+    size: number,
+    filtered: RowFilterDTO = {},
+    sample: boolean = true,
+    shuffle: boolean = false
+  ) {
     return apiV2.post<unknown, DatasetPageDTO>(`/dataset/${datasetId}/rows`, filtered, {
       params: {
         offset,
         size,
         sample,
-        shuffle
-      }
+        shuffle,
+      },
     });
   },
   async editDatasetName(datasetId: string, name: string) {
@@ -465,9 +475,9 @@ export const api = {
       },
     });
   },
-    async createSlicingFunction(comparisonClauses: Array<ComparisonClauseDTO>) {
-        return apiV2.post<unknown, SlicingFunctionDTO>(`/slices/no-code`, comparisonClauses)
-    },
+  async createSlicingFunction(comparisonClauses: Array<ComparisonClauseDTO>) {
+    return apiV2.post<unknown, SlicingFunctionDTO>(`/slices/no-code`, comparisonClauses);
+  },
   async uploadLicense(form: FormData) {
     return apiV2.post<unknown, unknown>(`/ee/license`, form, {
       headers: {
@@ -481,7 +491,7 @@ export const api = {
       license: license,
     });
   },
-    async datasetProcessing(projectId: number, datasetUuid: string, functions: Array<ParameterizedCallableDTO>, sample: boolean = true) {
+  async datasetProcessing(projectId: number, datasetUuid: string, functions: Array<ParameterizedCallableDTO>, sample: boolean = true) {
     return apiV2.post<unknown, DatasetProcessingResultDTO>(
       `/project/${projectId}/datasets/${encodeURIComponent(datasetUuid)}/process?sample=${sample}`,
       functions

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -28,7 +28,6 @@ import {
   ManagedUserVM,
   MessageDTO,
   MLWorkerInfoDTO,
-  MLWorkerType,
   ModelDTO,
   ParameterizedCallableDTO,
   PasswordResetRequest,

--- a/frontend/src/components/AddDebuggingSessionModal.vue
+++ b/frontend/src/components/AddDebuggingSessionModal.vue
@@ -7,10 +7,10 @@ import ModelSelector from '@/views/main/utils/ModelSelector.vue';
 import { computed, onActivated, ref } from "vue";
 import { useMainStore } from "@/stores/main";
 import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
-import { useProjectStore } from '@/stores/project';
+import { useMLWorkerStore } from '@/stores/ml-worker';
 
 const debuggingSessionsStore = useDebuggingSessionsStore();
-const projectStore = useProjectStore();
+const mlWorkerStore = useMLWorkerStore();
 
 interface Props {
   projectId: number;
@@ -28,10 +28,6 @@ const sessionName = ref("");
 const selectedDataset = ref<DatasetDTO | null>(null);
 const selectedModel = ref<ModelDTO | null>(null);
 
-const project = computed(() => {
-  return projectStore.project(props.projectId)
-});
-
 const missingValues = computed(() => {
   if (selectedDataset.value === null || selectedModel.value === null) {
     return true;
@@ -42,18 +38,9 @@ const missingValues = computed(() => {
 const emit = defineEmits(['createDebuggingSession'])
 
 async function createNewDebuggingSession() {
-  const mlWorkers = await api.getMLWorkerSettings();
-  const isWorkerAvailable = mlWorkers.find(
-    value => {
-      if (project.value?.mlWorkerType === 'EXTERNAL') {
-        return value.isRemote === true;
-      } else {
-        return value.isRemote === false;
-      }
-    }
-  )
+  await mlWorkerStore.checkExternalWorkerConnection();
 
-  if (!isWorkerAvailable) {
+  if (!mlWorkerStore.isExternalWorkerConnected) {
     useMainStore().addNotification({
       content: 'ML Worker is not connected. Please start the ML Worker first and try again.',
       color: TYPE.ERROR,
@@ -63,17 +50,16 @@ async function createNewDebuggingSession() {
 
   loading.value = true;
   try {
-      const newDebuggingSession = await debuggingSessionsStore.createDebuggingSession({
-          datasetId: selectedDataset.value!.id,
-          modelId: selectedModel.value!.id,
-          name: sessionName.value,
-          sample: true
-      });
-
-      closeDialog();
-      emit('createDebuggingSession', newDebuggingSession);
+    const newDebuggingSession = await debuggingSessionsStore.createDebuggingSession({
+      datasetId: selectedDataset.value!.id,
+      modelId: selectedModel.value!.id,
+      name: sessionName.value,
+      sample: true
+    });
+    closeDialog();
+    emit('createDebuggingSession', newDebuggingSession);
   } finally {
-      loading.value = false;
+    loading.value = false;
   }
 }
 
@@ -98,7 +84,6 @@ async function loadModels() {
 }
 
 onActivated(async () => {
-  await projectStore.getProject({ id: props.projectId });
   await loadDatasets();
   await loadModels();
 });

--- a/frontend/src/components/AddDebuggingSessionModal.vue
+++ b/frontend/src/components/AddDebuggingSessionModal.vue
@@ -45,7 +45,7 @@ async function createNewDebuggingSession() {
       content: 'ML Worker is not connected. Please start the ML Worker first and try again.',
       color: TYPE.ERROR,
     });
-    return;
+    throw new Error('ML Worker is not connected. Please start the ML Worker first and try again.');
   }
 
   loading.value = true;

--- a/frontend/src/components/StartWorkerInstructions.vue
+++ b/frontend/src/components/StartWorkerInstructions.vue
@@ -64,8 +64,8 @@ const generateApiAccessToken = async () => {
     }
 }
 
-function checkForExternalWorker() {
-    mlWorkerStore.checkExternalWorkerConnection();
+async function checkForExternalWorker() {
+    await mlWorkerStore.checkExternalWorkerConnection();
     if (mlWorkerStore.isExternalWorkerConnected) {
         useMainStore().addNotification({
             content: 'External worker connection found!',

--- a/frontend/src/components/StartWorkerInstructions.vue
+++ b/frontend/src/components/StartWorkerInstructions.vue
@@ -32,7 +32,7 @@ import { computed, onMounted, ref } from "vue";
 import { useMainStore } from "@/stores/main";
 import { useRoute } from "vue-router/composables";
 import { apiURL } from "@/env";
-import { JWTToken, MLWorkerType } from "@/generated-sources";
+import { JWTToken } from "@/generated-sources";
 import CodeSnippet from "./CodeSnippet.vue";
 import { api } from "@/api";
 
@@ -41,25 +41,11 @@ const appSettings = computed(() => mainStore.appSettings);
 const mainStore = useMainStore();
 const route = useRoute();
 
-interface Props {
-    mlWorkerType: MLWorkerType;
-}
-
-const props = withDefaults(defineProps<Props>(), {
-    mlWorkerType: MLWorkerType.EXTERNAL
-});
 
 const apiAccessToken = ref<JWTToken | null>(null);
 
-
-const isExternalWorker = computed(() => props.mlWorkerType === MLWorkerType.EXTERNAL);
-
 const codeContent = computed(() => {
-    if (isExternalWorker.value) {
-        return `giskard worker start -u ${apiURL}`;
-    } else {
-        return `giskard worker start -s -u ${apiURL} # for internal worker`;
-    }
+    return `giskard worker start -u ${apiURL}`;
 })
 
 const generateApiAccessToken = async () => {

--- a/frontend/src/components/StartWorkerInstructions.vue
+++ b/frontend/src/components/StartWorkerInstructions.vue
@@ -23,6 +23,11 @@
                     page
                 </p>
             </div>
+            <v-card-actions>
+                <div class="d-flex align-center">
+                    <v-btn color="primary" @click="checkForExternalWorker">Reload</v-btn>
+                </div>
+            </v-card-actions>
         </v-card-text>
     </v-card>
 </template>
@@ -30,15 +35,18 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 import { useMainStore } from "@/stores/main";
+import { useMLWorkerStore } from "@/stores/ml-worker";
 import { useRoute } from "vue-router/composables";
 import { apiURL } from "@/env";
 import { JWTToken } from "@/generated-sources";
 import CodeSnippet from "./CodeSnippet.vue";
 import { api } from "@/api";
+import { TYPE } from "vue-toastification";
 
 const appSettings = computed(() => mainStore.appSettings);
 
 const mainStore = useMainStore();
+const mlWorkerStore = useMLWorkerStore();
 const route = useRoute();
 
 
@@ -53,6 +61,21 @@ const generateApiAccessToken = async () => {
         apiAccessToken.value = await api.getApiAccessToken();
     } catch (error) {
         console.log(error);
+    }
+}
+
+function checkForExternalWorker() {
+    mlWorkerStore.checkExternalWorkerConnection();
+    if (mlWorkerStore.isExternalWorkerConnected) {
+        useMainStore().addNotification({
+            content: 'External worker connection found!',
+            color: TYPE.SUCCESS,
+        });
+    } else {
+        useMainStore().addNotification({
+            content: 'No external worker connection found',
+            color: TYPE.ERROR,
+        });
     }
 }
 

--- a/frontend/src/stores/ml-worker.ts
+++ b/frontend/src/stores/ml-worker.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia';
+import { api } from '@/api';
+
+interface State {
+  isExternalWorkerConnected: boolean;
+}
+
+export const useMLWorkerStore = defineStore('ml-worker', {
+  state: (): State => ({
+    isExternalWorkerConnected: false,
+  }),
+  getters: {},
+  actions: {
+    async checkExternalWorkerConnection() {
+      try {
+        this.isExternalWorkerConnected = await api.isExternalMLWorkerConnected();
+      } catch (error) {
+        console.error(error);
+      }
+    },
+  },
+});

--- a/frontend/src/views/main/project/Debugger.vue
+++ b/frontend/src/views/main/project/Debugger.vue
@@ -4,8 +4,9 @@ import { $vfm } from 'vue-final-modal';
 import { api } from '@/api';
 import { useRouter } from 'vue-router/composables';
 import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
+import { useMLWorkerStore } from "@/stores/ml-worker";
 import { useProjectStore } from "@/stores/project";
-import { InspectionDTO, MLWorkerInfoDTO } from "@/generated-sources";
+import { InspectionDTO } from "@/generated-sources";
 import AddDebuggingSessionModal from '@/components/AddDebuggingSessionModal.vue';
 import InlineEditText from '@/components/InlineEditText.vue';
 import ConfirmModal from './modals/ConfirmModal.vue';
@@ -15,6 +16,7 @@ const router = useRouter();
 
 const projectStore = useProjectStore();
 const debuggingSessionsStore = useDebuggingSessionsStore();
+const mlWorkerStore = useMLWorkerStore();
 
 interface Props {
   projectId: number;
@@ -23,7 +25,6 @@ interface Props {
 const props = defineProps<Props>();
 
 const searchSession = ref("");
-const allMLWorkerSettings = ref<MLWorkerInfoDTO[]>([]);
 
 const project = computed(() => {
   return projectStore.project(props.projectId)
@@ -124,21 +125,9 @@ async function openInspection(projectId: string, inspectionId: string) {
   });
 }
 
-const isMLWorkerConnected = computed(() => {
-  if (project.value?.mlWorkerType === 'EXTERNAL') {
-    return isWorkerAvailable(false);
-  } else {
-    return isWorkerAvailable(true);
-  }
-});
-
-function isWorkerAvailable(isInternal: boolean): boolean {
-  return allMLWorkerSettings.value.find(value => value.isRemote === !isInternal) !== undefined;
-}
-
 onActivated(async () => {
   await projectStore.getProject({ id: props.projectId });
-  allMLWorkerSettings.value = await api.getMLWorkerSettings();
+  await mlWorkerStore.checkExternalWorkerConnection();
 
   if (debuggingSessionsStore.currentDebuggingSessionId !== null) {
     await openInspection(props.projectId.toString(), debuggingSessionsStore.currentDebuggingSessionId.toString());
@@ -150,7 +139,7 @@ onActivated(async () => {
 </script>
 
 <template>
-  <div v-if="isMLWorkerConnected" class="vertical-container">
+  <div v-if="mlWorkerStore.isExternalWorkerConnected" class="vertical-container">
     <v-container fluid class="vc" v-if="debuggingSessionsStore.debuggingSessions.length > 0">
       <v-row>
         <v-col cols="4">

--- a/frontend/src/views/main/project/Debugger.vue
+++ b/frontend/src/views/main/project/Debugger.vue
@@ -212,7 +212,7 @@ onActivated(async () => {
   </div>
   <v-container v-else class="d-flex flex-column vc fill-height">
     <h1 class="pt-16">ML Worker is not connected</h1>
-    <StartWorkerInstructions :mlWorkerType="project?.mlWorkerType" />
+    <StartWorkerInstructions></StartWorkerInstructions>
   </v-container>
 </template>
 


### PR DESCRIPTION
## Description

This PR aims to add an endpoint to check if an external ML Worker is connected. 
This endpoint will be useful in deciding whether display some functionality on the frontend.

At the moment, three components are using this endpoint:
- Debugger.vue
- AddDebuggingSessionModal.vue
- InspectorLauncher.vue

In the future, more components will be using this endpoint.

## Related Issue

[GSK-1099 (available on Linear)](https://linear.app/giskard/issue/GSK-1099/disable-actions-that-require-external-worker-if-no-worker-is-connected)

## Type of Change


- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

