### PR TITLE
[GSK-1365] Make websocket reactive to worker status changes

### DIFF
--- a/backend/src/main/java/ai/giskard/event/UpdateWorkerStatusEvent.java
+++ b/backend/src/main/java/ai/giskard/event/UpdateWorkerStatusEvent.java
@@ -1,0 +1,9 @@
+package ai.giskard.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class UpdateWorkerStatusEvent extends ApplicationEvent {
+    public UpdateWorkerStatusEvent(Object source) {
+        super(source);
+    }
+}

--- a/backend/src/main/java/ai/giskard/ml/tunnel/OuterChannelHandler.java
+++ b/backend/src/main/java/ai/giskard/ml/tunnel/OuterChannelHandler.java
@@ -1,5 +1,6 @@
 package ai.giskard.ml.tunnel;
 
+import ai.giskard.event.UpdateWorkerStatusEvent;
 import ai.giskard.service.ml.MLWorkerDataEncryptor;
 import ai.giskard.service.ml.MLWorkerSecurityService;
 import com.google.common.eventbus.EventBus;
@@ -16,6 +17,7 @@ import io.netty.handler.logging.LoggingHandler;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 
 import javax.crypto.SecretKey;
 import java.net.SocketAddress;
@@ -28,6 +30,7 @@ import static ai.giskard.ml.tunnel.ServiceChannelCommand.START_INNER_SERVER;
 
 @ChannelHandler.Sharable
 public class OuterChannelHandler extends ChannelInboundHandlerAdapter {
+    private ApplicationEventPublisher applicationEventPublisher;
     private final Logger log = LoggerFactory.getLogger(OuterChannelHandler.class);
 
     private Optional<InnerServerStartResponse> innerServerData = Optional.empty();
@@ -36,11 +39,13 @@ public class OuterChannelHandler extends ChannelInboundHandlerAdapter {
 
     private final ChannelRegistry channelRegistry = new ChannelRegistry();
 
+
     @Getter
     private EventBus eventBus = new EventBus();
 
-    public OuterChannelHandler(MLWorkerSecurityService mlWorkerSecurityService) {
+    public OuterChannelHandler(MLWorkerSecurityService mlWorkerSecurityService, ApplicationEventPublisher applicationEventPublisher) {
         this.mlWorkerSecurityService = mlWorkerSecurityService;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     private void initInnerServer(SocketChannel outerChannel, String keyId) {
@@ -167,6 +172,7 @@ public class OuterChannelHandler extends ChannelInboundHandlerAdapter {
             if (future.isSuccess()) {
                 log.info("Started inner server {} for incoming service channel {}", localAddress, serviceOuterChannel.id());
             }
+            applicationEventPublisher.publishEvent(new UpdateWorkerStatusEvent(this));
         });
         serviceOuterChannel.closeFuture().addListener(future -> {
             log.info("Shutting down inner server for outer channel {}", serviceOuterChannel.id());
@@ -175,8 +181,9 @@ public class OuterChannelHandler extends ChannelInboundHandlerAdapter {
             channelRegistry.removeServiceChannel(serviceOuterChannel.id());
             innerServerData = Optional.empty();
             eventBus.post(innerServerData);
-
+            applicationEventPublisher.publishEvent(new UpdateWorkerStatusEvent(this));
         });
+
         return new InnerServerStartResponse(localAddress, innerChannelFuture, group);
     }
 }

--- a/backend/src/main/java/ai/giskard/web/socket/WorkerStatusSocketService.java
+++ b/backend/src/main/java/ai/giskard/web/socket/WorkerStatusSocketService.java
@@ -1,17 +1,14 @@
 package ai.giskard.web.socket;
 
+import ai.giskard.event.UpdateWorkerStatusEvent;
 import ai.giskard.service.ml.MLWorkerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
-
-import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 
 @Service
 @RequiredArgsConstructor
@@ -20,24 +17,17 @@ public class WorkerStatusSocketService {
     private final MLWorkerService mlWorkerService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    @PostConstruct
-    public void init() {
-        Timer timer = new Timer();
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                Map<String, Boolean> data = new HashMap<>();
-                data.put("connected", mlWorkerService.isExternalWorkerConnected());
-
-                simpMessagingTemplate.convertAndSend(
-                        "/topic/worker-status",
-                        data);
-            }
-        }, 0, 60000);
+    @EventListener
+    public void handleSessionSubscribeEvent(SessionSubscribeEvent event) {
+        sendCurrentStatus();
     }
 
     @EventListener
-    public void handleSessionSubscribeEvent(SessionSubscribeEvent event) {
+    public void handleUpdateWorkerStatusEvent(UpdateWorkerStatusEvent event) {
+        sendCurrentStatus();
+    }
+
+    public void sendCurrentStatus() {
         Map<String, Boolean> data = new HashMap<>();
         data.put("connected", mlWorkerService.isExternalWorkerConnected());
 

--- a/backend/src/main/java/ai/giskard/web/socket/WorkerStatusSocketService.java
+++ b/backend/src/main/java/ai/giskard/web/socket/WorkerStatusSocketService.java
@@ -2,8 +2,10 @@ package ai.giskard.web.socket;
 
 import ai.giskard.service.ml.MLWorkerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import javax.annotation.PostConstruct;
 import java.util.HashMap;
@@ -31,6 +33,16 @@ public class WorkerStatusSocketService {
                         "/topic/worker-status",
                         data);
             }
-        }, 0, 5000);
+        }, 0, 60000);
+    }
+
+    @EventListener
+    public void handleSessionSubscribeEvent(SessionSubscribeEvent event) {
+        Map<String, Boolean> data = new HashMap<>();
+        data.put("connected", mlWorkerService.isExternalWorkerConnected());
+
+        simpMessagingTemplate.convertAndSend(
+                "/topic/worker-status",
+                data);
     }
 }


### PR DESCRIPTION
## Description

This PR aims to migrate the polling system of  the ML Worker websocket to only send the current worker status message to the channel if one of the following conditions happens:

 - worker connected
 - worker disconnected
 - new client subscriber to the channel
 
## Related Issue

[GSK-1365 (available on Linear)](https://linear.app/giskard/issue/GSK-1365/make-websocket-reactive-to-worker-status)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix