### PR TITLE
Feature/gsk 1814 add a message error when the server is started with version

### DIFF
--- a/giskard/commands/cli_server.py
+++ b/giskard/commands/cli_server.py
@@ -126,7 +126,7 @@ def _start(attached=False, skip_version_check=False, version=None):
 
     version = get_version(version)
 
-    if not skip_version_check and version == giskard.get_version():
+    if not skip_version_check and version != giskard.get_version():
         logger.error(
             f"""
 You're trying to start the server with version '{version}' while currently using Giskard '{giskard.get_version()}'

--- a/giskard/commands/cli_server.py
+++ b/giskard/commands/cli_server.py
@@ -132,9 +132,9 @@ def _start(attached=False, skip_version_check=False, version=None):
 You're trying to start the server with version '{version}' while currently using Giskard '{giskard.get_version()}'
         
 This might lead to incompatibility issues!
-If you want to proceed please add `--skip-version-check`
+If you want to proceed please add `--skip-version-check` to the start command.
         
-To upgrade giskard please run `giskard server stop && giskard server upgrade`
+We recommend you to upgrade giskard by running `giskard server stop && giskard server upgrade` in order to fix this issue.
 """
         )
         return


### PR DESCRIPTION
## Description

Added an error message when trying to start the server with a different version of the python library

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
