### PR TITLE
[GSK-1790] Fix UI bug when adding a new feedback

### DIFF
--- a/backend/src/main/java/ai/giskard/service/MailService.java
+++ b/backend/src/main/java/ai/giskard/service/MailService.java
@@ -74,7 +74,12 @@ public class MailService {
         try {
             MimeMessageHelper message = new MimeMessageHelper(mimeMessage, isMultipart, StandardCharsets.UTF_8.name());
             message.setTo(to);
-            message.setFrom(applicationProperties.getEmailFrom());
+
+            if (applicationProperties.getEmailFrom() != null) {
+                message.setFrom(applicationProperties.getEmailFrom());
+            } else {
+                message.setFrom("noreply@giskard.ai");
+            }
             message.setSubject(subject);
             message.setText(content, isHtml);
             javaMailSender.send(mimeMessage);


### PR DESCRIPTION
## Description

This PR solves a bug when a user tries to create a new feedback and a red message appears just below the modal displaying a backend error. 

Basically, the backend was trying to create a feedback without a email from, generating an uncatched exception. Therefore, I added a default email from (noreply@giskard.ai) to avoid this problem.

## Related Issue

[GSK-1790 (available on Linear)](https://linear.app/giskard/issue/GSK-1790/feedback-button-does-not-work-in-the-demo-environment)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
