### PR TITLE
Use 80 as default port in ML worker

### DIFF
--- a/giskard/ml_worker/ml_worker.py
+++ b/giskard/ml_worker/ml_worker.py
@@ -64,8 +64,9 @@ class MLWorker:
             self.ml_worker_id = EXTERNAL_WORKER_ID
             # Use the URL path component provided by settings
 
-            port = backend_url.port
-            # Use 443 port if https and no given port
+            # Use 80 port by default
+            port = backend_url.port if backend_url.port else 80
+            # Fix 443 port if https and no given port
             if backend_url.scheme == "https" and backend_url.port is None:
                 port = 443
             backend_url = validate_url(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

Fix the error when connecting using `giskard worker start -u http://<host> -k <key>`:

```
Traceback (most recent call last):
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/bin/giskard", line 8, in <module>
    sys.exit(cli())
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/inoki/.virtualenvs/giskard-py310-dev/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/***/giskard/giskard/cli_utils.py", line 35, in wrapper
    return func(*args, **kwargs)
  File "/Users/***/giskard/giskard/commands/cli_worker.py", line 60, in wrapper
    return func(*args, **kwargs)
  File "/Users/***/giskard/giskard/commands/cli_worker.py", line 112, in start_command
    _start_command(is_server, url, api_key, is_daemon, hf_token, int(nb_workers) if nb_workers is not None else None)
  File "/Users/***/giskard/giskard/commands/cli_worker.py", line 164, in _start_command
    ml_worker = MLWorker(is_server, url, api_key, hf_token)
  File "/Users/***/giskard/giskard/ml_worker/ml_worker.py", line 48, in __init__
    ws_conn = self._create_websocket_client(backend_url, is_server, hf_token)
  File "/Users/***/giskard/giskard/ml_worker/ml_worker.py", line 71, in _create_websocket_client
    backend_url = validate_url(
  File "/Users/***/giskard/giskard/cli_utils.py", line 75, in validate_url
    return parse_obj_as(AnyHttpUrl, value)
  File "pydantic/tools.py", line 38, in pydantic.tools.parse_obj_as
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ParsingModel[AnyHttpUrl]
__root__
  URL invalid, extra characters found after valid URL: ':None/ml-worker' (type=value_error.url.extra; extra=:None/ml-worker)
```

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
