### PR TITLE
How to export scan report in quickstarts [GSK-2151]

### DIFF
--- a/docs/getting_started/quickstart/quickstart_llm.ipynb
+++ b/docs/getting_started/quickstart/quickstart_llm.ipynb
@@ -1187,6 +1187,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are running in a notebook, you can display the scan report directly in the notebook using `display(...)`, otherwise you can export the report to an HTML file. Check the [API Reference](https://docs.giskard.ai/en/latest/reference/scan/report.html#giskard.scanner.report.ScanReport) for more details on the export methods available on the `ScanReport` class."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -2876,7 +2883,10 @@
     }
    ],
    "source": [
-    "display(full_report)"
+    "display(full_report)\n",
+    "\n",
+    "# Save it to a file\n",
+    "full_report.to_html(\"scan_report.html\")"
    ]
   },
   {

--- a/docs/getting_started/quickstart/quickstart_nlp.ipynb
+++ b/docs/getting_started/quickstart/quickstart_nlp.ipynb
@@ -83,7 +83,7 @@
     "from datasets import load_dataset\n",
     "from transformers import AutoModelForSequenceClassification, AutoTokenizer\n",
     "\n",
-    "from giskard import Dataset, Model, scan, testing, GiskardClient, Suite "
+    "from giskard import Dataset, Model, scan, testing, GiskardClient, Suite"
    ]
   },
   {
@@ -112,17 +112,9 @@
    "source": [
     "MODEL_NAME = \"cardiffnlp/twitter-roberta-base-sentiment\"\n",
     "\n",
-    "DATASET_CONFIG = {\n",
-    "    \"path\": \"tweet_eval\",\n",
-    "    \"name\": \"sentiment\",\n",
-    "    \"split\": \"validation\"\n",
-    "}\n",
+    "DATASET_CONFIG = {\"path\": \"tweet_eval\", \"name\": \"sentiment\", \"split\": \"validation\"}\n",
     "\n",
-    "LABEL_MAPPING = {\n",
-    "    0: \"negative\",\n",
-    "    1: \"neutral\",\n",
-    "    2: \"positive\"\n",
-    "}\n",
+    "LABEL_MAPPING = {0: \"negative\", 1: \"neutral\", 2: \"positive\"}\n",
     "\n",
     "TEXT_COLUMN = \"text\"\n",
     "TARGET_COLUMN = \"label\""
@@ -204,7 +196,7 @@
     "giskard_dataset = Dataset(\n",
     "    df=raw_data,  # A pandas.DataFrame that contains the raw data (before all the pre-processing steps) and the actual ground truth variable (target).\n",
     "    target=TARGET_COLUMN,  # Ground truth variable.\n",
-    "    name=\"Tweets with sentiment\"  # Optional.\n",
+    "    name=\"Tweets with sentiment\",  # Optional.\n",
     ")"
    ]
   },
@@ -282,9 +274,9 @@
    "outputs": [],
    "source": [
     "def prediction_function(df: pd.DataFrame) -> np.ndarray:\n",
-    "    encoded_input = tokenizer(list(df[TEXT_COLUMN]), padding=True, return_tensors='pt')\n",
+    "    encoded_input = tokenizer(list(df[TEXT_COLUMN]), padding=True, return_tensors=\"pt\")\n",
     "    output = model(**encoded_input)\n",
-    "    return softmax(output['logits'].detach().numpy(), axis=1)\n",
+    "    return softmax(output[\"logits\"].detach().numpy(), axis=1)\n",
     "\n",
     "\n",
     "giskard_model = Model(\n",
@@ -292,7 +284,7 @@
     "    model_type=\"classification\",  # Either regression, classification or text_generation.\n",
     "    name=\"RoBERTa for sentiment classification\",  # Optional\n",
     "    classification_labels=list(LABEL_MAPPING.values()),  # Their order MUST be identical to the prediction_function's\n",
-    "    feature_names=[TEXT_COLUMN]  # Default: all columns of your dataset\n",
+    "    feature_names=[TEXT_COLUMN],  # Default: all columns of your dataset\n",
     ")"
    ]
   },
@@ -330,6 +322,13 @@
    "outputs": [],
    "source": [
     "results = scan(giskard_model, giskard_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are running in a notebook, you can display the scan report directly in the notebook using `display(...)`, otherwise you can export the report to an HTML file. Check the [API Reference](https://docs.giskard.ai/en/latest/reference/scan/report.html#giskard.scanner.report.ScanReport) for more details on the export methods available on the `ScanReport` class."
    ]
   },
   {
@@ -1776,7 +1775,10 @@
     }
    ],
    "source": [
-    "display(results)"
+    "display(results)\n",
+    "\n",
+    "# Save it to a file\n",
+    "results.to_html(\"scan_report.html\")"
    ]
   },
   {
@@ -1923,8 +1925,8 @@
    "outputs": [],
    "source": [
     "# Create a Giskard client after having install the Giskard server (see documentation)\n",
-    "api_key = \"<Giskard API key>\" #This can be found in the Settings tab of the Giskard hub\n",
-    "#hf_token = \"<Your Giskard Space token>\" #If the Giskard Hub is installed on HF Space, this can be found on the Settings tab of the Giskard Hub\n",
+    "api_key = \"<Giskard API key>\"  # This can be found in the Settings tab of the Giskard hub\n",
+    "# hf_token = \"<Your Giskard Space token>\" #If the Giskard Hub is installed on HF Space, this can be found on the Settings tab of the Giskard Hub\n",
     "\n",
     "client = GiskardClient(\n",
     "    url=\"http://localhost:19000\",  # Option 1: Use URL of your local Giskard instance.\n",

--- a/docs/getting_started/quickstart/quickstart_tabular.ipynb
+++ b/docs/getting_started/quickstart/quickstart_tabular.ipynb
@@ -103,13 +103,7 @@
     "# Constants.\n",
     "TARGET_COLUMN = \"Survived\"\n",
     "\n",
-    "CATEGORICAL_COLUMNS = [\n",
-    "    'Pclass', \n",
-    "    'Sex',\n",
-    "    \"SibSp\", \n",
-    "    \"Parch\", \n",
-    "    \"Embarked\"\n",
-    "]"
+    "CATEGORICAL_COLUMNS = [\"Pclass\", \"Sex\", \"SibSp\", \"Parch\", \"Embarked\"]"
    ]
   },
   {
@@ -175,8 +169,8 @@
     "giskard_dataset = Dataset(\n",
     "    df=raw_data,  # A pandas.DataFrame that contains the raw data (before all the pre-processing steps) and the actual ground truth variable (target).\n",
     "    target=TARGET_COLUMN,  # Ground truth variable\n",
-    "    name=\"Titanic dataset\", # Optional\n",
-    "    cat_columns=CATEGORICAL_COLUMNS  # List of categorical columns. Optional, but is a MUST if available. Inferred automatically if not.\n",
+    "    name=\"Titanic dataset\",  # Optional\n",
+    "    cat_columns=CATEGORICAL_COLUMNS,  # List of categorical columns. Optional, but is a MUST if available. Inferred automatically if not.\n",
     ")"
    ]
   },
@@ -247,7 +241,17 @@
     "    model_type=\"classification\",  # Either regression, classification or text_generation.\n",
     "    name=\"Titanic model\",  # Optional\n",
     "    classification_labels=classifier.classes_,  # Their order MUST be identical to the prediction_function's output order\n",
-    "    feature_names=['PassengerId', 'Pclass', 'Name', 'Sex', 'Age', 'SibSp', 'Parch', 'Fare', 'Embarked'],  # Default: all columns of your dataset\n",
+    "    feature_names=[\n",
+    "        \"PassengerId\",\n",
+    "        \"Pclass\",\n",
+    "        \"Name\",\n",
+    "        \"Sex\",\n",
+    "        \"Age\",\n",
+    "        \"SibSp\",\n",
+    "        \"Parch\",\n",
+    "        \"Fare\",\n",
+    "        \"Embarked\",\n",
+    "    ],  # Default: all columns of your dataset\n",
     ")"
    ]
   },
@@ -283,6 +287,13 @@
    "outputs": [],
    "source": [
     "results = scan(giskard_model, giskard_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are running in a notebook, you can display the scan report directly in the notebook using `display(...)`, otherwise you can export the report to an HTML file. Check the [API Reference](https://docs.giskard.ai/en/latest/reference/scan/report.html#giskard.scanner.report.ScanReport) for more details on the export methods available on the `ScanReport` class."
    ]
   },
   {
@@ -3552,7 +3563,10 @@
     }
    ],
    "source": [
-    "display(results)"
+    "display(results)\n",
+    "\n",
+    "# Save it to a file\n",
+    "results.to_html(\"scan_report.html\")"
    ]
   },
   {
@@ -3615,7 +3629,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_suite.add_test(testing.test_f1(model=giskard_model,dataset=giskard_dataset, threshold=0.7)).run()"
+    "test_suite.add_test(testing.test_f1(model=giskard_model, dataset=giskard_dataset, threshold=0.7)).run()"
    ]
   },
   {
@@ -3688,8 +3702,8 @@
    "outputs": [],
    "source": [
     "# Create a Giskard client after having install the Giskard server (see documentation)\n",
-    "api_key = \"<Giskard API key>\" #This can be found in the Settings tab of the Giskard Hub\n",
-    "hf_token = \"<Your Giskard Space token>\" #If the Giskard Hub is installed on HF Space, this can be found on the Settings tab of the Giskard Hub\n",
+    "api_key = \"<Giskard API key>\"  # This can be found in the Settings tab of the Giskard Hub\n",
+    "hf_token = \"<Your Giskard Space token>\"  # If the Giskard Hub is installed on HF Space, this can be found on the Settings tab of the Giskard Hub\n",
     "\n",
     "client = GiskardClient(\n",
     "    url=\"http://localhost:19000\",  # Option 1: Use URL of your local Giskard instance.\n",


### PR DESCRIPTION
Added instructions about how to export scan report to HTML, useful if the scan is not performed in a notebook.