### PR TITLE
Feature/gsk 1818 remove unnecessary objects in the UI

### DIFF
--- a/python-client/giskard/core/core.py
+++ b/python-client/giskard/core/core.py
@@ -196,7 +196,9 @@ class CallableMeta(SavableMeta, ABC):
     def populate_tags(self, tags=None):
         tags = [] if not tags else tags.copy()
 
-        if self.full_name.partition(".")[0] == "giskard":
+        if self.name == "<lambda>":
+            tags.append("lambda")
+        elif self.full_name.partition(".")[0] == "giskard":
             tags.append("giskard")
         else:
             tags.append("custom")

--- a/python-client/giskard/ml_worker/websocket/utils.py
+++ b/python-client/giskard/ml_worker/websocket/utils.py
@@ -109,7 +109,7 @@ def map_function_meta_ws(callable_type):
             debugDescription=test.debug_description,
         )
         for test in tests_registry.get_all().values()
-        if test.type == callable_type
+        if test.type == callable_type and "giskard" in test.tags
     }
 
 
@@ -153,7 +153,7 @@ def map_dataset_process_function_meta_ws(callable_type):
             processType=test.process_type.name,
         )
         for test in tests_registry.get_all().values()
-        if test.type == callable_type
+        if test.type == callable_type and "giskard" in test.tags
     }
 
 


### PR DESCRIPTION
## Description

- [x] Do not upload `<lambda>` from ML worker anymore (`SlicingFunction(lambda x: x, ...).upload(...)` will work)
 
## Related Issue


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

