### PR TITLE
[GSK-1341] Fix bug in base text perturbation detector

### DIFF
--- a/python-client/giskard/scanner/robustness/base_detector.py
+++ b/python-client/giskard/scanner/robustness/base_detector.py
@@ -82,7 +82,7 @@ class BaseTextPerturbationDetector(Detector):
             # Select a random subset of the changed records
             if len(changed_idx) > num_samples:
                 rng = np.random.default_rng(747)
-                changed_idx = changed_idx[rng.choice(len(changed_idx), num_samples)]
+                changed_idx = changed_idx[rng.choice(len(changed_idx), num_samples, replace=False)]
 
             original_data = Dataset(
                 dataset.df.loc[changed_idx],


### PR DESCRIPTION
The random generator `choice` method does replacement by default, resulting in duplicate indexes which then break the scan.