### PR TITLE
Do not run integration tests on windows

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -221,8 +221,8 @@ jobs:
           path: python-client/dist/*whl
           
       - name: Run integration tests for python
-        if: ${{ inputs.run-integration-tests }}
+        if: ${{ inputs.run-integration-tests && matrix.os != 'windows-2019' }}
         working-directory: python-client
         env:
-          PYTEST_XDIST_AUTO_NUM_WORKERS: ${{ matrix.os == 'windows-2019' && 1 || 2 }}
-        run: pdm run test
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 2
+        run: pdm run test -m 'not slow'


### PR DESCRIPTION
Slight improvement to not run integration tests on windows
Also avoid re-running not slow tests