### PR TITLE
[GSK-1491] Changing text of Create test CTA

### DIFF
--- a/python-client/giskard/push/__init__.py
+++ b/python-client/giskard/push/__init__.py
@@ -125,9 +125,9 @@ class BorderlinePush(ExamplePush):
                 #    "cta": CallToActionKind.SaveExample,
                 # },
                 {
-                    "action": "Generate an inconsistency test",
-                    "explanation": "This may help you ensure this inconsistent pattern is not common to the "
-                                   "whole dataset",
+                    "action": "Generate a test specific to this example",
+                    "explanation": "This may help you ensure that this example is not predicted with low confidence "
+                                   "for a new model",
                     "button": "Create test",
                     "cta": CallToActionKind.AddTestToCatalog,
                 },


### PR DESCRIPTION
I changed `action` and `explanation` according to the linear card, but kept the button as "Create test", unit test is not really appropriate here.