### PR TITLE
Make scan widget optionally embeddable

### DIFF
--- a/python-client/giskard/scanner/templates/base.html
+++ b/python-client/giskard/scanner/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <title>Giskard Scan Results</title>
     <base target="_blank">
+    <meta charset="utf-8">
     {% block head %}{% endblock %}
 </head>
 

--- a/python-client/giskard/scanner/templates/scan_results.html
+++ b/python-client/giskard/scanner/templates/scan_results.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+
 {% block head %}
 <style>{% include "static/style.css" %}</style>
 {% endblock %}
@@ -12,7 +14,10 @@
         {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block javascript %}
 <script type="text/javascript">
-    {% include "static/internal.js" %}
+{% include "static/internal.js" %}
 </script>
 {% endblock %}


### PR DESCRIPTION
- made the scan result `to_html` produce a complete HTML page
- optional `embed=True` produces the iframe to embed in notebook
- fixed problem in the j2 templates that prevented the correct layout to be used