### PR TITLE
[GSK-1813] Fix giskard server upgrade runs for 20mns without returning

### DIFF
--- a/giskard/commands/cli_server.py
+++ b/giskard/commands/cli_server.py
@@ -452,14 +452,17 @@ def upgrade(version):
     if not version:
         version = latest_version
 
-    installed_version = _get_settings().get("version")
+    installed_version = _get_settings().get("version") if _get_settings() else None
     if installed_version == version:
         logger.info(f"Giskard server is already running version {version}")
         return
 
     logger.info(f"Updating Giskard Server {installed_version} -> {version}")
     _pull_image(version)
-    _write_settings({**_get_settings(), **{"version": version}})
+    if _get_settings():
+        _write_settings({**_get_settings(), **{"version": version}})
+    else:
+        _write_settings({**{"version": version}})
     logger.info(f"Giskard Server upgraded to {version}")
 
 

--- a/giskard/commands/cli_server.py
+++ b/giskard/commands/cli_server.py
@@ -188,7 +188,8 @@ def _fetch_latest_tag() -> str:
     latest_tag = "latest"
     latest = next(i for i in json_response["results"] if i["name"] == latest_tag)
     latest_version_image = next(
-        i for i in json_response["results"] if ((i["name"] != latest_tag) and (i["digest"] == latest["digest"]))
+        (i for i in json_response["results"] if ((i["name"] != latest_tag) and (i["digest"] == latest["digest"]))),
+        { "name": giskard.__version__ } # Create a dictionary containing the current version as default value
     )
 
     tag = latest_version_image["name"]


### PR DESCRIPTION
## Description

Our `latest` image could disappear (or not on the first 10 items in Docker Hub repository), where the client will get stuck on parsing.
Use the version matching the local Giskard client in this case, and handle a few edge cases during upgrade.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
