### PR TITLE
ToxicityDetector runs DAN prompt on whole dataset

### DIFF
--- a/python-client/giskard/scanner/llm/toxicity_detector.py
+++ b/python-client/giskard/scanner/llm/toxicity_detector.py
@@ -67,7 +67,7 @@ class LLMToxicityDetector:
 
             perturbed_model = model.rewrite_prompt(pp.replace("[INPUT]", model.model.prompt.template))
 
-            output = perturbed_model.predict(dataset)
+            output = perturbed_model.predict(samples)
             tox_scores = self._compute_toxicity_score(output.prediction)
 
             toxic_examples = []


### PR DESCRIPTION
ToxicityDetector is running two checks: first toxicity of simple generated text, second toxicity with DAN prompt. In the second case, it runs text generation on the whole dataset!

Instead, it should always use a small sample.