### PR TITLE
[GSK-1203] Track interactions on Catalog with mixpanel

### DIFF
--- a/frontend/src/views/main/project/Catalog.vue
+++ b/frontend/src/views/main/project/Catalog.vue
@@ -54,8 +54,8 @@ const refreshingRef = ref<() => void>();
 
 function trackTabChange(name: string) {
     mixpanel.track("Catalog tab change", {
-        from: route.path.split('/').pop(),
-        to: name
+        fromTab: route.path.split('/').pop(),
+        toTab: name
     });
 }
 

--- a/frontend/src/views/main/project/Catalog.vue
+++ b/frontend/src/views/main/project/Catalog.vue
@@ -1,23 +1,23 @@
 <template>
     <div class="vc mt-2 pb-0" v-if="catalog">
         <div>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-datasets' }">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-datasets' }" @click="trackTabChange('datasets')">
                 <v-icon left small class="mr-1">mdi-database</v-icon>
                 Datasets
             </v-btn>
-            <v-btn text outlined class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-models' }" color="primary">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-models' }" @click="trackTabChange('models')">
                 <v-icon left small class="mr-1">mdi-cube-outline</v-icon>
                 Models
             </v-btn>
-            <v-btn text outlined class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-tests' }" color="primary">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-tests' }" @click="trackTabChange('tests')">
                 <v-icon left small class="mr-1">mdi-test-tube</v-icon>
                 Tests
             </v-btn>
-            <v-btn text outlined class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-slicing-functions' }" color="primary">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-slicing-functions' }" @click="trackTabChange('slicing-functions')">
                 <v-icon left small class="mr-1">mdi-knife</v-icon>
                 Slicing functions
             </v-btn>
-            <v-btn text outlined class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-transformation-functions' }" color="primary">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-transformation-functions' }" @click="trackTabChange('transformation-functions')">
                 <v-icon left small class="mr-1">mdi-chart-bell-curve</v-icon>
                 Transformation functions
             </v-btn>
@@ -31,25 +31,33 @@
 import { onActivated, onDeactivated, ref, watch } from "vue";
 import { useCatalogStore } from "@/stores/catalog";
 import { storeToRefs } from "pinia";
-import LoadingFullscreen from "@/components/LoadingFullscreen.vue";
 import { useRouter, useRoute } from "vue-router/composables";
 import { schedulePeriodicJob } from "@/utils/job-utils";
+import mixpanel from "mixpanel-browser";
+import LoadingFullscreen from "@/components/LoadingFullscreen.vue";
 
-const router = useRouter();
 const route = useRoute();
+const router = useRouter();
+const catalogStore = useCatalogStore();
 
 let props = defineProps<{
     projectId: number,
     suiteId?: number
 }>();
 
-const catalogStore = useCatalogStore();
-const { catalog } = storeToRefs(catalogStore);
-
 const componentRoute = 'project-catalog';
 const defaultRoute = 'project-catalog-tests';
 
+const { catalog } = storeToRefs(catalogStore);
 const refreshingRef = ref<() => void>();
+
+
+function trackTabChange(name: string) {
+    mixpanel.track("Catalog tab change", {
+        from: route.path.split('/').pop(),
+        to: name
+    });
+}
 
 async function checkAndRedirect() {
     if (route.name === componentRoute) {

--- a/frontend/src/views/main/project/Catalog.vue
+++ b/frontend/src/views/main/project/Catalog.vue
@@ -1,23 +1,23 @@
 <template>
     <div class="vc mt-2 pb-0" v-if="catalog">
         <div>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-datasets' }" @click="trackTabChange('datasets')">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-datasets' }" @click="trackTabChange('project-catalog-datasets')">
                 <v-icon left small class="mr-1">mdi-database</v-icon>
                 Datasets
             </v-btn>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-models' }" @click="trackTabChange('models')">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-datasets' }" @click="trackTabChange('project-catalog-datasets')">
                 <v-icon left small class="mr-1">mdi-cube-outline</v-icon>
                 Models
             </v-btn>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-tests' }" @click="trackTabChange('tests')">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-tests' }" @click="trackTabChange('project-catalog-tests')">
                 <v-icon left small class="mr-1">mdi-test-tube</v-icon>
                 Tests
             </v-btn>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-slicing-functions' }" @click="trackTabChange('slicing-functions')">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-slicing-functions' }" @click="trackTabChange('project-catalog-slicing-functions')">
                 <v-icon left small class="mr-1">mdi-knife</v-icon>
                 Slicing functions
             </v-btn>
-            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-transformation-functions' }" @click="trackTabChange('transformation-functions')">
+            <v-btn text outlined color="primary" class="ma-1 rounded-pill tab" :to="{ name: 'project-catalog-transformation-functions' }" @click="trackTabChange('project-catalog-transformation-functions')">
                 <v-icon left small class="mr-1">mdi-chart-bell-curve</v-icon>
                 Transformation functions
             </v-btn>
@@ -54,8 +54,8 @@ const refreshingRef = ref<() => void>();
 
 function trackTabChange(name: string) {
     mixpanel.track("Catalog tab change", {
-        fromTab: route.path.split('/').pop(),
-        toTab: name
+        from: route.name,
+        to: name
     });
 }
 

--- a/frontend/src/views/main/project/FiltersCatalog.vue
+++ b/frontend/src/views/main/project/FiltersCatalog.vue
@@ -166,6 +166,7 @@ import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import CodeSnippet from "@/components/CodeSnippet.vue";
 import IEditorOptions = editor.IEditorOptions;
 import mixpanel from "mixpanel-browser";
+import { anonymize } from "@/utils";
 
 let props = defineProps<{
     projectId: number,
@@ -234,6 +235,7 @@ async function runSlicingFunction() {
 
     mixpanel.track("Run slicing function from Catalog", {
         slicingFunctionName: selected.value!.name,
+        inputs: anonymize(params),
     });
 
     sliceResult.value = await api.datasetProcessing(props.projectId, selectedDataset.value!, [{

--- a/frontend/src/views/main/project/FiltersCatalog.vue
+++ b/frontend/src/views/main/project/FiltersCatalog.vue
@@ -116,29 +116,24 @@
                                             {{
                                                 sliceResult.totalRows
                                             }}</p>
-                                        <DatasetTable :dataset-id="sliceResult.datasetId"
-                                                      :deleted-rows="sliceResult.filteredRows"/>
+                                        <DatasetTable :dataset-id="sliceResult.datasetId" :deleted-rows="sliceResult.filteredRows" />
                                     </v-col>
                                 </v-row>
                             </div>
 
-                            <div id="code-group" class="py-4"
-                                 v-if="selected.processType == DatasetProcessFunctionType.CODE">
+                            <div id="code-group" class="py-4" v-if="selected.processType == DatasetProcessFunctionType.CODE">
                                 <div class="d-flex">
                                     <v-icon left class="group-icon pb-1 mr-1">mdi-code-braces-box</v-icon>
                                     <span class="group-title">Source code</span>
                                 </div>
-                                <CodeSnippet class="mt-2" :codeContent="selected.code"
-                                             :key="selected.name + '_source_code'"></CodeSnippet>
+                                <CodeSnippet class="mt-2" :codeContent="selected.code" :key="selected.name + '_source_code'"></CodeSnippet>
                             </div>
-                            <div id="code-group" class="py-4"
-                                 v-if="selected.processType == DatasetProcessFunctionType.CLAUSES">
+                            <div id="code-group" class="py-4" v-if="selected.processType == DatasetProcessFunctionType.CLAUSES">
                                 <div class="d-flex">
                                     <v-icon left class="group-icon pb-1 mr-1">mdi-filter-check</v-icon>
                                     <span class="group-title">Clauses</span>
                                 </div>
-                                <CodeSnippet class="mt-2" :codeContent="selected.name"
-                                             :key="selected.name + '_source_code'"></CodeSnippet>
+                                <CodeSnippet class="mt-2" :codeContent="selected.name" :key="selected.name + '_source_code'"></CodeSnippet>
                             </div>
                         </div>
                     </v-col>
@@ -153,23 +148,24 @@
 </template>
 
 <script setup lang="ts">
-import {chain} from "lodash";
-import {computed, inject, onActivated, ref, watch} from "vue";
-import {pasterColor} from "@/utils";
-import {editor} from "monaco-editor";
-import {DatasetProcessFunctionType, FunctionInputDTO, SlicingFunctionDTO, SlicingResultDTO} from "@/generated-sources";
+import { chain } from "lodash";
+import { computed, inject, onActivated, ref, watch } from "vue";
+import { pasterColor } from "@/utils";
+import { editor } from "monaco-editor";
+import { DatasetProcessFunctionType, FunctionInputDTO, SlicingFunctionDTO, SlicingResultDTO } from "@/generated-sources";
 import StartWorkerInstructions from "@/components/StartWorkerInstructions.vue";
-import {storeToRefs} from "pinia";
-import {useCatalogStore} from "@/stores/catalog";
+import { storeToRefs } from "pinia";
+import { useCatalogStore } from "@/stores/catalog";
 import DatasetSelector from "@/views/main/utils/DatasetSelector.vue";
-import {api} from "@/api";
+import { api } from "@/api";
 import DatasetTable from "@/components/DatasetTable.vue";
 import SuiteInputListSelector from "@/components/SuiteInputListSelector.vue";
 import DatasetColumnSelector from "@/views/main/utils/DatasetColumnSelector.vue";
-import {alphabeticallySorted} from "@/utils/comparators";
-import {extractArgumentDocumentation} from "@/utils/python-doc.utils";
+import { alphabeticallySorted } from "@/utils/comparators";
+import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import CodeSnippet from "@/components/CodeSnippet.vue";
 import IEditorOptions = editor.IEditorOptions;
+import mixpanel from "mixpanel-browser";
 
 let props = defineProps<{
     projectId: number,
@@ -236,12 +232,15 @@ async function runSlicingFunction() {
         })
     }
 
+    mixpanel.track("Run slicing function from Catalog", {
+        slicingFunctionName: selected.value!.name,
+    });
+
     sliceResult.value = await api.datasetProcessing(props.projectId, selectedDataset.value!, [{
         uuid: selected.value!.uuid,
         params,
         type: 'SLICING',
     }]);
-
 }
 
 watch(() => selected.value, () => {

--- a/frontend/src/views/main/project/InspectorLauncher.vue
+++ b/frontend/src/views/main/project/InspectorLauncher.vue
@@ -81,7 +81,11 @@ async function loadDatasets() {
 }
 
 async function launchInspector() {
-  mixpanel.track('Create inspection', { datasetId: datasetSelected.value!.id, modelId: props.model.id });
+  mixpanel.track('Create debugging session', {
+    source: "InspectorLauncher",
+    datasetId: datasetSelected.value!.id,
+    modelId: props.model.id
+  });
   try {
     creatingInspection.value = true;
 

--- a/frontend/src/views/main/project/TestsCatalog.vue
+++ b/frontend/src/views/main/project/TestsCatalog.vue
@@ -139,6 +139,7 @@ import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import { alphabeticallySorted } from "@/utils/comparators";
 import CodeSnippet from "@/components/CodeSnippet.vue";
 import mixpanel from "mixpanel-browser";
+import { anonymize } from "@/utils";
 
 let props = defineProps<{
     projectId: number,
@@ -198,6 +199,7 @@ const selectedTestUsage = computed(() => {
 async function runTest() {
     mixpanel.track("Run test from Catalog", {
         testName: selected.value!.name,
+        inputs: anonymize(Object.values(testArguments.value))
     });
 
     testResult.value = await api.runAdHocTest(props.projectId, selected.value!.uuid, Object.values(testArguments.value));

--- a/frontend/src/views/main/project/TestsCatalog.vue
+++ b/frontend/src/views/main/project/TestsCatalog.vue
@@ -138,6 +138,7 @@ import SuiteInputListSelector from "@/components/SuiteInputListSelector.vue";
 import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import { alphabeticallySorted } from "@/utils/comparators";
 import CodeSnippet from "@/components/CodeSnippet.vue";
+import mixpanel from "mixpanel-browser";
 
 let props = defineProps<{
     projectId: number,
@@ -148,7 +149,6 @@ let props = defineProps<{
 const searchFilter = ref<string>("");
 let { testFunctions } = storeToRefs(useCatalogStore());
 let selected = ref<TestFunctionDTO | null>(null);
-let tryMode = ref(true)
 let testArguments = ref<{ [name: string]: FunctionInputDTO }>({})
 let testResult = ref<TestTemplateExecutionResultDTO | null>(null);
 
@@ -196,6 +196,10 @@ const selectedTestUsage = computed(() => {
 
 
 async function runTest() {
+    mixpanel.track("Run test from Catalog", {
+        testName: selected.value!.name,
+    });
+
     testResult.value = await api.runAdHocTest(props.projectId, selected.value!.uuid, Object.values(testArguments.value));
 }
 

--- a/frontend/src/views/main/project/TransformationsCatalog.vue
+++ b/frontend/src/views/main/project/TransformationsCatalog.vue
@@ -162,9 +162,10 @@ import DatasetTable from "@/components/DatasetTable.vue";
 import SuiteInputListSelector from "@/components/SuiteInputListSelector.vue";
 import DatasetColumnSelector from "@/views/main/utils/DatasetColumnSelector.vue";
 import { alphabeticallySorted } from "@/utils/comparators";
-import {extractArgumentDocumentation} from "@/utils/python-doc.utils";
+import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import IEditorOptions = editor.IEditorOptions;
 import CodeSnippet from "@/components/CodeSnippet.vue";
+import mixpanel from "mixpanel-browser";
 
 let props = defineProps<{
     projectId: number,
@@ -230,6 +231,10 @@ async function runTransformationFunction() {
             value: selectedColumn.value
         })
     }
+
+    mixpanel.track("Run transformation function from Catalog", {
+        transformationFunctionName: selected.value!.name,
+    });
 
     transformationResult.value = await api.datasetProcessing(props.projectId, selectedDataset.value!, [{
         uuid: selected.value!.uuid,

--- a/frontend/src/views/main/project/TransformationsCatalog.vue
+++ b/frontend/src/views/main/project/TransformationsCatalog.vue
@@ -166,6 +166,7 @@ import { extractArgumentDocumentation } from "@/utils/python-doc.utils";
 import IEditorOptions = editor.IEditorOptions;
 import CodeSnippet from "@/components/CodeSnippet.vue";
 import mixpanel from "mixpanel-browser";
+import { anonymize } from "@/utils";
 
 let props = defineProps<{
     projectId: number,
@@ -234,6 +235,7 @@ async function runTransformationFunction() {
 
     mixpanel.track("Run transformation function from Catalog", {
         transformationFunctionName: selected.value!.name,
+        inputs: anonymize(params),
     });
 
     transformationResult.value = await api.datasetProcessing(props.projectId, selectedDataset.value!, [{

--- a/frontend/src/views/main/project/modals/AddTestToSuite.vue
+++ b/frontend/src/views/main/project/modals/AddTestToSuite.vue
@@ -110,7 +110,7 @@ const mainStore = useMainStore();
 async function submit(close) {
   mixpanel.track("Add test to suite", {
     testName: test.name,
-    suiteId: anonymize(selectedSuite.value),
+    suiteId: selectedSuite.value,
     inputs: anonymize(Object.values(testInputs.value))
   })
 

--- a/frontend/src/views/main/project/modals/AddTestToSuite.vue
+++ b/frontend/src/views/main/project/modals/AddTestToSuite.vue
@@ -62,6 +62,7 @@ import { useMainStore } from "@/stores/main";
 import { TYPE } from 'vue-toastification';
 import { extractArgumentDocumentation, ParsedDocstring } from "@/utils/python-doc.utils";
 import mixpanel from 'mixpanel-browser';
+import { anonymize } from "@/utils";
 
 const { projectId, test, suiteId, testArguments } = defineProps<{
   projectId: number,
@@ -109,6 +110,8 @@ const mainStore = useMainStore();
 async function submit(close) {
   mixpanel.track("Add test to suite", {
     testName: test.name,
+    suiteId: anonymize(selectedSuite.value),
+    inputs: anonymize(Object.values(testInputs.value))
   })
 
   const suiteTest: SuiteTestDTO = {


### PR DESCRIPTION
## Description

This PR adds telemetry to actions on the Catalog tab.

## Related Issue

[GSK-1203 (available on Linear)](https://linear.app/giskard/issue/GSK-1203/track-interactions-on-catalog-with-mixpanel)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
