### PR TITLE
[GSK-1576] Make "go back" available with shuffle mode in Dataset Explorer

### DIFF
--- a/frontend/src/views/main/project/InspectorWrapper.vue
+++ b/frontend/src/views/main/project/InspectorWrapper.vue
@@ -197,7 +197,7 @@ const rowIdxInPage = ref(0);
 const regressionThreshold = ref(0.1);
 const percentRegressionUnit = ref(true);
 
-const canPrevious = computed(() => !shuffleMode.value && rowNb.value > 0);
+const canPrevious = computed(() => rowNb.value > 0);
 const canNext = computed(() => rowNb.value < totalRows.value - 1);
 const { transformationFunctions } = storeToRefs(useInspectionStore());
 


### PR DESCRIPTION
## Description

This PR makes the previous data point available while the shuffle mode is on in the Dataset Explorer (Debugger tab). Previously, it was not able to move back to the previous data point when the shuffle mode was on.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

[GSK-1576 (available on Linear)](https://linear.app/giskard/issue/GSK-1576/cant-go-back-in-shuffle-mode)

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix