### PR TITLE
[GSK-1906] Allow output to be anonymous from ad-hoc test

### DIFF
--- a/giskard/ml_worker/websocket/utils.py
+++ b/giskard/ml_worker/websocket/utils.py
@@ -251,7 +251,9 @@ def do_run_adhoc_test(client, arguments, test, debug_info=None):
                 + "but extract_debug_info did not return the information needed."
             )
 
-        test_result.output_df.name += debug_info["suffix"]
+        if test_result.output_df.name is not None:
+            # Dataset can have empty name
+            test_result.output_df.name += debug_info["suffix"]
 
         test_result.output_df_id = test_result.output_df.upload(client=client, project_key=debug_info["project_key"])
         # We won't return output_df from WS, rather upload it


### PR DESCRIPTION
## Description

Before, it was test function who provides the name in debug mode. We need to loose this constraint to avoid providing name everywhere.

## Related Issue

[GSK-1906]

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
