### PR TITLE
[GSK-2111] Update scan docs

### DIFF
--- a/docs/open_source/scan/scan_llm/index.md
+++ b/docs/open_source/scan/scan_llm/index.md
@@ -214,6 +214,13 @@ Jump to the [test customization](https://docs.giskard.ai/en/latest/open_source/c
 * Create more tests relevant to your use case, combining input prompts that make your model fail and custome evaluation criteria
 * Share results, and collaborate with your team to integrate business feedback
 
+To upload your test suite, you must have created a project on Giskard Hub and instantiated a Giskard Python client. If you haven't done this yet, follow the first steps of [upload your object](https://docs.giskard.ai/en/latest/giskard_hub/upload/index.html#upload-your-object) guide.
+
+Then, upload your test suite like this:
+```python
+test_suite.upload(giskard_client, project_key)
+```
+
 [Here's a demo](https://huggingface.co/spaces/giskardai/giskard) of the Giskard Hub in action.
 
 ## Troubleshooting

--- a/docs/open_source/scan/scan_nlp/index.md
+++ b/docs/open_source/scan/scan_nlp/index.md
@@ -197,6 +197,13 @@ Jump to the [test customization](https://docs.giskard.ai/en/latest/open_source/c
 * Create more domain-specific tests relevant to your use case
 * Share results, and collaborate with your team to integrate business feedback
 
+To upload your test suite, you must have created a project on Giskard Hub and instantiated a Giskard Python client. If you haven't done this yet, follow the first steps of [upload your object](https://docs.giskard.ai/en/latest/giskard_hub/upload/index.html#upload-your-object) guide.
+
+Then, upload your test suite like this:
+```python
+test_suite.upload(giskard_client, project_key)
+```
+
 [Here's a demo](https://huggingface.co/spaces/giskardai/giskard) of the Giskard Hub in action.
 
 ## Troubleshooting

--- a/docs/open_source/scan/scan_tabular/index.md
+++ b/docs/open_source/scan/scan_tabular/index.md
@@ -274,6 +274,13 @@ Jump to the [test customization](https://docs.giskard.ai/en/latest/open_source/c
 * Create more domain-specific tests relevant to your use case
 * Share results, and collaborate with your team to integrate business feedback
 
+To upload your test suite, you must have created a project on Giskard Hub and instantiated a Giskard Python client. If you haven't done this yet, follow the first steps of [upload your object](https://docs.giskard.ai/en/latest/giskard_hub/upload/index.html#upload-your-object) guide.
+
+Then, upload your test suite like this:
+```python
+test_suite.upload(giskard_client, project_key)
+```
+
 [Here's a demo](https://huggingface.co/spaces/giskardai/giskard) of the Giskard Hub in action.
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

This PR updates the [scan docs](https://docs.giskard.ai/en/latest/open_source/scan/scan_llm/index.html#upload-your-test-suite-to-the-giskard-hub-to), adding a code snippet to upload the scan results and referencing the [upload your object](https://docs.giskard.ai/en/latest/giskard_hub/upload/index.html#upload-your-object) guide.

## Related Issue

[GSK-2111 (available on Linear)](https://linear.app/giskard/issue/GSK-2111/update-upload-scan-docs)

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
