### PR TITLE
Only set the backend as not ready when there is an API error

### DIFF
--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -30,7 +30,7 @@ export const useMainStore = defineStore('main', {
         license: null,
         coworkers: [],
         notifications: [],
-        backendReady: false
+        backendReady: true
     }),
     getters: {
         authAvailable(state: State) {


### PR DESCRIPTION
## Description

Only set the backend as not ready when there is an API error (no waiting for backend to try on refresh)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
