### PR TITLE
[GSK-1509][GSK-1990] Add up/download tests for model, dataset and callable

### DIFF
--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -58,7 +58,7 @@ class ModelMetaInfo(ConfiguredBaseModel):
 
 
 class DatasetMetaInfo(ConfiguredBaseModel):
-    target: str
+    target: Optional[str]
     columnTypes: Dict[str, str]
     columnDtypes: Dict[str, str]
     numberOfRows: int

--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -58,12 +58,12 @@ class ModelMetaInfo(ConfiguredBaseModel):
 
 
 class DatasetMetaInfo(ConfiguredBaseModel):
-    target: Optional[str]
+    target: Optional[str] = None
     columnTypes: Dict[str, str]
     columnDtypes: Dict[str, str]
     numberOfRows: int
     categoryFeatures: Dict[str, List[str]]
-    name: Optional[str]
+    name: Optional[str] = None
     originalSizeBytes: int
     compressedSizeBytes: int
     createdDate: str

--- a/giskard/core/core.py
+++ b/giskard/core/core.py
@@ -101,7 +101,7 @@ class ModelMeta:
 @dataclass
 class DatasetMeta:
     name: Optional[str]
-    target: str
+    target: Optional[str]
     column_types: Dict[str, str]
     column_dtypes: Dict[str, str]
     number_of_rows: int

--- a/giskard/ml_worker/core/savable.py
+++ b/giskard/ml_worker/core/savable.py
@@ -64,7 +64,9 @@ class Artifact(Generic[SMT], ABC):
             return None
 
         with open(file, "r") as f:
-            return cls._get_meta_class(**yaml.load(f, Loader=yaml.FullLoader))
+            # PyYAML prohibits the arbitary execution so our class cannot be loaded safely,
+            # see: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+            return yaml.load(f, Loader=yaml.UnsafeLoader)
 
     def upload(self, client: GiskardClient, project_key: Optional[str] = None) -> str:
         """

--- a/tests/models/test_base_model.py
+++ b/tests/models/test_base_model.py
@@ -1,8 +1,11 @@
 import numpy as np
 import pandas as pd
 import pytest
+import uuid
 
 from giskard.models.base.model import BaseModel
+
+from tests import utils
 
 
 class _CustomModel(BaseModel):
@@ -31,4 +34,36 @@ def test_base_model_raises_error_if_classification_labels_not_provided():
         _CustomModel("classification")
 
 
-# @TODO: add tests for model download
+# Tests for model download
+def test_model_download(request):
+    model: BaseModel = request.getfixturevalue("german_credit_model")
+    project_key = str(uuid.uuid4())
+
+    with utils.MockedProjectCacheDir(project_key):
+        with utils.MockedClient(mock_all=False) as (client, mr):
+            # The model needs to request files
+            utils.register_uri_for_model_meta_info(mr, model, project_key)
+            utils.register_uri_for_model_artifact_info(mr, model, project_key, register_file_contents=True)
+
+            downloaded_model = BaseModel.download(client=client, project_key=project_key, model_id=str(model.id))
+
+            assert downloaded_model.id == model.id
+            assert downloaded_model.meta == model.meta
+
+
+def test_model_download_with_cache(request):
+    model: BaseModel = request.getfixturevalue("german_credit_model")
+    project_key = str(uuid.uuid4())
+
+    with utils.MockedProjectCacheDir(project_key):
+        # Save the model to cache dir
+        utils.local_save_model_under_giskard_home_cache(model=model, project_key=project_key)
+
+        with utils.MockedClient(mock_all=False) as (client, mr):
+            # The model is cached, can be created without further requests
+            utils.register_uri_for_model_meta_info(mr, model, project_key)
+
+            downloaded_model = BaseModel.download(client=client, project_key=project_key, model_id=str(model.id))
+
+            assert downloaded_model.id == model.id
+            assert downloaded_model.meta == model.meta

--- a/tests/test_artifact_download.py
+++ b/tests/test_artifact_download.py
@@ -1,0 +1,302 @@
+
+import posixpath
+import uuid
+import pandas as pd
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import requests_mock
+
+from giskard import slicing_function, transformation_function
+from giskard.ml_worker.core.savable import Artifact
+from giskard.ml_worker.testing.test_result import TestResult as GiskardTestResult
+from giskard import test
+
+from tests.utils import (
+    CALLABLE_FUNCTION_META_CACHE,
+    CALLABLE_FUNCTION_PKL_CACHE,
+    MockedClient,
+    MockedProjectCacheDir,
+    fixup_mocked_artifact_meta_version,
+    get_local_cache_callable_artifact,
+    register_uri_for_artifact_meta_info,
+    register_uri_for_artifact_info,
+    get_url_for_artifact_meta_info,
+    get_url_for_artifacts_base,
+    local_save_artifact_under_giskard_home_cache,
+)
+
+
+BASE_CLIENT_URL = "http://giskard-host:12345/api/v2"
+
+
+# Define a test function
+@test
+def my_custom_test(model, data):
+    return GiskardTestResult(passed=True)
+
+
+# Define a slicing function
+@slicing_function(row_level=False)
+def head_slice(df: pd.DataFrame) -> pd.DataFrame:
+    return df.head(10)
+
+
+# Define a transformation function
+@transformation_function()
+def do_nothing(row):
+    return row
+
+
+def test_download_global_test_function_from_registry():
+    cf: Artifact = my_custom_test
+
+    # Load from registry using uuid without client
+    download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=None, project_key=None)
+
+    # Check the downloaded info
+    assert download_cf.__class__ is cf.__class__
+    assert download_cf.meta.uuid == cf.meta.uuid
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_global_test_function_from_local(cf):
+    project_key = str(uuid.uuid4())
+    with MockedProjectCacheDir(project_key):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+
+        local_save_artifact_under_giskard_home_cache(cf, project_key=None)
+
+        # Load from registry using uuid without client
+        download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=None, project_key=None)
+
+        # Check the downloaded info
+        assert download_cf.__class__ is cf.__class__
+        assert download_cf.meta.uuid == cf.meta.uuid
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_callable_function(cf: Artifact):
+    with MockedClient(mock_all=False) as (client, mr):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+        cache_dir = get_local_cache_callable_artifact(project_key=None, artifact=cf)
+
+        # Save to temp
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            cf.save(tmpdir_path)
+            # Check saved file
+            assert (tmpdir_path / CALLABLE_FUNCTION_PKL_CACHE).exists()
+            assert (tmpdir_path / CALLABLE_FUNCTION_META_CACHE).exists()
+
+            # Fixup the differences from Backend
+            meta_info = fixup_mocked_artifact_meta_version(cf.meta.to_json())
+            # Fixup the name to avoid load from module
+            meta_info.update({
+                "name": f"fake_{cf._get_name()}",
+            })
+            url = get_url_for_artifact_meta_info(cf, project_key=None)
+            mr.register_uri(method=requests_mock.GET, url=url, json=meta_info)
+
+            # Register for Artifact info
+            register_uri_for_artifact_info(mr, cf, project_key=None)
+
+            # Register for Artifacts content
+            artifacts_base_url = get_url_for_artifacts_base(cf, project_key=None)
+            for file in [CALLABLE_FUNCTION_META_CACHE, CALLABLE_FUNCTION_PKL_CACHE]:
+                with open(tmpdir_path / file, "rb") as f:
+                    mr.register_uri(
+                        method=requests_mock.GET,
+                        url=posixpath.join(artifacts_base_url, file),
+                        content=f.read(),
+                    )
+
+            # Download: should not call load_artifact to request and download
+            download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=None)
+            # Check the downloaded info
+            assert download_cf.__class__ is cf.__class__
+            assert download_cf.meta.uuid == cf.meta.uuid
+            # Check the downloaded files
+            assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+            assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_global_callable_function_from_module(cf: Artifact):
+    with MockedClient(mock_all=False) as (client, mr):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+        cache_dir = get_local_cache_callable_artifact(project_key=None, artifact=cf)
+
+        # Prepare global URL
+        register_uri_for_artifact_meta_info(mr, cf, project_key=None)
+        register_uri_for_artifact_info(mr, cf, project_key=None)
+
+        # Download: should not call load_artifact to request and download
+        download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=None)
+        # Check the downloaded info
+        assert download_cf.__class__ is cf.__class__
+        assert download_cf.meta.uuid == cf.meta.uuid
+        # Check the files that do not need to be downloaded
+        assert not (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert not (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_global_callable_function_from_cache(cf: Artifact):
+    with MockedClient(mock_all=False) as (client, mr):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID
+        cache_dir = get_local_cache_callable_artifact(project_key=None, artifact=cf)
+
+        # Save to local cache
+        local_save_artifact_under_giskard_home_cache(artifact=cf, project_key=None)
+        assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+        register_uri_for_artifact_meta_info(mr, cf, project_key=None)
+
+        # Download: should not call load_artifact to request and download
+        download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=None)
+        # Check the downloaded info
+        assert download_cf.__class__ is cf.__class__
+        assert download_cf.meta.uuid == cf.meta.uuid
+
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_callable_function_in_project(cf: Artifact):
+    project_key = str(uuid.uuid4())
+    with MockedClient(mock_all=False) as (client, mr), MockedProjectCacheDir(project_key=project_key):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+        cache_dir = get_local_cache_callable_artifact(project_key=project_key, artifact=cf)
+
+        # Save to temp
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            cf.save(tmpdir_path)
+            # Check saved file
+            assert (tmpdir_path / CALLABLE_FUNCTION_PKL_CACHE).exists()
+            assert (tmpdir_path / CALLABLE_FUNCTION_META_CACHE).exists()
+
+            # Fixup the differences from Backend
+            meta_info = fixup_mocked_artifact_meta_version(cf.meta.to_json())
+            # Fixup the name to avoid load from module
+            meta_info.update({
+                "name": f"fake_{cf._get_name()}",
+            })
+            url = get_url_for_artifact_meta_info(cf, project_key=project_key)
+            mr.register_uri(method=requests_mock.GET, url=url, json=meta_info)
+
+            # Register for Artifact info
+            register_uri_for_artifact_info(mr, cf, project_key=project_key)
+
+            # Register for Artifacts content
+            artifacts_base_url = get_url_for_artifacts_base(cf, project_key=project_key)
+            for file in [CALLABLE_FUNCTION_META_CACHE, CALLABLE_FUNCTION_PKL_CACHE]:
+                with open(tmpdir_path / file, "rb") as f:
+                    mr.register_uri(
+                        method=requests_mock.GET,
+                        url=posixpath.join(artifacts_base_url, file),
+                        content=f.read(),
+                    )
+
+            # Download: should not call load_artifact to request and download
+            download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=project_key)
+            # Check the downloaded info
+            assert download_cf.__class__ is cf.__class__
+            assert download_cf.meta.uuid == cf.meta.uuid
+            # Check the downloaded files
+            assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+            assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_callable_function_from_module_in_project(cf: Artifact):
+    project_key = str(uuid.uuid4())
+    with MockedClient(mock_all=False) as (client, mr), MockedProjectCacheDir(project_key):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+        cache_dir = get_local_cache_callable_artifact(project_key=project_key, artifact=cf)
+
+        # Prepare global URL
+        register_uri_for_artifact_meta_info(mr, cf, project_key)
+        register_uri_for_artifact_info(mr, cf, project_key)
+
+        # Download: should not call load_artifact to request and download
+        download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=project_key)
+        # Check the downloaded info
+        assert download_cf.__class__ is cf.__class__
+        assert download_cf.meta.uuid == cf.meta.uuid
+        # Check the files that do not need to be downloaded
+        assert not (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert not (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_download_callable_function_from_cache_in_project(cf: Artifact):
+    project_key = str(uuid.uuid4())
+    with MockedClient(mock_all=False) as (client, mr), MockedProjectCacheDir(project_key):
+        cf.meta.uuid = str(uuid.uuid4())    # Regenerate a UUID to ensure not loading from registry
+        cache_dir = get_local_cache_callable_artifact(project_key=project_key, artifact=cf)
+
+        # Save to local cache
+        local_save_artifact_under_giskard_home_cache(artifact=cf, project_key=project_key)
+        assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+
+        register_uri_for_artifact_meta_info(mr, cf, project_key)
+
+        # Download: should not call load_artifact to request and download
+        download_cf = cf.__class__.download(uuid=cf.meta.uuid, client=client, project_key=project_key)
+        # Check the downloaded info
+        assert download_cf.__class__ is cf.__class__
+        assert download_cf.meta.uuid == cf.meta.uuid

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,10 +1,15 @@
 import re
+import pandas as pd
 
 import pytest
 
-from giskard import Dataset
+from giskard import Dataset, slicing_function, transformation_function
+from giskard.ml_worker.core.savable import Artifact
 from giskard.models.sklearn import SKLearnModel
-from tests.utils import MockedClient, match_model_id, match_url_patterns
+from giskard.ml_worker.testing.test_result import TestResult as GiskardTestResult
+from giskard import test
+
+from tests.utils import CALLABLE_FUNCTION_META_CACHE, CALLABLE_FUNCTION_PKL_CACHE, get_local_cache_callable_artifact, match_model_id, match_url_patterns, MockedClient
 
 model_name = "uploaded model"
 
@@ -111,3 +116,65 @@ def test_upload_models_exceptions(data, model, request):
     data = request.getfixturevalue(data)
     model = request.getfixturevalue(model)
     _test_upload_model_exceptions(model, data)
+
+
+# Define a test function
+@test
+def my_custom_test(model, data):
+    return GiskardTestResult(passed=True)
+
+
+# Define a slicing function
+@slicing_function(row_level=False)
+def head_slice(df: pd.DataFrame) -> pd.DataFrame:
+    return df.head(10)
+
+
+# Define a transformation function
+@transformation_function()
+def do_nothing(row):
+    return row
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_upload_callable_function(cf: Artifact):
+    artifact_url_pattern = re.compile(
+        "http://giskard-host:12345/api/v2/artifacts/global/" + cf._get_name() + "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.*"
+    )
+    with MockedClient() as (client, mr):
+        cf.upload(client=client, project_key=None)
+        # Check local cache
+        cache_dir = get_local_cache_callable_artifact(project_key=None, artifact=cf)
+        assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+        # Check requested URL
+        match_url_patterns(mr.request_history, artifact_url_pattern)
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        my_custom_test, # Test
+        head_slice,     # Slice
+        do_nothing,     # Transformation
+    ],
+)
+def test_upload_callable_function_to_project(cf: Artifact):
+    artifact_url_pattern = re.compile(
+        "http://giskard-host:12345/api/v2/artifacts/test-project/" + cf._get_name() + "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.*"
+    )
+    with MockedClient() as (client, mr):
+        cf.upload(client=client, project_key="test-project")
+        # Check local cache
+        cache_dir = get_local_cache_callable_artifact(project_key="test-project", artifact=cf)
+        assert (cache_dir / CALLABLE_FUNCTION_PKL_CACHE).exists()
+        assert (cache_dir / CALLABLE_FUNCTION_META_CACHE).exists()
+        # Check requested URL
+        match_url_patterns(mr.request_history, artifact_url_pattern)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,7 @@ from giskard.path_utils import get_size
 
 import tests.utils
 from giskard.client.giskard_client import GiskardClient
+from giskard.client import dtos
 from giskard.datasets.base import Dataset
 from giskard.ml_worker import ml_worker
 from giskard.models.base.model import BaseModel
@@ -209,20 +210,25 @@ def fixup_mocked_artifact_meta_version(meta_info):
 
 
 def mock_dataset_meta_info(dataset: Dataset, project_key: str):
-    dataset_meta_info = dataset.meta.__dict__.copy()
+    meta = dataset.meta
     with tempfile.TemporaryDirectory() as tmpdir:
         original_size_bytes, compressed_size_bytes = dataset.save(Path(tmpdir), str(dataset.id))
-    dataset_meta_info.update({
-        "columnTypes": dataset_meta_info.pop("column_types"),
-        "columnDtypes": dataset_meta_info.pop("column_dtypes"),
-        "numberOfRows": dataset_meta_info.pop("number_of_rows"),
-        "categoryFeatures": dataset_meta_info.pop("category_features"),
-        "project": project_key,
-        "id": str(dataset.id),
-        "originalSizeBytes": original_size_bytes,
-        "compressedSizeBytes": compressed_size_bytes,
-    })
-    return dataset_meta_info
+
+    logger.debug(f"The project_key {project_key} will be ignored by Backend")
+
+    dataset_meta_info = dtos.DatasetMetaInfo(
+        target=meta.target,
+        columnTypes=meta.column_types,
+        columnDtypes=meta.column_dtypes,
+        numberOfRows=meta.number_of_rows,
+        categoryFeatures=meta.category_features,
+        name=meta.name,
+        originalSizeBytes=original_size_bytes,
+        compressedSizeBytes=compressed_size_bytes,
+        createdDate="now",  # createdDate is not nullable but not used
+        id=str(dataset.id),
+    )
+    return dataset_meta_info.dict()
 
 
 def mock_model_meta_info(model: BaseModel, project_key: str):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,13 @@ def match_url_patterns(last_requests, url_pattern):
                 assert req.headers.get(header_name) == headers_to_match[header_name]
 
 
+def is_url_requested(last_requests, url):
+    for i in last_requests:
+        if i.url == url:
+            return True
+    return False
+
+
 class MockedClient:
     artifact_url_pattern = re.compile(
         "http://giskard-host:12345/api/v2/artifacts/test-project/models/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.*"
@@ -292,31 +299,37 @@ def register_uri_for_artifact_info(mr: requests_mock.Mocker, cf: Artifact, proje
 
 def register_uri_for_artifacts_under_dir(mr: requests_mock.Mocker, dir_path: Path, artifacts_base_url, register_file_contents: bool = False):
     artifacts = []
+    artifact_urls = []
     for f in dir_path.iterdir():
         artifacts.append(f.name)
         if register_file_contents:
             with f.open("rb") as content:
                 # Read the entire file can use a lot of memory
                 mr.register_uri(method=requests_mock.GET, url=posixpath.join(artifacts_base_url, f.name), content=content.read())
-    return artifacts
+                artifact_urls.append(posixpath.join(artifacts_base_url, f.name))
+    return artifacts, artifact_urls
 
 
 def register_uri_for_dataset_meta_info(mr: requests_mock.Mocker, dataset: Dataset, project_key: str):
     dataset_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "datasets", str(dataset.id))
     dataset_meta_info = mock_dataset_meta_info(dataset, project_key)
     mr.register_uri(method=requests_mock.GET, url=dataset_url, json=dataset_meta_info)
+    return [dataset_url]
 
 
 def register_uri_for_dataset_artifact_info(mr: requests_mock.Mocker, dataset: Dataset, project_key: str, register_file_contents: bool = False):
     artifact_info_url = posixpath.join(CLIENT_BASE_URL, "artifact-info", project_key, "datasets", str(dataset.id))
     artifacts_base_url = posixpath.join(CLIENT_BASE_URL, "artifacts", project_key, "datasets", str(dataset.id))
     artifacts = []
+    artifact_urls = []
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         dataset.save(Path(tmpdir), dataset.id)  # Save dataset in temp dir
-        artifacts = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
+        artifacts, artifact_urls = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
 
     mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+    artifact_urls.extend([artifact_info_url])
+    return artifact_urls
 
 
 def register_uri_for_any_dataset_artifact_info_upload(mr: requests_mock.Mocker, register_files=False):
@@ -344,7 +357,7 @@ def register_uri_for_model_artifact_info(mr: requests_mock.Mocker, model: BaseMo
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         model.save(Path(tmpdir))  # Save dataset in temp dir
-        artifacts = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
+        artifacts, _ = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
 
     mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,19 +2,36 @@ import glob
 import logging
 import os
 import re
+import shutil
 import tarfile
 from pathlib import Path
+from typing import Optional
+import posixpath
+import tempfile
+import platform
 
 import requests
 import requests_mock
+from giskard.ml_worker.core.savable import Artifact
+from giskard.ml_worker.utils.file_utils import get_file_name
+from giskard.path_utils import get_size
 
 import tests.utils
 from giskard.client.giskard_client import GiskardClient
+from giskard.datasets.base import Dataset
+from giskard.ml_worker import ml_worker
+from giskard.models.base.model import BaseModel
+from giskard.settings import settings
 
 logger = logging.getLogger(__name__)
 resource_dir: Path = Path.home() / ".giskard"
 
 headers_to_match = {"Authorization": "Bearer SECRET_TOKEN", "Content-Type": "application/json"}
+
+CALLABLE_FUNCTION_PKL_CACHE = "data.pkl"
+CALLABLE_FUNCTION_META_CACHE = "meta.yaml"
+
+CLIENT_BASE_URL = "http://giskard-host:12345/api/v2"
 
 
 def match_model_id(my_model_id):
@@ -115,3 +132,215 @@ def get_email_files():
         os.makedirs(out_path, exist_ok=True)
         file.extractall(path=out_path)
     return [f.replace(".cats", "") for f in glob.glob(str(enron_path) + "/*/*.cats")]
+
+
+class MockedWebSocketMLWorker:
+    def __init__(self, is_server=False, backend_url= None, api_key=None, hf_token=None) -> None:
+        client = None if is_server else MockedClient(mock_all=True)
+        self.client = client
+
+        self.backend_url = backend_url
+        self.api_key = api_key
+        self.hf_token = hf_token
+
+        self.ml_worker_id = ml_worker.INTERNAL_WORKER_ID if is_server else ml_worker.EXTERNAL_WORKER_ID
+
+    def is_remote_worker(self):
+        return self.ml_worker_id is not ml_worker.INTERNAL_WORKER_ID
+
+
+class MockedProjectCacheDir:
+    def __init__(self, project_key=None):
+        self.local_path_root = get_local_cache_project(project_key)
+
+    def __enter__(self):
+        self.local_path_root.mkdir(parents=True)
+        return self.local_path_root
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        shutil.rmtree(str(self.local_path_root), ignore_errors=True)
+
+
+def get_local_cache_base():
+    return settings.home_dir / settings.cache_dir
+
+
+def get_local_cache_project(project_key: Optional[str]):
+    return get_local_cache_base() / (project_key or "global")
+
+
+def get_local_cache_artifact(project_key: Optional[str], name: str, uuid: str):
+    return get_local_cache_project(project_key) / name / uuid
+
+
+def get_local_cache_callable_artifact(project_key: Optional[str], artifact: Artifact):
+    return get_local_cache_artifact(project_key, artifact._get_name(), artifact.meta.uuid)
+
+
+def local_save_model_under_giskard_home_cache(model: BaseModel, project_key: str):
+    local_path_model = get_local_cache_artifact(project_key, "models", str(model.id))
+    local_path_model.mkdir(parents=True)
+    model.save(local_path=local_path_model)
+
+
+def local_save_dataset_under_giskard_home_cache(dataset: Dataset, project_key: str):
+    local_path_dataset = get_local_cache_artifact(project_key, "datasets", str(dataset.id))
+    local_path_dataset.mkdir(parents=True)
+    dataset.save(local_path=local_path_dataset, dataset_id=dataset.id)
+
+
+def local_save_artifact_under_giskard_home_cache(artifact: Artifact, project_key: Optional[str]):
+    local_path = get_local_cache_callable_artifact(project_key, artifact)
+    local_path.mkdir(parents=True)
+    artifact.save(local_dir=local_path)
+
+
+def fixup_mocked_artifact_meta_version(meta_info):
+    meta_info.update({
+        "displayName": meta_info.pop("display_name"),
+        "moduleDoc": meta_info.pop("module_doc"),
+        "version": 1,
+    })
+    for arg in meta_info["args"] if meta_info["args"] else []:
+        arg.update({
+            "defaultValue": arg.pop("default")
+        })
+    return meta_info
+
+
+def mock_dataset_meta_info(dataset: Dataset, project_key: str):
+    dataset_meta_info = dataset.meta.__dict__.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        original_size_bytes, compressed_size_bytes = dataset.save(Path(tmpdir), str(dataset.id))
+    dataset_meta_info.update({
+        "columnTypes": dataset_meta_info.pop("column_types"),
+        "columnDtypes": dataset_meta_info.pop("column_dtypes"),
+        "numberOfRows": dataset_meta_info.pop("number_of_rows"),
+        "categoryFeatures": dataset_meta_info.pop("category_features"),
+        "project": project_key,
+        "id": str(dataset.id),
+        "originalSizeBytes": original_size_bytes,
+        "compressedSizeBytes": compressed_size_bytes,
+    })
+    return dataset_meta_info
+
+
+def mock_model_meta_info(model: BaseModel, project_key: str):
+    size = 0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model.save(tmpdir)
+        size = get_size(tmpdir)
+    meta = model.meta
+    model_meta_info = meta.__dict__.copy()
+    model_meta_info.update({
+        "threshold": model_meta_info.pop("classification_threshold"),
+        "modelType": model_meta_info.pop("model_type").name.upper(),
+        "featureNames": model_meta_info.pop("feature_names"),
+        "classificationLabels": model_meta_info.pop("classification_labels"),
+        "classificationLabelsDtype": (
+            None
+            if (not meta.classification_labels or not len(meta.classification_labels))
+            else type(meta.classification_labels[0]).__name__
+        ),
+        "languageVersion": platform.python_version(),
+        "language": "PYTHON",
+        "id": str(model.id),
+        "project": project_key,
+        "size": size,
+    })
+    return model_meta_info
+
+
+def get_url_for_artifact_meta_info(cf: Artifact, project_key:Optional[str] = None):
+    return posixpath.join(CLIENT_BASE_URL, "project", project_key, cf._get_name(), cf.meta.uuid) if project_key \
+        else posixpath.join(CLIENT_BASE_URL, cf._get_name(), cf.meta.uuid)
+
+
+def get_url_for_artifacts_base(cf: Artifact, project_key:Optional[str] = None):
+    return posixpath.join(CLIENT_BASE_URL, "artifacts", project_key, cf._get_name(), cf.meta.uuid) if project_key \
+        else posixpath.join(CLIENT_BASE_URL, "artifacts", "global", cf._get_name(), cf.meta.uuid)
+
+
+def register_uri_for_artifact_meta_info(mr: requests_mock.Mocker, cf: Artifact, project_key:Optional[str] = None):
+    url = get_url_for_artifact_meta_info(cf, project_key)
+    # Fixup the differences from Backend
+    meta_info = fixup_mocked_artifact_meta_version(cf.meta.to_json())
+
+    mr.register_uri(method=requests_mock.GET, url=url, json=meta_info)
+
+
+def register_uri_for_artifact_info(mr: requests_mock.Mocker, cf: Artifact, project_key:Optional[str] = None):
+    artifact_info_url = posixpath.join(CLIENT_BASE_URL, "artifact-info", project_key, cf._get_name(), cf.meta.uuid) if project_key \
+        else posixpath.join(CLIENT_BASE_URL, "artifact-info", "global", cf._get_name(), cf.meta.uuid)
+    artifacts = [
+        CALLABLE_FUNCTION_PKL_CACHE,
+        CALLABLE_FUNCTION_META_CACHE,
+    ]
+    mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+
+
+def register_uri_for_artifacts_under_dir(mr: requests_mock.Mocker, dir_path: Path, artifacts_base_url, register_file_contents: bool = False):
+    artifacts = []
+    for f in dir_path.iterdir():
+        artifacts.append(f.name)
+        if register_file_contents:
+            with f.open("rb") as content:
+                # Read the entire file can use a lot of memory
+                mr.register_uri(method=requests_mock.GET, url=posixpath.join(artifacts_base_url, f.name), content=content.read())
+    return artifacts
+
+
+def register_uri_for_dataset_meta_info(mr: requests_mock.Mocker, dataset: Dataset, project_key: str):
+    dataset_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "datasets", str(dataset.id))
+    dataset_meta_info = mock_dataset_meta_info(dataset, project_key)
+    mr.register_uri(method=requests_mock.GET, url=dataset_url, json=dataset_meta_info)
+
+
+def register_uri_for_dataset_artifact_info(mr: requests_mock.Mocker, dataset: Dataset, project_key: str, register_file_contents: bool = False):
+    artifact_info_url = posixpath.join(CLIENT_BASE_URL, "artifact-info", project_key, "datasets", str(dataset.id))
+    artifacts_base_url = posixpath.join(CLIENT_BASE_URL, "artifacts", project_key, "datasets", str(dataset.id))
+    artifacts = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        dataset.save(Path(tmpdir), dataset.id)  # Save dataset in temp dir
+        artifacts = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
+
+    mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+
+
+def register_uri_for_any_dataset_artifact_info_upload(mr: requests_mock.Mocker, register_files=False):
+    meta_info_pattern = re.compile(
+        "http://giskard-host:12345/api/v2/project/.*/datasets"
+    )
+    artifacts_url_pattern = re.compile(
+        "http://giskard-host:12345/api/v2/artifacts/.*/datasets/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.*"
+    )
+    mr.register_uri(method=requests_mock.POST, url=meta_info_pattern)
+    if register_files:
+        mr.register_uri(method=requests_mock.POST, url=artifacts_url_pattern)
+
+
+def register_uri_for_model_meta_info(mr: requests_mock.Mocker, model: BaseModel, project_key: str):
+    model_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "models", str(model.id))
+    model_meta_info = mock_model_meta_info(model, project_key=project_key)
+    mr.register_uri(method=requests_mock.GET, url=model_url, json=model_meta_info)
+
+
+def register_uri_for_model_artifact_info(mr: requests_mock.Mocker, model: BaseModel, project_key: str, register_file_contents: bool = False):
+    artifact_info_url = posixpath.join(CLIENT_BASE_URL, "artifact-info", project_key, "models", str(model.id))
+    artifacts_base_url = posixpath.join(CLIENT_BASE_URL, "artifacts", project_key, "models", str(model.id))
+    artifacts = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        model.save(Path(tmpdir))  # Save dataset in temp dir
+        artifacts = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
+
+    mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+
+
+def register_uri_for_inspection(mr: requests_mock.Mocker, project_key: str, inspection_id: int, sample: bool):
+    url = posixpath.join(CLIENT_BASE_URL, "artifacts", f"{project_key}/models/inspections/{inspection_id}")
+    calculated_url = posixpath.join(url, get_file_name("calculated", "csv", sample))
+    predictions_url = posixpath.join(url, get_file_name("predictions", "csv", sample))
+    mr.register_uri(method=requests_mock.POST, url=calculated_url, json={})
+    mr.register_uri(method=requests_mock.POST, url=predictions_url, json={})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -279,6 +279,14 @@ def get_url_for_artifacts_base(cf: Artifact, project_key:Optional[str] = None):
         else posixpath.join(CLIENT_BASE_URL, "artifacts", "global", cf._get_name(), cf.meta.uuid)
 
 
+def get_url_for_dataset(dataset: Dataset, project_key: str):
+    return posixpath.join(CLIENT_BASE_URL, "project", project_key, "datasets", str(dataset.id))
+
+
+def get_url_for_model(model: BaseModel, project_key: str):
+    return posixpath.join(CLIENT_BASE_URL, "project", project_key, "models", str(model.id))
+
+
 def register_uri_for_artifact_meta_info(mr: requests_mock.Mocker, cf: Artifact, project_key:Optional[str] = None):
     url = get_url_for_artifact_meta_info(cf, project_key)
     # Fixup the differences from Backend
@@ -313,7 +321,7 @@ def register_uri_for_artifacts_under_dir(mr: requests_mock.Mocker, dir_path: Pat
 
 
 def register_uri_for_dataset_meta_info(mr: requests_mock.Mocker, dataset: Dataset, project_key: str):
-    dataset_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "datasets", str(dataset.id))
+    dataset_url = get_url_for_dataset(dataset, project_key)
     dataset_meta_info = mock_dataset_meta_info(dataset, project_key)
     mr.register_uri(method=requests_mock.GET, url=dataset_url, json=dataset_meta_info)
     return [dataset_url]
@@ -347,7 +355,7 @@ def register_uri_for_any_dataset_artifact_info_upload(mr: requests_mock.Mocker, 
 
 
 def register_uri_for_model_meta_info(mr: requests_mock.Mocker, model: BaseModel, project_key: str):
-    model_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "models", str(model.id))
+    model_url = get_url_for_model(model, project_key)
     model_meta_info = mock_model_meta_info(model, project_key=project_key)
     mr.register_uri(method=requests_mock.GET, url=model_url, json=model_meta_info)
     return [model_url]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -285,6 +285,7 @@ def register_uri_for_artifact_meta_info(mr: requests_mock.Mocker, cf: Artifact, 
     meta_info = fixup_mocked_artifact_meta_version(cf.meta.to_json())
 
     mr.register_uri(method=requests_mock.GET, url=url, json=meta_info)
+    return [url]
 
 
 def register_uri_for_artifact_info(mr: requests_mock.Mocker, cf: Artifact, project_key:Optional[str] = None):
@@ -295,6 +296,7 @@ def register_uri_for_artifact_info(mr: requests_mock.Mocker, cf: Artifact, proje
         CALLABLE_FUNCTION_META_CACHE,
     ]
     mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+    return [artifact_info_url]
 
 
 def register_uri_for_artifacts_under_dir(mr: requests_mock.Mocker, dir_path: Path, artifacts_base_url, register_file_contents: bool = False):
@@ -348,18 +350,22 @@ def register_uri_for_model_meta_info(mr: requests_mock.Mocker, model: BaseModel,
     model_url = posixpath.join(CLIENT_BASE_URL, "project", project_key, "models", str(model.id))
     model_meta_info = mock_model_meta_info(model, project_key=project_key)
     mr.register_uri(method=requests_mock.GET, url=model_url, json=model_meta_info)
+    return [model_url]
 
 
 def register_uri_for_model_artifact_info(mr: requests_mock.Mocker, model: BaseModel, project_key: str, register_file_contents: bool = False):
     artifact_info_url = posixpath.join(CLIENT_BASE_URL, "artifact-info", project_key, "models", str(model.id))
     artifacts_base_url = posixpath.join(CLIENT_BASE_URL, "artifacts", project_key, "models", str(model.id))
     artifacts = []
+    artifact_urls = []
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         model.save(Path(tmpdir))  # Save dataset in temp dir
-        artifacts, _ = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
+        artifacts, artifact_urls = register_uri_for_artifacts_under_dir(mr, tmpdir_path, artifacts_base_url, register_file_contents)
 
     mr.register_uri(method=requests_mock.GET, url=artifact_info_url, json=artifacts)
+    artifact_urls.extend([artifact_info_url])
+    return artifact_urls
 
 
 def register_uri_for_inspection(mr: requests_mock.Mocker, project_key: str, inspection_id: int, sample: bool):


### PR DESCRIPTION
## Description

- Separate #1504 by websocket actor and model/dataset/callable downloading.
- Improve meta info mock using the DTOs imported in #1514
- Fix optional `target` field in `DatasetMetaInfo` in GSK-1990

## Related Issue

[GSK-1990]
[GSK-1509]

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
