### PR TITLE
[GSK-1320] Make AddTestToSuite scrollable

### DIFF
--- a/frontend/src/views/main/project/modals/AddTestToSuite.vue
+++ b/frontend/src/views/main/project/modals/AddTestToSuite.vue
@@ -53,18 +53,18 @@
 
 <script setup lang="ts">
 
-import {computed, onMounted, ref} from 'vue';
-import {api} from '@/api';
-import {FunctionInputDTO, SuiteTestDTO, TestFunctionDTO, TestSuiteDTO} from '@/generated-sources';
+import { computed, onMounted, ref } from 'vue';
+import { api } from '@/api';
+import { FunctionInputDTO, SuiteTestDTO, TestFunctionDTO, TestSuiteDTO } from '@/generated-sources';
 import SuiteInputListSelector from '@/components/SuiteInputListSelector.vue';
-import {chain} from 'lodash';
-import {useMainStore} from "@/stores/main";
-import {TYPE} from 'vue-toastification';
-import {extractArgumentDocumentation, ParsedDocstring} from "@/utils/python-doc.utils";
+import { chain } from 'lodash';
+import { useMainStore } from "@/stores/main";
+import { TYPE } from 'vue-toastification';
+import { extractArgumentDocumentation, ParsedDocstring } from "@/utils/python-doc.utils";
 import mixpanel from 'mixpanel-browser';
-import {anonymize} from "@/utils";
+import { anonymize } from "@/utils";
 
-const {projectId, test, suiteId, testArguments} = defineProps<{
+const { projectId, test, suiteId, testArguments } = defineProps<{
   projectId: number,
   test: TestFunctionDTO,
   suiteId?: number,
@@ -118,26 +118,26 @@ async function submit(close) {
     test,
     testUuid: test.uuid,
     functionInputs: chain(testInputs.value)
-        .omitBy(({value}) => value === null
-            || (typeof value === 'string' && value.trim() === '')
-            || (typeof value === 'number' && Number.isNaN(value)))
-        .value() as { [name: string]: FunctionInputDTO }
+      .omitBy(({ value }) => value === null
+        || (typeof value === 'string' && value.trim() === '')
+        || (typeof value === 'number' && Number.isNaN(value)))
+      .value() as { [name: string]: FunctionInputDTO }
   }
 
   await api.addTestToSuite(projectId, selectedSuite.value!, suiteTest);
   mainStore.addNotification({
-    content: `'${test.displayName ?? test.name}' has been added to '${testSuites.value.find(({id}) => id === selectedSuite.value)!.name}'`,
+    content: `'${test.displayName ?? test.name}' has been added to '${testSuites.value.find(({ id }) => id === selectedSuite.value)!.name}'`,
     color: TYPE.SUCCESS
   });
   close();
 
   mixpanel.track('Add test to test suite',
-      {
-        suiteId: selectedSuite.value,
-        projectId: projectId,
-        testUuid: test.uuid,
-        testName: test.displayName ?? test.name
-      });
+    {
+      suiteId: selectedSuite.value,
+      projectId: projectId,
+      testUuid: test.uuid,
+      testName: test.displayName ?? test.name
+    });
 }
 
 async function createTestSuite() {
@@ -153,11 +153,11 @@ async function createTestSuite() {
   });
 
   mixpanel.track('Create test suite',
-      {
-        id: suite,
-        projectKey: project.key,
-        screen: 'Test catalog (Add test to suite modal)'
-      });
+    {
+      id: suite,
+      projectKey: project.key,
+      screen: 'Test catalog (Add test to suite modal)'
+    });
 
   await loadData();
 
@@ -183,5 +183,7 @@ async function createTestSuite() {
 
 .modal-card {
   min-width: 50vw;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 </style>

--- a/frontend/src/views/main/utils/KwargsCodeEditor.vue
+++ b/frontend/src/views/main/utils/KwargsCodeEditor.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="mt-1 editor-container">
-        <MonacoEditor ref="editor" :value="props.value" @change="onInput" class='editor' language='python' style="height: 300px" :options="monacoOptions" />
+        <MonacoEditor ref="editor" :value="props.value" @change="onInput" class='editor' language='python' style="height: 150px" :options="monacoOptions" />
     </div>
 </template>
 


### PR DESCRIPTION
## Description

This PR aims to fix the size of the component `AddTestToSuite`. There was a bug in which the user could not close the modal if the content were too big. Now, this modal is scrollable.

## Related Issue

[GSK-1320 (available on Linear)](https://linear.app/giskard/issue/GSK-1320/no-add-test-button-when-adding-accuracy-actual-reference-difference)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
