### PR TITLE
[GSK-2030] Various mlflow related updates

### DIFF
--- a/giskard/core/suite.py
+++ b/giskard/core/suite.py
@@ -97,11 +97,12 @@ class TestSuiteResult:
         for test_result in self.results:
             test_name = test_result[0]
             test_name = process_text(test_name)
+            mlflow_metric_name = f"{test_result[1].metric_name} for {test_name}"
             if mlflow_client is None and mlflow_run_id is None:
-                mlflow.log_metric(test_name, test_result[1].metric)
+                mlflow.log_metric(mlflow_metric_name, test_result[1].metric)
             elif mlflow_client and mlflow_run_id:
-                mlflow_client.log_metric(mlflow_run_id, test_name, test_result[1].metric)
-            metrics[test_name] = test_result[1].metric
+                mlflow_client.log_metric(mlflow_run_id, mlflow_metric_name, test_result[1].metric)
+            metrics[mlflow_metric_name] = test_result[1].metric
 
         return metrics
 

--- a/giskard/integrations/mlflow/giskard_evaluator_utils.py
+++ b/giskard/integrations/mlflow/giskard_evaluator_utils.py
@@ -23,6 +23,7 @@ alphanumeric_map = {
     "=": "equal to",
     "!=": "different of",
 }
+control_chars_map = {"\\r": "carriage return", "\\b": "backspace"}
 
 
 def unwrap_python_model_from_pyfunc_if_langchain(pyfunc_model):
@@ -44,6 +45,9 @@ def unwrap_python_model_from_pyfunc_if_langchain(pyfunc_model):
 def process_text(some_string):
     for k, v in alphanumeric_map.items():
         some_string = some_string.replace(k, v)
+    for k, v in control_chars_map.items():
+        some_string = some_string.replace(k, v)
+
     some_string = some_string.replace("data slice", "data slice -")
     some_string = re.sub(r"[^A-Za-z0-9_\-. /]+", "", some_string)
 

--- a/giskard/models/automodel.py
+++ b/giskard/models/automodel.py
@@ -55,7 +55,9 @@ class Model(CloudpickleSerializableModel):
         * if regression or text_generation: an array of predictions corresponding to data entries
         (rows of pandas.DataFrame) and outputs.
     name : Optional[str]
-        the name of the model.
+        Name of the model.
+    description : Optional[str]
+        Description of the model's task. Mandatory for non-langchain text_generation models.
     model_type : ModelType
         The type of the model: regression, classification or text_generation.
     data_preprocessing_function : Optional[Callable[[pd.DataFrame]
@@ -92,6 +94,7 @@ class Model(CloudpickleSerializableModel):
         data_preprocessing_function: Callable[[pd.DataFrame], Any] = None,
         model_postprocessing_function: Callable[[Any], Any] = None,
         name: Optional[str] = None,
+        description: Optional[str] = None,
         feature_names: Optional[Iterable] = None,
         classification_threshold: Optional[float] = 0.5,
         classification_labels: Optional[Iterable] = None,

--- a/giskard/models/base/model.py
+++ b/giskard/models/base/model.py
@@ -92,6 +92,7 @@ class BaseModel(ABC):
         Parameters:
             model_type (ModelType): Type of the model, either ModelType.REGRESSION or ModelType.CLASSIFICATION.
             name (str, optional): Name of the model. If not provided, defaults to the class name.
+            description (str, optional): Description of the model's task. Mandatory for non-langchain text_generation models.
             feature_names (Iterable, optional): A list of names of the input features.
             classification_threshold (float, optional): Threshold value used for classification models. Defaults to 0.5.
             classification_labels (Iterable, optional): A list of labels for classification models.

--- a/giskard/scanner/llm/llm_chars_injection_detector.py
+++ b/giskard/scanner/llm/llm_chars_injection_detector.py
@@ -100,7 +100,7 @@ def _generate_char_injection_tests(issue: Issue):
 
     feature = issue.features[0]
     return {
-        f"Character injection ({issue.meta['special_char'].encode('unicode_escape').decode('ascii')}) in “{feature}”": test_llm_char_injection(
+        f"{issue.meta['special_char'].encode('unicode_escape').decode('ascii')} character injection in “{feature}”": test_llm_char_injection(
             dataset=issue.dataset,
             characters=[issue.meta["special_char"]],
             features=issue.features,


### PR DESCRIPTION
- exposing `description` in `giskard.Model` in order to be able to do this:
  ```py
  evaluator_config={
    "model_config":
     {"name": "Climate Change Question Answering",
      "description": "This model answers any question about climate change based on IPCC reports",
      "feature_names": ["query"],}
    }
  ```
  instead of 
  ```py
  evaluator_config={
    "model_config":
     {"name": "Climate Change Question Answering",
      "kwargs": {"description": "This model answers any question about climate change based on IPCC reports"},
      "feature_names": ["query"],}
    }
  ```
- reformatting the metrics names logged into mlflow