### PR TITLE
[GSK-1399] Make CodeSnippet props optional

### DIFF
--- a/frontend/src/components/CodeSnippet.vue
+++ b/frontend/src/components/CodeSnippet.vue
@@ -6,8 +6,8 @@ import { copyToClipboard } from "@/global-keys";
 
 
 interface Props {
-  codeContent: string;
-  language: string;
+  codeContent?: string;
+  language?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -31,7 +31,8 @@ async function copyCode() {
 </script>
 
 <template>
-  <!-- //NOSONAR --><div class="pre-block rounded pa-4"><code v-html="highlightedCode" class="code-block" />
+  <!-- //NOSONAR -->
+  <div class="pre-block rounded pa-4"><code v-html="highlightedCode" class="code-block" />
     <v-btn class="copy-button" small icon @click="copyCode">
       <v-icon small>mdi-content-copy</v-icon>
       <span v-show="copied" class="copied-message">Copied</span>


### PR DESCRIPTION
## Description
This PR makes the props of `CodeSnippet` component as optional, in order to avoid getting console errors like "missing prop ..."

## Related Issue

[GSK-1399 (available on Linear)](https://linear.app/giskard/issue/GSK-1399/fix-missing-required-prop-in-codesnippet-component)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
