### PR TITLE
Detach TransformationFunction selector from menu

### DIFF
--- a/frontend/src/components/TransformationPopover.vue
+++ b/frontend/src/components/TransformationPopover.vue
@@ -1,49 +1,52 @@
 <template>
-    <v-menu offset-x :close-on-content-click="false" v-model="opened">
+    <v-menu offset-x :close-on-content-click='false' v-model='opened'>
 
-        <template v-slot:activator="{ on: onMenu }">
+      <template v-slot:activator='{ on: onMenu }'>
 
-            <v-tooltip right>
-                <template v-slot:activator="{ on: onTooltip }">
-                    <v-btn small icon :color="hasTransformation ? 'primary' : 'grey'" v-on="{ ...onMenu, ...onTooltip }">
-                        <v-icon size=18>mdi-swap-horizontal</v-icon>
-                    </v-btn>
-                </template>
-                <span>Apply a transformation</span>
-            </v-tooltip>
-        </template>
+        <v-tooltip right>
+          <template v-slot:activator='{ on: onTooltip }'>
+            <v-btn small icon :color="hasTransformation ? 'primary' : 'grey'" v-on='{ ...onMenu, ...onTooltip }'>
+              <v-icon size='18'>mdi-swap-horizontal</v-icon>
+            </v-btn>
+          </template>
+          <span>Apply a transformation</span>
+        </v-tooltip>
+      </template>
 
-        <v-card dark color="primary">
-            <v-card-title>
-                <p>Transformation for '{{ column }}'</p>
-            </v-card-title>
-            <v-card-text>
-                <TransformationFunctionSelector label="Transformation to apply" :column-type="columnType" :column-name="column" :value.sync="transformation.uuid" :args.sync="transformation.params" @onChanged="handleOnChanged" />
-            </v-card-text>
-            <v-card-actions>
-            </v-card-actions>
-        </v-card>
+      <v-card dark color='primary'>
+        <v-card-title>
+          <p>Transformation for '{{ column }}'</p>
+        </v-card-title>
+        <v-card-text>
+          <TransformationFunctionSelector label='Transformation to apply' :column-type='columnType'
+                                          :column-name='column' :value.sync='transformation.uuid'
+                                          :args.sync='transformation.params' @onChanged='handleOnChanged'
+                                          :attach='false' />
+        </v-card-text>
+        <v-card-actions>
+        </v-card-actions>
+      </v-card>
     </v-menu>
 </template>
 
 <script setup lang="ts">
 
-import { storeToRefs } from "pinia";
-import { useInspectionStore } from "@/stores/inspection";
-import { computed, ref } from "vue";
-import TransformationFunctionSelector from "@/views/main/utils/TransformationFunctionSelector.vue";
-import { ParameterizedCallableDTO } from "@/generated-sources";
+import { storeToRefs } from 'pinia';
+import { useInspectionStore } from '@/stores/inspection';
+import { computed, ref } from 'vue';
+import TransformationFunctionSelector from '@/views/main/utils/TransformationFunctionSelector.vue';
+import { ParameterizedCallableDTO } from '@/generated-sources';
 
 const props = defineProps<{
-    column: string,
-    columnType: string
-}>()
+  column: string,
+  columnType: string
+}>();
 
 const transformation = ref<Partial<ParameterizedCallableDTO>>({
-    uuid: undefined,
-    params: [],
-    type: 'TRANSFORMATION'
-})
+  uuid: undefined,
+  params: [],
+  type: 'TRANSFORMATION'
+});
 const opened = ref<boolean>(false);
 
 let inspectionStore = useInspectionStore();

--- a/frontend/src/views/main/utils/TransformationFunctionSelector.vue
+++ b/frontend/src/views/main/utils/TransformationFunctionSelector.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex" :class="{w100: fullWidth}">
         <v-select
-          attach
+          :attach='attach'
           clearable
           :outlined='fullWidth'
           class='slice-function-selector'
@@ -41,10 +41,12 @@ const props = withDefaults(defineProps<{
   args?: Array<FunctionInputDTO>,
   icon: boolean,
   columnType?: string,
-  columnName?: string
+  columnName?: string,
+  attach: string | boolean
 }>(), {
-    fullWidth: true,
-    icon: false
+  fullWidth: true,
+  icon: false,
+  attach: ''
 });
 
 const emit = defineEmits(['update:value', 'update:args', 'onChanged']);


### PR DESCRIPTION
## Description

Detach TransformationFunction selector from menu
## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
