### PR TITLE
[GSK-1617] ModelCache does not load cached results correctly on Windows

### DIFF
--- a/python-client/giskard/models/base/wrapper.py
+++ b/python-client/giskard/models/base/wrapper.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Union
 
 import cloudpickle
+import mlflow
 import numpy as np
 import pandas as pd
 import yaml
-import mlflow
 
 from ...core.core import ModelType
 from ...core.validation import configured_validate_arguments
@@ -31,18 +31,18 @@ class WrapperModel(BaseModel, ABC):
 
     @configured_validate_arguments
     def __init__(
-            self,
-            model: Any,
-            model_type: ModelType,
-            data_preprocessing_function: Optional[Callable[[pd.DataFrame], Any]] = None,
-            model_postprocessing_function: Optional[Callable[[Any], Any]] = None,
-            name: Optional[str] = None,
-            feature_names: Optional[Iterable] = None,
-            classification_threshold: Optional[float] = 0.5,
-            classification_labels: Optional[Iterable] = None,
-            id: Optional[str] = None,
-            batch_size: Optional[int] = None,
-            **kwargs,
+        self,
+        model: Any,
+        model_type: ModelType,
+        data_preprocessing_function: Optional[Callable[[pd.DataFrame], Any]] = None,
+        model_postprocessing_function: Optional[Callable[[Any], Any]] = None,
+        name: Optional[str] = None,
+        feature_names: Optional[Iterable] = None,
+        classification_threshold: Optional[float] = 0.5,
+        classification_labels: Optional[Iterable] = None,
+        id: Optional[str] = None,
+        batch_size: Optional[int] = None,
+        **kwargs,
     ) -> None:
         """
         Parameters
@@ -130,7 +130,12 @@ class WrapperModel(BaseModel, ABC):
             output = self._postprocess(output)
             outputs.append(output)
 
-        return np.concatenate(outputs)
+        raw_prediction = np.concatenate(outputs)
+
+        if self.is_regression:
+            return raw_prediction.astype(float)
+
+        return raw_prediction
 
     def _possibly_fix_predictions_shape(self, raw_predictions: np.ndarray):
         if not self.is_classification:
@@ -292,15 +297,11 @@ class WrapperModel(BaseModel, ABC):
             # ensuring backward compatibility
             return {"batch_size": None}
 
-    def to_mlflow(self,
-                  artifact_path: str = "prediction-function-from-giskard",
-                  **kwargs):
-
+    def to_mlflow(self, artifact_path: str = "prediction-function-from-giskard", **kwargs):
         def _giskard_predict(df):
             return self.predict(df)
 
         class MLflowModel(mlflow.pyfunc.PythonModel):
-
             def predict(self, df):
                 return _giskard_predict(df)
 

--- a/python-client/giskard/models/cache/cache.py
+++ b/python-client/giskard/models/cache/cache.py
@@ -2,7 +2,7 @@ import csv
 import os
 import uuid
 from pathlib import Path
-from typing import Dict, List, Any, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -32,7 +32,9 @@ class ModelCache:
     def __init__(self, model_type: SupportedModelTypes, id: Optional[str] = None, cache_dir: Path = None):
         self.id = id or str(uuid.uuid4())
         self.prediction_cache = dict()
-        self.cache_dir = cache_dir or Path(settings.home_dir / settings.cache_dir / "global/prediction_cache" / self.id)
+        self.cache_dir = cache_dir or Path(
+            settings.home_dir / settings.cache_dir / "global" / "prediction_cache" / self.id
+        )
 
         if id is not None:
             if (self.cache_dir / CACHE_CSV_FILENAME).exists():


### PR DESCRIPTION
This is caused by bad formatting of newlines in csv read/write, see [here](https://docs.python.org/3/library/csv.html#id3).

Fixing also a series of other issues:

- Fix cache loading when cache is disabled
- Fix broken cache for text generation models (and added a test)
- Fix broken cache path on Windows
- Fix broken CSV writing on Windows
- Ensure regression models output is casted to float
