### PR TITLE
Remove auto-created `version` from mandatory fields

### DIFF
--- a/giskard/ml_worker/websocket/__init__.py
+++ b/giskard/ml_worker/websocket/__init__.py
@@ -33,13 +33,13 @@ class TestFunctionArgument(BaseModel):
 
 
 # CallableMeta shows that all fields can be none,
-# but we have a pre-check here for Database constraints:
+# but we have a pre-check here for Database constraints except auto-created "version":
 # referring to `ai.giskard.domain.Callable` and `ai.giskard.domain.TestFunction`.
 class FunctionMeta(BaseModel):
     uuid: str
     name: str
     displayName: Optional[str] = None
-    version: int
+    version: Optional[int] = None
     module: Optional[str] = None
     doc: Optional[str] = None
     moduleDoc: Optional[str] = None
@@ -51,14 +51,14 @@ class FunctionMeta(BaseModel):
 
 
 # CallableMeta shows that all fields can be none,
-# but we have a pre-check here for Database constraints:
+# but we have a pre-check here for Database constraints except auto-created "version":
 # referring to `ai.giskard.domain.Callable`, `ai.giskard.domain.SlicingFunction`,
 # `ai.giskard.domain.TransformationFunction` and `ai.giskard.domain.DatasetProcessFunction`.
 class DatasetProcessFunctionMeta(BaseModel):
     uuid: str
     name: str
     displayName: Optional[str] = None
-    version: int
+    version: Optional[int] = None
     module: Optional[str] = None
     doc: Optional[str] = None
     moduleDoc: Optional[str] = None

--- a/tests/communications/test_dto_serialization.py
+++ b/tests/communications/test_dto_serialization.py
@@ -25,7 +25,7 @@ MANDATORY_FIELDS = {
     "DataFrame": ["rows"],
     "DataRow": ["columns"],
     "DatasetMeta": [],
-    "DatasetProcessFunctionMeta": ["uuid", "name", "code", "version", "cellLevel"],
+    "DatasetProcessFunctionMeta": ["uuid", "name", "code", "cellLevel"],
     "DatasetProcessing": ["datasetId", "totalRows"],
     "DatasetProcessingFunction": [],
     "DatasetProcessingParam": ["dataset"],
@@ -39,7 +39,7 @@ MANDATORY_FIELDS = {
     "ExplainTextParam": ["model", "feature_name", "columns", "column_types"],
     "Explanation": ["per_feature"],
     "FuncArgument": ["name", "none"],
-    "FunctionMeta": ["uuid", "name", "code", "version"],
+    "FunctionMeta": ["uuid", "name", "code"],
     "GenerateTestSuite": [],
     "GenerateTestSuiteParam": ["project_key"],
     "GeneratedTestInput": ["name", "value", "is_alias"],
@@ -89,6 +89,7 @@ OPTIONAL_FIELDS = {
     "DataRow": [],
     "DatasetMeta": ["target"],
     "DatasetProcessFunctionMeta": [
+        "version",
         "displayName",
         "module",
         "doc",
@@ -124,6 +125,7 @@ OPTIONAL_FIELDS = {
         "args",
     ],
     "FunctionMeta": [
+        "version",
         "displayName",
         "module",
         "doc",


### PR DESCRIPTION
## Description

The `version` field will be created and maintained by Backend.

## Related Issue

Failed auto tests after merging main: https://github.com/Giskard-AI/giskard/actions/runs/6702684521/job/18212031756#step:16:3646

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
