### PR TITLE
[GSK-2037] Fix test for Benjamini-Hochberg filtering in PerformanceBiasDetector

### DIFF
--- a/giskard/scanner/common/loss_based_detector.py
+++ b/giskard/scanner/common/loss_based_detector.py
@@ -5,13 +5,13 @@ from typing import Sequence
 
 import pandas as pd
 
-from ..issues import Issue
-from ..logger import logger
-from ..registry import Detector
 from ...datasets.base import Dataset
 from ...ml_worker.testing.registry.slicing_function import SlicingFunction
 from ...models.base import BaseModel
 from ...slicing.slice_finder import SliceFinder
+from ..issues import Issue
+from ..logger import logger
+from ..registry import Detector
 
 
 class LossBasedDetector(Detector):
@@ -95,8 +95,11 @@ class LossBasedDetector(Detector):
         sliced = sf.run(dataset_with_meta, features, target=self.LOSS_COLUMN_NAME)
         slices = sum(sliced.values(), start=[])
 
-        # Keep only slices of size at least 5% of the dataset or 20 samples (whatever is larger)
-        slices = [s for s in slices if max(0.05 * len(dataset), 20) <= len(dataset_with_meta.slice(s))]
+        # Keep only slices of size at least 5% of the dataset or 20 samples (whatever is larger) and conversely exclude
+        # slices which are larger than 95% of the dataset
+        slices = [
+            s for s in slices if max(0.05 * len(dataset), 20) <= len(dataset_with_meta.slice(s)) <= 0.95 * len(dataset)
+        ]
 
         return slices
 

--- a/tests/fixtures/titanic.py
+++ b/tests/fixtures/titanic.py
@@ -1,6 +1,6 @@
 import pytest
 
-from giskard import Model, Dataset
+from giskard import Dataset, Model
 from giskard.demo import titanic
 
 
@@ -16,4 +16,9 @@ def titanic_model(titanic_model_data_raw):
 
 @pytest.fixture()
 def titanic_dataset(titanic_model_data_raw):
-    return Dataset(titanic_model_data_raw[1], target="Survived", name="Titanic dataset")
+    return Dataset(
+        titanic_model_data_raw[1],
+        target="Survived",
+        name="Titanic dataset",
+        cat_columns=["Pclass", "Sex", "SibSp", "Parch", "Embarked"],
+    )

--- a/tests/scan/test_performance_bias_detector.py
+++ b/tests/scan/test_performance_bias_detector.py
@@ -70,7 +70,6 @@ def test_performance_bias_detector_with_tabular(german_credit_model, german_cred
         assert str(issue.slicing_fn) in issue.description
 
 
-@pytest.mark.slow
 def test_performance_bias_detector_with_text_features(enron_model, enron_data):
     # Augment the dataset with random data
     df = pd.DataFrame({col: enron_data.df[col].sample(500, replace=True).values for col in enron_data.columns})
@@ -82,19 +81,18 @@ def test_performance_bias_detector_with_text_features(enron_model, enron_data):
     assert all([isinstance(issue, Issue) for issue in issues])
 
 
-@pytest.mark.slow
 def test_selects_issues_with_benjamini_hochberg(titanic_model, titanic_dataset):
     # By default, it does not use the statistical significance
     detector = PerformanceBiasDetector()
 
     issues = detector.run(titanic_model, titanic_dataset)
-    assert len(issues) == 8
+    assert len(issues) == 10
 
     # Setting alpha enables the Benjamini–Hochberg procedure
     detector = PerformanceBiasDetector(alpha=0.10)
 
     issues = detector.run(titanic_model, titanic_dataset)
-    assert len(issues) == 3
+    assert len(issues) == 4
 
     detector = PerformanceBiasDetector(alpha=1e-10)
 

--- a/tests/scan/test_performance_bias_detector.py
+++ b/tests/scan/test_performance_bias_detector.py
@@ -72,7 +72,7 @@ def test_performance_bias_detector_with_tabular(german_credit_model, german_cred
 
 def test_performance_bias_detector_with_text_features(enron_model, enron_data):
     # Augment the dataset with random data
-    df = pd.DataFrame({col: enron_data.df[col].sample(500, replace=True).values for col in enron_data.columns})
+    df = pd.DataFrame({col: enron_data.df[col].sample(100, replace=True).values for col in enron_data.columns})
     dataset = Dataset(df, target=enron_data.target, column_types=enron_data.column_types)
     detector = PerformanceBiasDetector()
 


### PR DESCRIPTION
Issues:

- the Titanic dataset in the fixtures is not initialized correctly: it is missing the categorical features, which are then considered "text"
- normally this should not be a problem because the text slicer would work equally well, creating the same slices when there are few unique values
- but by default, the vectorizer ignores words of less than 2 chars, and in this case the values are single-letter values "S", "Q", and they are ignored by the text vectorizer

The behaviour of the vectorizer makes sense. On the contrary, I fixed the fixture Dataset by putting the correct categorical features. This can possibly break other tests.

---

Side note: while checking how the slices were treated in the `LossBasedDetector`, I added an extra filter on slice size which should make the slicing detectors roughly 40% faster.