### PR TITLE
[GSK-1563] Fix tooltip size when hovering on push button

### DIFF
--- a/frontend/src/components/PushPopover.vue
+++ b/frontend/src/components/PushPopover.vue
@@ -14,7 +14,7 @@
     </template>
 
 
-    <v-card dark color="primary">
+    <v-card dark color="primary" class="push-card">
       <v-card-title>
         {{ push.pushTitle }}
       </v-card-title>
@@ -206,6 +206,11 @@ watch(() => opened, (newValue, oldValue) => {
 </script>
 
 <style scoped>
+.v-tooltip__content,
+.push-card {
+  width: 40vw;
+}
+
 .rim1 {
   position: absolute;
   top: 50%;
@@ -239,5 +244,15 @@ watch(() => opened, (newValue, oldValue) => {
     border: white .5em solid;
     opacity: 0;
   }
+}
+
+.v-card__title {
+  font-size: 1.125rem;
+  line-height: 1.25rem;
+}
+
+.v-list-item__title,
+.v-list-item__subtitle {
+  white-space: normal;
 }
 </style>

--- a/python-client/giskard/push/__init__.py
+++ b/python-client/giskard/push/__init__.py
@@ -213,7 +213,7 @@ class ContributionPush(FeaturePush):
 
     def _set_title_and_details(self):
         if self.correct_prediction:
-            self.push_title = f"{str(self.feature)}=={str(self.value)} contributes a lot to the prediction"
+            self.push_title = f"`{str(self.feature)}`=={str(self.value)} contributes a lot to the prediction"
             self.details = [
                 {
                     "action": f"Save the {'quartile' if self.bounds is not None else 'slice'} {self.slicing_function.query} and continue debugging session",
@@ -235,7 +235,7 @@ class ContributionPush(FeaturePush):
                 },
             ]
         else:
-            self.push_title = f"{str(self.feature)}=={str(self.value)} contributes a lot to the incorrect prediction"
+            self.push_title = f"`{str(self.feature)}`=={str(self.value)} contributes a lot to the incorrect prediction"
             self.details = [
                 {
                     "action": f"Save the {'quartile' if self.bounds is not None else 'slice'} {self.slicing_function.query} and continue debugging session",
@@ -300,9 +300,9 @@ class PerturbationPush(FeaturePush):
             self.tests = [test_metamorphic_invariance_with_mad]
             self.test_params = self.transformation_functions_params[0]
             self.push_title = (
-                f"Adding {round(self.value_perturbed[0] - self.value,2)} to {self.feature} makes the prediction change"
+                f"Adding {round(self.value_perturbed[0] - self.value,2)} to `{self.feature}` makes the prediction change"
             )
         else:
             self.tests = [test_metamorphic_invariance]
             self.test_params = {"transformation_function": self.transformation_functions[0]}
-            self.push_title = f"Perturbing {self.feature} into {self.value_perturbed[0]} makes the prediction change"
+            self.push_title = f"""Perturbing `{self.feature}` into "{self.value_perturbed[0]}" makes the prediction change"""

--- a/python-client/giskard/utils/artifacts.py
+++ b/python-client/giskard/utils/artifacts.py
@@ -11,7 +11,7 @@ except ImportError:
 PRIMITIVES = Union[bool, str, int, float, NoneType]
 
 
-def _serialize_artifact(artifact, artifact_uuid: Optional[str | uuid.UUID]) -> str:
+def _serialize_artifact(artifact, artifact_uuid: Optional[Union[str, uuid.UUID]]) -> str:
     if artifact_uuid is None:
         raise ValueError(f"Cannot serialize artifacts without UUID: {artifact}")
 
@@ -22,7 +22,7 @@ def serialize_parameter(default_value: Any) -> PRIMITIVES:
     if default_value == inspect.Parameter.empty:
         return None
 
-    if isinstance(default_value, PRIMITIVES):
+    if isinstance(default_value, PRIMITIVES.__args__):
         return default_value
 
     from ..ml_worker.core.savable import Artifact
@@ -33,7 +33,7 @@ def serialize_parameter(default_value: Any) -> PRIMITIVES:
     from giskard.datasets.base import Dataset
     from giskard.models.base import BaseModel
 
-    if isinstance(default_value, BaseModel | Dataset):
+    if isinstance(default_value, Union[BaseModel, Dataset].__args__):
         return _serialize_artifact(default_value, default_value.id)
 
     raise ValueError(f"Serialization of {type(default_value)} is not supported")

--- a/python-client/giskard/utils/artifacts.py
+++ b/python-client/giskard/utils/artifacts.py
@@ -1,6 +1,6 @@
 import inspect
 import uuid
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 try:
     from types import NoneType
@@ -8,7 +8,7 @@ except ImportError:
     # types.NoneType is only available from python >=3.10
     NoneType = type(None)
 
-PRIMITIVES = bool | str | int | float | NoneType
+PRIMITIVES = Union[bool, str, int, float, NoneType]
 
 
 def _serialize_artifact(artifact, artifact_uuid: Optional[str | uuid.UUID]) -> str:


### PR DESCRIPTION
## Description

This PR makes the push tooltip and card with a smaller width, but also displaying their contents without hidden overflow.

## Related Issue

[GSK-1563 (available on Linear)](https://linear.app/giskard/issue/GSK-1563/push-hover-preview-is-to-long-for-text)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
