### PR TITLE
[GSK-1277] Fix redirect errors on Debugger component

### DIFF
--- a/frontend/src/components/AddDebuggingSessionModal.vue
+++ b/frontend/src/components/AddDebuggingSessionModal.vue
@@ -54,12 +54,13 @@ async function createNewDebuggingSession() {
       datasetId: selectedDataset.value!.id,
       modelId: selectedModel.value!.id,
       name: sessionName.value,
-      sample: true
+      sample: false
     });
-    closeDialog();
+    debuggingSessionsStore.setCurrentDebuggingSessionId(newDebuggingSession.id);
     emit('createDebuggingSession', newDebuggingSession);
   } finally {
     loading.value = false;
+    closeDialog();
   }
 }
 

--- a/frontend/src/views/main/Main.vue
+++ b/frontend/src/views/main/Main.vue
@@ -2,7 +2,7 @@
   <v-main class="fill-height vertical-container">
     <v-navigation-drawer fixed app persistent class="background" mobile-breakpoint="sm" width="75" color="primaryLight">
       <v-layout column fill-height>
-        <v-list subheader class="align-center">
+        <v-list subheader class="align-center" @click="resetStates">
           <v-list-item to="/" @click.stop="() => {
             projectStore.setCurrentProjectId(null);
           }">
@@ -50,38 +50,29 @@
             <span>You have to select a project to interact with this menu.</span>
           </v-tooltip>
 
-          <div v-else>
-            <v-list-item :to="{
-              name: 'project-catalog',
-              params: {
-                id: projectStore.currentProjectId,
-              }
-            }" value="catalog">
+          <div v-else @click="resetStates">
+            <v-list-item :to="{ name: 'project-catalog', params: { id: currentProjectId } }" value="catalog">
               <v-list-item-content>
                 <v-icon>mdi-book-open-page-variant-outline</v-icon>
                 <div class="caption">Catalog</div>
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item value="testing" @click="redirectToTesting" link>
+            <v-list-item :to="{ name: 'project-testing', params: { id: currentProjectId } }" value="testing">
               <v-list-item-content>
                 <v-icon>mdi-list-status</v-icon>
                 <div class="caption">Testing</div>
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item value="debugger" @click="redirectToDebugger" link>
+            <v-list-item :to="{ name: 'project-debugger', params: { id: currentProjectId } }" value="debugger">
               <v-list-item-content>
                 <v-icon>mdi-shield-search</v-icon>
                 <div class="caption">Debugger</div>
               </v-list-item-content>
             </v-list-item>
             <v-divider />
-            <v-list-item :to="{
-              name: 'project-feedbacks', params: {
-                id: projectStore.currentProjectId,
-              }
-            }" value="feedbacks">
+            <v-list-item :to="{ name: 'project-feedbacks', params: { id: currentProjectId } }" value="feedbacks">
               <v-list-item-content>
                 <v-icon>mdi-comment-multiple-outline</v-icon>
                 <div class="caption">Feedback</div>
@@ -89,8 +80,6 @@
             </v-list-item>
             <v-divider />
           </div>
-
-
         </v-list>
         <v-spacer></v-spacer>
         <v-list>
@@ -141,11 +130,10 @@ import { useProjectStore } from "@/stores/project";
 import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
 import { useTestSuitesStore } from "@/stores/test-suites";
 import { computed, ref, watch } from "vue";
-import { useRoute, useRouter } from 'vue-router/composables';
+import { useRoute } from 'vue-router/composables';
 import moment from "moment/moment";
 
 const route = useRoute();
-const router = useRouter();
 const mainStore = useMainStore();
 const userStore = useUserStore();
 const projectStore = useProjectStore();
@@ -164,7 +152,6 @@ if (mainStore.license) {
 
 
 const hasAdminAccess = computed(() => {
-
   return userStore.hasAdminAccess;
 });
 
@@ -182,42 +169,27 @@ const userId = computed(() => {
   }
 });
 
+const currentProjectId = computed(() => {
+  if (projectStore.currentProjectId === null) {
+    return null;
+  }
+  return projectStore.currentProjectId.toString();
+});
+
+async function logout() {
+  await userStore.userLogout();
+}
+
+function resetStates() {
+  debuggingSessionsStore.setCurrentDebuggingSessionId(null);
+  testSuitesStore.setCurrentTestSuiteId(null);
+}
 
 watch(() => route.name, async (name) => {
   if (name === 'projects-home') {
     projectStore.setCurrentProjectId(null);
   }
 })
-
-async function logout() {
-  await userStore.userLogout();
-}
-
-async function redirectToDebugger() {
-  if (projectStore.currentProjectId === null) {
-    return;
-  }
-  debuggingSessionsStore.setCurrentDebuggingSessionId(null);
-  await router.push({
-    name: 'project-debugger',
-    params: {
-      projectId: projectStore.currentProjectId.toString()
-    }
-  });
-}
-
-async function redirectToTesting() {
-  if (projectStore.currentProjectId === null) {
-    return;
-  }
-  testSuitesStore.setCurrentTestSuiteId(null);
-  await router.push({
-    name: 'project-testing',
-    params: {
-      projectId: projectStore.currentProjectId.toString()
-    }
-  });
-}
 </script>
 
 <style scoped>

--- a/frontend/src/views/main/project/Debugger.vue
+++ b/frontend/src/views/main/project/Debugger.vue
@@ -1,142 +1,3 @@
-<script setup lang="ts">
-import { computed, ref, onActivated, watch, onMounted } from "vue";
-import { $vfm } from 'vue-final-modal';
-import { api } from '@/api';
-import { useRouter } from 'vue-router/composables';
-import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
-import { useMLWorkerStore } from "@/stores/ml-worker";
-import { useProjectStore } from "@/stores/project";
-import { InspectionDTO } from "@/generated-sources";
-import AddDebuggingSessionModal from '@/components/AddDebuggingSessionModal.vue';
-import InlineEditText from '@/components/InlineEditText.vue';
-import ConfirmModal from './modals/ConfirmModal.vue';
-import StartWorkerInstructions from "@/components/StartWorkerInstructions.vue";
-
-const router = useRouter();
-
-const projectStore = useProjectStore();
-const debuggingSessionsStore = useDebuggingSessionsStore();
-const mlWorkerStore = useMLWorkerStore();
-
-interface Props {
-  projectId: number;
-}
-
-const props = defineProps<Props>();
-
-const searchSession = ref("");
-
-const project = computed(() => {
-  return projectStore.project(props.projectId)
-});
-
-const filteredSessions = computed(() => {
-
-  return orderByDate(debuggingSessionsStore.debuggingSessions.filter((session) => {
-    const dataset = session.dataset;
-    const model = session.model;
-    const search = searchSession.value.toLowerCase();
-
-    return (
-      session.id.toString().includes(search) ||
-      session.name.toLowerCase().includes(search) ||
-      dataset.name.toLowerCase().includes(search) ||
-      dataset.id.toString().includes(search) ||
-      model.name.toLowerCase().includes(search) ||
-      model.id.toString().includes(search)
-    );
-  }));
-})
-
-async function showPastSessions() {
-  debuggingSessionsStore.reload();
-  resetSearchInput();
-  debuggingSessionsStore.setCurrentDebuggingSessionId(null);
-  await router.push({
-    name: 'project-debugger',
-    params: {
-      projectId: props.projectId.toString()
-    }
-  });
-}
-
-async function createDebuggingSession(debuggingSession: InspectionDTO) {
-  debuggingSessionsStore.reload();
-  debuggingSessionsStore.setCurrentDebuggingSessionId(debuggingSession.id);
-  await openInspection(props.projectId.toString(), debuggingSession.id.toString());
-}
-
-async function renameSession(id: number, name: string) {
-  const currentSession = debuggingSessionsStore.debuggingSessions.find(s => s.id === id);
-  if (currentSession) {
-    currentSession.name = name;
-    debuggingSessionsStore.updateDebuggingSessionName(id, {
-      name,
-      datasetId: currentSession.dataset.id,
-      modelId: currentSession.model.id,
-      sample: currentSession.sample
-    });
-  }
-}
-
-function orderByDate(debuggingSessions: InspectionDTO[]): InspectionDTO[] {
-  return debuggingSessions.sort((a, b) => {
-    const aDate = new Date(a.createdDate);
-    const bDate = new Date(b.createdDate);
-
-    return bDate.getTime() - aDate.getTime();
-  });
-}
-
-function deleteDebuggingSession(debuggingSession: InspectionDTO) {
-  $vfm.show({
-    component: ConfirmModal,
-    bind: {
-      title: 'Delete debugging session',
-      text: `Are you sure that you want to delete the debugging session '${debuggingSession.name}'?`,
-      isWarning: true
-    },
-    on: {
-      async confirm(close) {
-        await api.deleteInspection(debuggingSession.id);
-        await debuggingSessionsStore.reload();
-        close();
-      }
-    }
-  });
-}
-
-async function openDebuggingSession(debuggingSessionId: number, projectId: number) {
-  debuggingSessionsStore.setCurrentDebuggingSessionId(debuggingSessionId);
-  await openInspection(projectId.toString(), debuggingSessionId.toString());
-}
-
-function resetSearchInput() {
-  searchSession.value = "";
-}
-
-async function openInspection(projectId: string, inspectionId: string) {
-  await router.push({
-    name: 'inspection',
-    params: {
-      projectId,
-      inspectionId
-    }
-  });
-}
-
-onActivated(async () => {
-  await projectStore.getProject({ id: props.projectId });
-  await mlWorkerStore.checkExternalWorkerConnection();
-
-  if (debuggingSessionsStore.currentDebuggingSessionId !== null) {
-    await openInspection(props.projectId.toString(), debuggingSessionsStore.currentDebuggingSessionId.toString());
-  } else {
-    await debuggingSessionsStore.loadDebuggingSessions(props.projectId);
-  }
-});
-
-</script>
 
 <template>
   <div v-if="mlWorkerStore.isExternalWorkerConnected" class="vertical-container">
@@ -204,7 +65,7 @@ onActivated(async () => {
       <v-alert class="text-center">
         <p class="headline font-weight-medium grey--text text--darken-2">You haven't created any debugging session for this project. <br>Please create your first session to start debugging your model.</p>
       </v-alert>
-      <AddDebuggingSessionModal :projectId="projectId" v-on:createDebuggingSession="createDebuggingSession"></AddDebuggingSessionModal>
+      <AddDebuggingSessionModal v-show="debuggingSessionsStore.currentDebuggingSessionId === null" :projectId="projectId" @createDebuggingSession="createDebuggingSession"></AddDebuggingSessionModal>
       <div class="d-flex justify-center mb-6">
         <img src="@/assets/logo_debugger.png" class="debugger-logo" title="Debugger tab logo" alt="A turtle using a magnifying glass">
       </div>
@@ -215,6 +76,154 @@ onActivated(async () => {
     <StartWorkerInstructions></StartWorkerInstructions>
   </v-container>
 </template>
+
+<script setup lang="ts">
+import { computed, ref, onActivated, watch, onMounted } from "vue";
+import { $vfm } from 'vue-final-modal';
+import { api } from '@/api';
+import { useRouter, useRoute } from 'vue-router/composables';
+import { useDebuggingSessionsStore } from "@/stores/debugging-sessions";
+import { useMLWorkerStore } from "@/stores/ml-worker";
+import { useProjectStore } from "@/stores/project";
+import { InspectionDTO } from "@/generated-sources";
+import AddDebuggingSessionModal from '@/components/AddDebuggingSessionModal.vue';
+import InlineEditText from '@/components/InlineEditText.vue';
+import ConfirmModal from './modals/ConfirmModal.vue';
+import StartWorkerInstructions from "@/components/StartWorkerInstructions.vue";
+import { debug } from "console";
+
+const router = useRouter();
+const route = useRoute();
+
+const projectStore = useProjectStore();
+const debuggingSessionsStore = useDebuggingSessionsStore();
+const mlWorkerStore = useMLWorkerStore();
+
+interface Props {
+  projectId: number;
+}
+
+const props = defineProps<Props>();
+
+const searchSession = ref("");
+
+const project = computed(() => {
+  return projectStore.project(props.projectId)
+});
+
+const filteredSessions = computed(() => {
+
+  return orderByDate(debuggingSessionsStore.debuggingSessions.filter((session) => {
+    const dataset = session.dataset;
+    const model = session.model;
+    const search = searchSession.value.toLowerCase();
+
+    return (
+      session.id.toString().includes(search) ||
+      session.name.toLowerCase().includes(search) ||
+      dataset.name.toLowerCase().includes(search) ||
+      dataset.id.toString().includes(search) ||
+      model.name.toLowerCase().includes(search) ||
+      model.id.toString().includes(search)
+    );
+  }));
+})
+
+async function showPastSessions() {
+  debuggingSessionsStore.reload();
+  resetSearchInput();
+  debuggingSessionsStore.setCurrentDebuggingSessionId(null);
+  await router.push({
+    name: 'project-debugger',
+    params: {
+      projectId: props.projectId.toString()
+    }
+  });
+}
+
+async function createDebuggingSession(debuggingSession: InspectionDTO) {
+  await openDebuggingSession(debuggingSession.id, props.projectId);
+}
+
+async function renameSession(id: number, name: string) {
+  const currentSession = debuggingSessionsStore.debuggingSessions.find(s => s.id === id);
+  if (currentSession) {
+    currentSession.name = name;
+    debuggingSessionsStore.updateDebuggingSessionName(id, {
+      name,
+      datasetId: currentSession.dataset.id,
+      modelId: currentSession.model.id,
+      sample: currentSession.sample
+    });
+  }
+}
+
+function orderByDate(debuggingSessions: InspectionDTO[]): InspectionDTO[] {
+  return debuggingSessions.sort((a, b) => {
+    const aDate = new Date(a.createdDate);
+    const bDate = new Date(b.createdDate);
+
+    return bDate.getTime() - aDate.getTime();
+  });
+}
+
+function deleteDebuggingSession(debuggingSession: InspectionDTO) {
+  $vfm.show({
+    component: ConfirmModal,
+    bind: {
+      title: 'Delete debugging session',
+      text: `Are you sure that you want to delete the debugging session '${debuggingSession.name}'?`,
+      isWarning: true
+    },
+    on: {
+      async confirm(close) {
+        await api.deleteInspection(debuggingSession.id);
+        await debuggingSessionsStore.reload();
+        close();
+      }
+    }
+  });
+}
+
+async function openDebuggingSession(debuggingSessionId: number, projectId: number) {
+  debuggingSessionsStore.setCurrentDebuggingSessionId(debuggingSessionId);
+  await openInspection(projectId.toString(), debuggingSessionId.toString());
+}
+
+function resetSearchInput() {
+  searchSession.value = "";
+}
+
+async function openInspection(projectId: string, inspectionId: string) {
+  await router.push({
+    name: 'inspection',
+    params: {
+      id: projectId,
+      inspectionId: inspectionId
+    }
+  });
+}
+
+watch(() => debuggingSessionsStore.currentDebuggingSessionId, async (currentDebuggingSessionId) => {
+  if (currentDebuggingSessionId !== null) {
+    await openInspection(props.projectId.toString(), currentDebuggingSessionId.toString());
+  }
+});
+
+onActivated(async () => {
+  await projectStore.getProject({ id: props.projectId });
+  await mlWorkerStore.checkExternalWorkerConnection();
+  await debuggingSessionsStore.loadDebuggingSessions(props.projectId);
+
+  if (route.params.inspectionId !== undefined) {
+    debuggingSessionsStore.setCurrentDebuggingSessionId(parseInt(route.params.inspectionId));
+  }
+
+  if (debuggingSessionsStore.currentDebuggingSessionId !== null) {
+    await openInspection(props.projectId.toString(), debuggingSessionsStore.currentDebuggingSessionId.toString());
+  }
+});
+</script>
 
 <style scoped>
 .debugger-logo {

--- a/frontend/src/views/main/project/InspectorLauncher.vue
+++ b/frontend/src/views/main/project/InspectorLauncher.vue
@@ -99,19 +99,25 @@ async function launchInspector() {
       throw new Error('ML Worker is not connected. Please start the ML Worker first and try again.');
     }
 
-    const inspection = await api.prepareInspection(
-      {
-        datasetId: datasetSelected.value!.id,
-        modelId: props.model.id,
-        name: "",
-        sample: false
-      });
+    const inspection = await api.prepareInspection({
+      datasetId: datasetSelected.value!.id,
+      modelId: props.model.id,
+      name: "",
+      sample: false
+    });
+
     debuggingSessionsStore.setCurrentDebuggingSessionId(inspection.id);
+
     await router.push({
-      name: 'project-debugger',
+      name: 'inspection', params: {
+        id: props.projectId.toString(),
+        inspectionId: inspection.id.toString(),
+      }
     })
-    reset();
+
+
   } finally {
+    reset();
     creatingInspection.value = false;
   }
 }

--- a/frontend/src/views/main/project/InspectorWrapper.vue
+++ b/frontend/src/views/main/project/InspectorWrapper.vue
@@ -1,172 +1,155 @@
 <template>
-  <v-container v-if="inspection" fluid class="vc">
+  <v-container v-if="inspection" fluid class="vc" :key="inspection.id">
     <v-row align="center" no-gutters style='height: 60px;'>
 
       <v-toolbar class='data-explorer-toolbar' flat>
         <v-tooltip bottom min-width="400">
-            <template v-slot:activator="{ on, attrs }">
-                <v-icon v-on="on" class="pr-5" medium>info</v-icon>
-            </template>
-            <h3> Debugging session </h3>
-            <div class="d-flex">
-                <div> Id</div>
-                <v-spacer/>
-                <div> {{ inspection.id }}</div>
-            </div>
-            <div class="d-flex">
-                <div> Name</div>
-                <v-spacer/>
-                <div class="pl-5"> {{ inspection.name || "-" }}</div>
-            </div>
-            <br/>
-            <h3> Model </h3>
-            <div class="d-flex">
-                <div> Id</div>
-                <v-spacer/>
-                <div> {{ inspection.model.id }}</div>
-            </div>
-            <div class="d-flex">
-                <div> Name</div>
-                <v-spacer/>
-                <div class="pl-5"> {{ inspection.model.name }}</div>
-            </div>
-            <br/>
-            <h3> Dataset </h3>
-            <div class="d-flex">
-                <div> Id</div>
-                <v-spacer/>
-                <div> {{ inspection.dataset.id }}</div>
-            </div>
-            <div class="d-flex pb-3">
-                <div> Name</div>
-                <v-spacer/>
-                <div class="pl-5"> {{ inspection.dataset.name }}</div>
-            </div>
+          <template v-slot:activator="{ on, attrs }">
+            <v-icon v-on="on" class="pr-5" medium>info</v-icon>
+          </template>
+          <h3> Debugging session </h3>
+          <div class="d-flex">
+            <div> Id</div>
+            <v-spacer />
+            <div> {{ inspection.id }}</div>
+          </div>
+          <div class="d-flex">
+            <div> Name</div>
+            <v-spacer />
+            <div class="pl-5"> {{ inspection.name || "-" }}</div>
+          </div>
+          <br />
+          <h3> Model </h3>
+          <div class="d-flex">
+            <div> Id</div>
+            <v-spacer />
+            <div> {{ inspection.model.id }}</div>
+          </div>
+          <div class="d-flex">
+            <div> Name</div>
+            <v-spacer />
+            <div class="pl-5"> {{ inspection.model.name }}</div>
+          </div>
+          <br />
+          <h3> Dataset </h3>
+          <div class="d-flex">
+            <div> Id</div>
+            <v-spacer />
+            <div> {{ inspection.dataset.id }}</div>
+          </div>
+          <div class="d-flex pb-3">
+            <div> Name</div>
+            <v-spacer />
+            <div class="pl-5"> {{ inspection.dataset.name }}</div>
+          </div>
         </v-tooltip>
-          <span class='subtitle-1 mr-2'>Dataset Explorer</span>
-          <v-btn icon @click='shuffleMode = !shuffleMode'>
-              <v-icon v-if='shuffleMode' color='primary'>mdi-shuffle-variant</v-icon>
-              <v-icon v-else>mdi-shuffle-variant</v-icon>
-          </v-btn>
-          <v-btn :disabled='!canPrevious' icon @click='previous'>
-              <v-icon>mdi-skip-previous</v-icon>
-          </v-btn>
-          <v-btn :disabled='!canNext' icon @click='next'>
-              <v-icon>mdi-skip-next</v-icon>
-          </v-btn>
+        <span class='subtitle-1 mr-2'>Dataset Explorer</span>
+        <v-btn icon @click='shuffleMode = !shuffleMode'>
+          <v-icon v-if='shuffleMode' color='primary'>mdi-shuffle-variant</v-icon>
+          <v-icon v-else>mdi-shuffle-variant</v-icon>
+        </v-btn>
+        <v-btn :disabled='!canPrevious' icon @click='previous'>
+          <v-icon>mdi-skip-previous</v-icon>
+        </v-btn>
+        <v-btn :disabled='!canNext' icon @click='next'>
+          <v-icon>mdi-skip-next</v-icon>
+        </v-btn>
 
-          <span class='caption grey--text' v-if="totalRows > 0">
+        <span class='caption grey--text' v-if="totalRows > 0">
           Entry #{{ totalRows === 0 ? 0 : rowNb + 1 }} / {{ totalRows }}
         </span>
-          <span v-show="originalData && isDefined(originalData['Index'])" class='caption grey--text'
-                style='margin-left: 15px'>Row Index {{ originalData['Index'] + 1 }}</span>
-          <v-chip class="ml-2" outlined link
-                  :color="inspection.sample ? 'purple' : 'primary'"
-                  @click="handleSwitchSample" x-small>
-              {{ inspection.sample ? 'Sample' : 'Whole' }} data
-          </v-chip>
+        <span v-show="originalData && isDefined(originalData['Index'])" class='caption grey--text' style='margin-left: 15px'>Row Index {{ originalData['Index'] + 1 }}</span>
+        <v-chip class="ml-2" outlined link :color="inspection.sample ? 'purple' : 'primary'" @click="handleSwitchSample" x-small>
+          {{ inspection.sample ? 'Sample' : 'Whole' }} data
+        </v-chip>
       </v-toolbar>
-        <v-spacer/>
+      <v-spacer />
 
-        <SlicingFunctionSelector label="Slice to apply" :project-id="projectId"
-                                 :full-width="false" :icon="true" class="mr-3"
-                                 :allow-no-code-slicing="true"
-                                 @onChanged="processDataset"
-                                 :value.sync="selectedSlicingFunction.uuid"
-                                 :args.sync="selectedSlicingFunction.params"
-                                 :dataset="inspection.dataset"/>
+      <SlicingFunctionSelector label="Slice to apply" :project-id="projectId" :full-width="false" :icon="true" class="mr-3" :allow-no-code-slicing="true" @onChanged="processDataset" :value.sync="selectedSlicingFunction.uuid" :args.sync="selectedSlicingFunction.params" :dataset="inspection.dataset" />
 
-        <InspectionFilter :is-target-available="isDefined(inspection.dataset.target)" :labels="labels"
-                          :model-type="inspection.model.modelType" @input="f => filter = f"/>
+      <InspectionFilter :is-target-available="isDefined(inspection.dataset.target)" :labels="labels" :model-type="inspection.model.modelType" @input="f => filter = f" />
     </v-row>
-      <Inspector :dataset='inspection.dataset' :inputData.sync='inputData' :model='inspection.model'
-                 :originalData='originalData'
-                 :transformationModifications="modifications"
-                 class='px-0' @reset='resetInput' @submitValueFeedback='submitValueFeedback'
-                 @submitValueVariationFeedback='submitValueVariationFeedback' v-if="totalRows > 0"/>
-      <v-alert v-else border="bottom" colored-border type="warning" class="mt-8" elevation="2">
-          No data matches the selected filter.<br/>
-          In order to show data, please refine the filter's criteria.
-      </v-alert>
+    <Inspector :dataset='inspection.dataset' :inputData.sync='inputData' :model='inspection.model' :originalData='originalData' :transformationModifications="modifications" class='px-0' @reset='resetInput' @submitValueFeedback='submitValueFeedback' @submitValueVariationFeedback='submitValueVariationFeedback' v-if="totalRows > 0" />
+    <v-alert v-else border="bottom" colored-border type="warning" class="mt-8" elevation="2">
+      No data matches the selected filter.<br />
+      In order to show data, please refine the filter's criteria.
+    </v-alert>
 
 
-      <!-- For general feedback -->
-      <v-tooltip left>
-          <template v-slot:activator='{ on, attrs }'>
-              <v-btn :class="feedbackPopupToggle ? 'secondary' : 'primary'" bottom fab fixed class="zindex-10" right
-                     v-bind='attrs' @click='feedbackPopupToggle = !feedbackPopupToggle' v-on='on'>
-                  <v-icon v-if='feedbackPopupToggle'>mdi-close</v-icon>
-                  <v-icon v-else>mdi-message-plus</v-icon>
-              </v-btn>
-          </template>
-          <span v-if='feedbackPopupToggle'>Close</span>
-          <span v-else>Feedback</span>
-      </v-tooltip>
-      <v-overlay :value='feedbackPopupToggle' :z-index='10'></v-overlay>
-      <v-card v-if='feedbackPopupToggle' id='feedback-card' color='primary' dark>
-          <v-card-title>Is this input case insightful?</v-card-title>
-          <v-card-text class='px-3 py-0'>
-              <v-radio-group v-model='feedbackChoice' class='mb-2 mt-0' dark hide-details row>
-                  <v-radio label='Yes' value='yes'></v-radio>
-                  <v-radio label='No' value='no'></v-radio>
-                  <v-radio label='Other' value='other'></v-radio>
-              </v-radio-group>
-              <v-textarea v-model='feedback' :disabled='feedbackSubmitted' hide-details no-resize outlined
-                          placeholder='Why?' rows='2'></v-textarea>
-          </v-card-text>
-          <p v-if='feedbackError' class='caption error--text mb-0'>{{ feedbackError }}</p>
-          <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn :disabled='feedbackSubmitted' light small text @click='clearFeedback'>Cancel</v-btn>
-              <v-btn :disabled='!(feedback && feedbackChoice) || feedbackSubmitted' class='mx-1' color='white' light
-                     small @click='submitGeneralFeedback'>
-                  Send
-              </v-btn>
-              <v-icon v-show='feedbackSubmitted' color='white'>mdi-check</v-icon>
-          </v-card-actions>
-      </v-card>
-      <!-- End For general feedback -->
+    <!-- For general feedback -->
+    <v-tooltip left>
+      <template v-slot:activator='{ on, attrs }'>
+        <v-btn :class="feedbackPopupToggle ? 'secondary' : 'primary'" bottom fab fixed class="zindex-10" right v-bind='attrs' @click='feedbackPopupToggle = !feedbackPopupToggle' v-on='on'>
+          <v-icon v-if='feedbackPopupToggle'>mdi-close</v-icon>
+          <v-icon v-else>mdi-message-plus</v-icon>
+        </v-btn>
+      </template>
+      <span v-if='feedbackPopupToggle'>Close</span>
+      <span v-else>Feedback</span>
+    </v-tooltip>
+    <v-overlay :value='feedbackPopupToggle' :z-index='10'></v-overlay>
+    <v-card v-if='feedbackPopupToggle' id='feedback-card' color='primary' dark>
+      <v-card-title>Is this input case insightful?</v-card-title>
+      <v-card-text class='px-3 py-0'>
+        <v-radio-group v-model='feedbackChoice' class='mb-2 mt-0' dark hide-details row>
+          <v-radio label='Yes' value='yes'></v-radio>
+          <v-radio label='No' value='no'></v-radio>
+          <v-radio label='Other' value='other'></v-radio>
+        </v-radio-group>
+        <v-textarea v-model='feedback' :disabled='feedbackSubmitted' hide-details no-resize outlined placeholder='Why?' rows='2'></v-textarea>
+      </v-card-text>
+      <p v-if='feedbackError' class='caption error--text mb-0'>{{ feedbackError }}</p>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn :disabled='feedbackSubmitted' light small text @click='clearFeedback'>Cancel</v-btn>
+        <v-btn :disabled='!(feedback && feedbackChoice) || feedbackSubmitted' class='mx-1' color='white' light small @click='submitGeneralFeedback'>
+          Send
+        </v-btn>
+        <v-icon v-show='feedbackSubmitted' color='white'>mdi-check</v-icon>
+      </v-card-actions>
+    </v-card>
+    <!-- End For general feedback -->
   </v-container>
 </template>
 
 <script setup lang='ts'>
-import {computed, onMounted, onUnmounted, ref, watch} from 'vue';
-import {api} from '@/api';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { api } from '@/api';
 import Inspector from './Inspector.vue';
 import Mousetrap from 'mousetrap';
 import {
-    CreateFeedbackDTO,
-    DatasetProcessingResultDTO,
-    Filter,
-    InspectionDTO,
-    ModelType,
-    ParameterizedCallableDTO,
-    RowFilterType
+  CreateFeedbackDTO,
+  DatasetProcessingResultDTO,
+  Filter,
+  InspectionDTO,
+  ModelType,
+  ParameterizedCallableDTO,
+  RowFilterType
 } from '@/generated-sources';
 import mixpanel from "mixpanel-browser";
 import _ from "lodash";
 import InspectionFilter from './InspectionFilter.vue';
 import SlicingFunctionSelector from "@/views/main/utils/SlicingFunctionSelector.vue";
-import {useCatalogStore} from "@/stores/catalog";
-import {storeToRefs} from "pinia";
-import {useInspectionStore} from "@/stores/inspection";
-import {$vfm} from "vue-final-modal";
+import { useCatalogStore } from "@/stores/catalog";
+import { storeToRefs } from "pinia";
+import { useInspectionStore } from "@/stores/inspection";
+import { $vfm } from "vue-final-modal";
 import BlockingLoadingModal from "@/views/main/project/modals/BlockingLoadingModal.vue";
-import {confirm} from "@/utils/confirmation.utils";
+import { confirm } from "@/utils/confirmation.utils";
 
 interface CreatedFeedbackCommonDTO {
-    targetFeature?: string | null;
-    userData: string;
-    modelId: string;
-    datasetId: string;
-    originalData: string;
-    projectId: number
+  targetFeature?: string | null;
+  userData: string;
+  modelId: string;
+  datasetId: string;
+  originalData: string;
+  projectId: number
 }
 
 interface Props {
-    inspectionId: number;
-    projectId: number;
-    isProjectOwnerOrAdmin: boolean;
+  inspectionId: number;
+  projectId: number;
+  // isProjectOwnerOrAdmin: boolean;
 }
 
 const props = defineProps<Props>();
@@ -188,14 +171,14 @@ const feedbackError = ref('');
 const feedbackSubmitted = ref(false);
 const labels = ref<string[]>([]);
 const filter = ref<Filter>({
-    inspectionId: props.inspectionId,
-    type: RowFilterType.ALL
+  inspectionId: props.inspectionId,
+  type: RowFilterType.ALL
 });
 
 const selectedSlicingFunction = ref<Partial<ParameterizedCallableDTO>>({
-    uuid: undefined,
-    params: [],
-    type: 'SLICING'
+  uuid: undefined,
+  params: [],
+  type: 'SLICING'
 });
 
 const dataProcessingResult = ref<DatasetProcessingResultDTO | null>(null);
@@ -211,7 +194,7 @@ const percentRegressionUnit = ref(true);
 
 const canPrevious = computed(() => !shuffleMode.value && rowNb.value > 0);
 const canNext = computed(() => rowNb.value < totalRows.value - 1);
-const {transformationFunctions} = storeToRefs(useInspectionStore());
+const { transformationFunctions } = storeToRefs(useInspectionStore());
 
 function commonFeedbackData(): CreatedFeedbackCommonDTO {
   return {
@@ -304,7 +287,7 @@ watch(() => [
   filter.value,
   shuffleMode.value,
   percentRegressionUnit.value,
-    dataProcessingResult.value
+  dataProcessingResult.value
 ], async (nv, ov) => applyFilter(nv, ov), { deep: true, immediate: false });
 
 async function updateRow(forceFetch) {
@@ -321,66 +304,72 @@ async function fetchRows(rowIdxInResults: number, forceFetch: boolean) {
   const remainder = rowIdxInResults % itemsPerPage;
   const newPage = Math.floor(rowIdxInResults / itemsPerPage);
   if ((rowIdxInResults > 0 && remainder === 0) || forceFetch) {
-      const result = await api.getDatasetRows(inspection.value!.dataset.id,
-          newPage * itemsPerPage, itemsPerPage, {
-              filter: {
-                  ...filter.value,
-                  inspectionId: props.inspectionId
-              },
-              removeRows: dataProcessingResult.value?.filteredRows
-          }, inspection.value!.sample, shuffleMode.value)
-      rows.value = result.content;
-      numberOfRows.value = result.totalItems;
+    const result = await api.getDatasetRows(inspection.value!.dataset.id,
+      newPage * itemsPerPage, itemsPerPage, {
+      filter: {
+        ...filter.value,
+        inspectionId: props.inspectionId
+      },
+      removeRows: dataProcessingResult.value?.filteredRows
+    }, inspection.value!.sample, shuffleMode.value)
+    rows.value = result.content;
+    numberOfRows.value = result.totalItems;
   }
 }
 
 
 function assignCurrentRow(forceFetch: boolean) {
-    rowIdxInPage.value = rowNb.value % itemsPerPage;
-    loadingData.value = true;
+  rowIdxInPage.value = rowNb.value % itemsPerPage;
+  loadingData.value = true;
 
-    inputData.value = rows.value[rowIdxInPage.value];
-    originalData.value = {...inputData.value}; // deep copy to avoid caching mechanisms
-    dataErrorMsg.value = '';
-    loadingData.value = false;
-    totalRows.value = numberOfRows.value;
-    if (forceFetch) {
-        rowNb.value = 0;
-    }
+  inputData.value = rows.value[rowIdxInPage.value];
+  originalData.value = { ...inputData.value }; // deep copy to avoid caching mechanisms
+  dataErrorMsg.value = '';
+  loadingData.value = false;
+  totalRows.value = numberOfRows.value;
+  if (forceFetch) {
+    rowNb.value = 0;
+  }
 }
 
 
 const modifications = computed(() => dataProcessingResult.value?.modifications?.find(m => m.rowId === originalData.value['_GISKARD_INDEX_'])?.modifications ?? {});
 
 function resetInput() {
-    inputData.value = {
-        ...originalData.value,
-        ...modifications.value
-    };
+  inputData.value = {
+    ...originalData.value,
+    ...modifications.value
+  };
 }
 
 async function doSubmitFeedback(payload: CreateFeedbackDTO) {
-    mixpanel.track('Submit feedback', {
-        datasetId: payload.datasetId,
-        feedbackChoice: payload.feedbackChoice,
-        feedbackType: payload.feedbackType,
-        modelId: payload.modelId,
-        projectId: payload.projectId
-    });
-    await api.submitFeedback(payload, payload.projectId);
+  mixpanel.track('Submit feedback', {
+    datasetId: payload.datasetId,
+    feedbackChoice: payload.feedbackChoice,
+    feedbackType: payload.feedbackType,
+    modelId: payload.modelId,
+    projectId: payload.projectId
+  });
+  await api.submitFeedback(payload, payload.projectId);
 }
 
 const transformationPipeline = computed(() => Object.values(transformationFunctions.value))
 
-watch(() => transformationPipeline.value, processDataset, {deep: true})
+watch(() => transformationPipeline.value, processDataset, { deep: true })
+
+watch(() => props.inspectionId, async (nv, ov) => {
+  if (nv !== ov) {
+    await init();
+  }
+});
 
 async function processDataset() {
-    const pipeline = [selectedSlicingFunction.value, ...transformationPipeline.value]
-        .filter(callable => !!callable.uuid) as Array<ParameterizedCallableDTO>;
+  const pipeline = [selectedSlicingFunction.value, ...transformationPipeline.value]
+    .filter(callable => !!callable.uuid) as Array<ParameterizedCallableDTO>;
 
-    loadingProcessedDataset.value = true;
-    dataProcessingResult.value = await api.datasetProcessing(props.projectId, inspection.value!.dataset.id, pipeline, inspection.value!.sample)
-    loadingProcessedDataset.value = false;
+  loadingProcessedDataset.value = true;
+  dataProcessingResult.value = await api.datasetProcessing(props.projectId, inspection.value!.dataset.id, pipeline, inspection.value!.sample)
+  loadingProcessedDataset.value = false;
 }
 
 function bindKeys() {
@@ -394,51 +383,51 @@ function resetKeys() {
 
 
 async function init() {
-    inspection.value = await api.getInspection(props.inspectionId);
-    useInspectionStore().$reset();
-    await useCatalogStore().loadCatalog(props.projectId);
+  inspection.value = await api.getInspection(props.inspectionId);
+  useInspectionStore().$reset();
+  await useCatalogStore().loadCatalog(props.projectId);
 }
 
 onMounted(async () => {
-    labels.value = await api.getLabelsForTarget(props.inspectionId);
-    bindKeys();
-    await init();
+  labels.value = await api.getLabelsForTarget(props.inspectionId);
+  bindKeys();
+  await init();
 });
 
 onUnmounted(() => {
-    resetKeys();
+  resetKeys();
 });
 
 async function handleSwitchSample() {
-    if (inspection.value!.sample) {
-        const confirmed = await confirm($vfm, 'Inspect whole dataset', 'Opening the debugger on the whole data might cause performance issues');
-        if (!confirmed) {
-            return;
-        }
+  if (inspection.value!.sample) {
+    const confirmed = await confirm($vfm, 'Inspect whole dataset', 'Opening the debugger on the whole data might cause performance issues');
+    if (!confirmed) {
+      return;
     }
+  }
 
-    await $vfm.show({
-        component: BlockingLoadingModal,
-        bind: {
-            title: "Preprocessing dataset",
-            text: "Please wait. This operation might take some time."
-        },
-        on: {
-            async mounted(close) {
-                try {
-                    inspection.value = await api.updateInspectionName(inspection.value!.id, {
-                        name: inspection.value!.name,
-                        datasetId: inspection.value!.dataset.id,
-                        modelId: inspection.value!.model.id,
-                        sample: !inspection.value!.sample
-                    });
-                    await updateRow(true);
-                } finally {
-                    close();
-                }
-            }
+  await $vfm.show({
+    component: BlockingLoadingModal,
+    bind: {
+      title: "Preprocessing dataset",
+      text: "Please wait. This operation might take some time."
+    },
+    on: {
+      async mounted(close) {
+        try {
+          inspection.value = await api.updateInspectionName(inspection.value!.id, {
+            name: inspection.value!.name,
+            datasetId: inspection.value!.dataset.id,
+            modelId: inspection.value!.model.id,
+            sample: !inspection.value!.sample
+          });
+          await updateRow(true);
+        } finally {
+          close();
         }
-    });
+      }
+    }
+  });
 }
 </script>
 


### PR DESCRIPTION
## Description

This PR aims to fix all redirects to Debugger when opening/creating a debugging session.

Examples:
- Debugger tab: when there is no debugging session, creating a new one should open the InspectionWrapper component
- Debugger tab: when there are debugging sessions, creating a new one should open the InspectionWrapper component
- Catalog/Models tab: clicking on "DEBUG" button of a specific model should redirect to Debugger tab and open the InspectionWrapper component

## Related Issue

[GSK-1277 (available on Linear)](https://linear.app/giskard/issue/GSK-1277/debugging-session-doesnt-open-automatically-after-being-created) and [GSK-1228 (available on Linear)](https://linear.app/giskard/issue/GSK-1228/when-creating-for-the-first-time-a-debugging-session-the-app-displays)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
