### PR TITLE
[GSK-2114] Retrieve full exception info from worker process

### DIFF
--- a/giskard/ml_worker/websocket/listener.py
+++ b/giskard/ml_worker/websocket/listener.py
@@ -56,6 +56,7 @@ from giskard.push.perturbation import create_perturbation_push
 from giskard.push.prediction import create_borderline_push, create_overconfidence_push
 from giskard.utils import call_in_pool, shutdown_pool
 from giskard.utils.analytics_collector import analytics
+from giskard.utils.worker_pool import GiskardMLWorkerException
 
 logger = logging.getLogger(__name__)
 MAX_STOMP_ML_WORKER_REPLY_SIZE = 1500
@@ -97,6 +98,12 @@ def wrapped_handle_result(
                     error_str=str(e), error_type=type(e).__name__, detail=traceback.format_exc()
                 )
                 logger.warning(e)
+        except GiskardMLWorkerException as e:
+            # Retrieve the exception info from worker process
+            info: websocket.WorkerReply = websocket.ErrorReply(
+                error_str=e.info.message, error_type=e.info.type, detail=e.info.stack_trace
+            )
+            logger.warning(e)
         except Exception as e:
             info: websocket.WorkerReply = websocket.ErrorReply(
                 error_str=str(e), error_type=type(e).__name__, detail=traceback.format_exc()

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 import pytest
 
-from giskard.utils.worker_pool import PoolState, WorkerPoolExecutor
+from giskard.utils.worker_pool import PoolState, WorkerPoolExecutor, GiskardMLWorkerException
 
 @pytest.fixture(scope="function")
 def many_worker_pool():
@@ -94,9 +94,11 @@ def test_handle_exception_log(one_worker_pool: WorkerPoolExecutor):
     exception = future.exception(timeout=5)
     assert exception is not None
     print(exception)
-    assert "ZeroDivisionError: division by zero" in str(exception)
-    assert "in bugged_code" in str(exception)
-    assert "return 1 / 0" in str(exception)
+    assert isinstance(exception, GiskardMLWorkerException)
+    stacktrace = exception.info.stack_trace
+    assert "ZeroDivisionError: division by zero" in stacktrace
+    assert "in bugged_code" in stacktrace
+    assert "return 1 / 0" in stacktrace
     print(future.logs)
     assert "Before raising" in future.logs
     assert "ZeroDivisionError: division by zero" in future.logs


### PR DESCRIPTION
## Description

To make exception info consistent w/o process worker in GSK-1701.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
