### PR TITLE
[GSK-1900] Allow to move PyTorch model from HF to the given device

### DIFF
--- a/giskard/models/huggingface.py
+++ b/giskard/models/huggingface.py
@@ -186,6 +186,8 @@ class HuggingFaceModel(WrapperModel):
         self.huggingface_module = model.__class__
         self.pipeline_task = model.task if isinstance(model, pipelines.Pipeline) else None
         self.device = device if device else model.device.type   # Allow to overwrite device
+        if not self.device:
+            self.deivce = "cpu"
 
         try:
             if batch_size == 1 and model.device.type == "cuda":
@@ -214,6 +216,7 @@ class HuggingFaceModel(WrapperModel):
                 {
                     "huggingface_module": self.huggingface_module,
                     "pipeline_task": self.pipeline_task,
+                    "device": self.device,
                 },
                 f,
                 default_flow_style=False,


### PR DESCRIPTION
## Description

TF model could also be PyTorch NN module. We need use `to(device)` to move and run the models to GPU.

Can be tested using HF DistilBert model.

## Related Issue

[GSK-1900] ML worker cannot predict on GPU with model from Hugging Face

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
