### PR TITLE
[GSK-1783] Fix issues due to pydantic compatibility migration

### DIFF
--- a/python-client/giskard/cli_utils.py
+++ b/python-client/giskard/cli_utils.py
@@ -66,7 +66,7 @@ def create_pid_file_path(is_server, url):
 def ml_worker_id(is_server, url):
     key = f"{sys.executable}"
     if not is_server:
-        key += url
+        key += str(url)
     hash_value = hashlib.sha1(key.encode()).hexdigest()
     return hash_value
 

--- a/python-client/giskard/ml_worker/websocket/__init__.py
+++ b/python-client/giskard/ml_worker/websocket/__init__.py
@@ -334,12 +334,12 @@ class CallToActionKind(Enum):
 class GetPushParam(BaseModel):
     model: ArtifactRef
     dataset: ArtifactRef
-    dataframe: Optional[DataFrame]
+    dataframe: Optional[DataFrame] = None
     target: str
     column_types: Dict[str, str]
     column_dtypes: Dict[str, str]
-    push_kind: Optional[PushKind]
-    cta_kind: Optional[CallToActionKind]
+    push_kind: Optional[PushKind] = None
+    cta_kind: Optional[CallToActionKind] = None
 
 
 class PushDetails(BaseModel):
@@ -351,20 +351,20 @@ class PushDetails(BaseModel):
 
 class Push(BaseModel):
     kind: PushKind
-    key: Optional[str]
-    value: Optional[str]
+    key: Optional[str] = None
+    value: Optional[str] = None
     push_title: str
     push_details: List[PushDetails]
 
 
 class PushAction(BaseModel):
     object_uuid: str
-    arguments: Optional[List[FuncArgument]]
+    arguments: Optional[List[FuncArgument]] = None
 
 
 class GetPushResponse(BaseModel):
-    contribution: Optional[Push]
-    perturbation: Optional[Push]
-    overconfidence: Optional[Push]
-    borderline: Optional[Push]
-    action: Optional[PushAction]
+    contribution: Optional[Push] = None
+    perturbation: Optional[Push] = None
+    overconfidence: Optional[Push] = None
+    borderline: Optional[Push] = None
+    action: Optional[PushAction] = None


### PR DESCRIPTION
## Description

- `AnyHttpUrl` API becomes read-only and arg constructor is changed;
- `AnyHttpUrl` cannot be implicitly considered as a string;
- `pydantic` v2 has more strict validations on `Optional` fields.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
