### PR TITLE
Exclude anonymous dataset from AVID report

### DIFF
--- a/giskard/integrations/avid.py
+++ b/giskard/integrations/avid.py
@@ -47,8 +47,7 @@ def create_report_from_issue(issue: Issue, model: BaseModel, dataset: Dataset = 
         AVID Report created from the issue.
     """
     # Prepare artifacts
-    model_name = model.meta.name or model.__class__.__name__
-    artifacts = [Artifact(type=ArtifactTypeEnum.model, name=model_name)]
+    artifacts = [Artifact(type=ArtifactTypeEnum.model, name=model.name)]
     if dataset and dataset.meta.name:
         artifacts.append(Artifact(type=ArtifactTypeEnum.dataset, name=dataset.meta.name))
 

--- a/giskard/integrations/avid.py
+++ b/giskard/integrations/avid.py
@@ -47,8 +47,9 @@ def create_report_from_issue(issue: Issue, model: BaseModel, dataset: Dataset = 
         AVID Report created from the issue.
     """
     # Prepare artifacts
-    artifacts = [Artifact(type=ArtifactTypeEnum.model, name=model.meta.name)]
-    if dataset:
+    model_name = model.meta.name or model.__class__.__name__
+    artifacts = [Artifact(type=ArtifactTypeEnum.model, name=model_name)]
+    if dataset and dataset.meta.name:
         artifacts.append(Artifact(type=ArtifactTypeEnum.dataset, name=dataset.meta.name))
 
     affects = Affects(

--- a/giskard/models/base/model.py
+++ b/giskard/models/base/model.py
@@ -161,6 +161,10 @@ class BaseModel(ABC):
         )
 
     @property
+    def name(self):
+        return self.meta.name if self.meta.name is not None else self.__class__.__name__
+
+    @property
     def is_classification(self):
         """
         Returns True if the model is of type classification, False otherwise.

--- a/tests/integrations/test_avid.py
+++ b/tests/integrations/test_avid.py
@@ -79,3 +79,75 @@ def test_scan_report_can_be_exported_to_avid():
             avid_reports_read = [json.loads(line) for line in f.readlines()]
 
     assert len(avid_reports_read) == len(avid_reports)
+
+
+def test_avid_artifacts_from_scan_report():
+    model = Mock()
+    model.meta.name = "My Test Model"
+
+    # Dataset with no name should not be included
+    dataset = Mock()
+    dataset.meta.name = None
+    issues = [
+        Issue(
+            model,
+            dataset,
+            Harmfulness,
+            IssueLevel.MAJOR,
+            description="This is a test issue",
+            meta={"metric": "FPR", "metric_value": 0.23},
+            taxonomy=["avid-effect:performance:P0204", "avid-effect:ethics:E0301"],
+        ),
+    ]
+    report = ScanReport(issues=issues, model=model, dataset=dataset)
+    assert len(report.to_avid()[0].affects.artifacts) == 1
+    assert report.to_avid()[0].affects.artifacts[0].name == "My Test Model"
+
+    # Model with no name should give class name
+    model.meta.name = None
+    issues = [
+        Issue(
+            model,
+            dataset,
+            Harmfulness,
+            IssueLevel.MAJOR,
+            description="This is a test issue",
+            meta={"metric": "FPR", "metric_value": 0.23},
+            taxonomy=["avid-effect:performance:P0204", "avid-effect:ethics:E0301"],
+        ),
+    ]
+    report = ScanReport(issues=issues, model=model, dataset=dataset)
+    assert len(report.to_avid()[0].affects.artifacts) == 1
+    assert report.to_avid()[0].affects.artifacts[0].name == "Mock"
+
+    # No dataset
+    issues = [
+        Issue(
+            model,
+            None,
+            Harmfulness,
+            IssueLevel.MAJOR,
+            description="This is a test issue",
+            meta={"metric": "FPR", "metric_value": 0.23},
+            taxonomy=["avid-effect:performance:P0204", "avid-effect:ethics:E0301"],
+        ),
+    ]
+    report = ScanReport(issues=issues, model=model, dataset=dataset)
+    assert len(report.to_avid()[0].affects.artifacts) == 1
+
+    # Dataset and model with names are both included
+    model.meta.name = "My Test Model"
+    dataset.meta.name = "My Test Dataset"
+    issues = [
+        Issue(
+            model,
+            dataset,
+            Harmfulness,
+            IssueLevel.MAJOR,
+            description="This is a test issue",
+            meta={"metric": "FPR", "metric_value": 0.23},
+            taxonomy=["avid-effect:performance:P0204", "avid-effect:ethics:E0301"],
+        ),
+    ]
+    report = ScanReport(issues=issues, model=model, dataset=dataset)
+    assert len(report.to_avid()[0].affects.artifacts) == 2

--- a/tests/integrations/test_avid.py
+++ b/tests/integrations/test_avid.py
@@ -11,7 +11,7 @@ from giskard.scanner.report import ScanReport
 
 def test_scan_report_can_be_exported_to_avid():
     model = Mock()
-    model.meta.name = "My Test Model"
+    model.name = "My Test Model"
     dataset = Mock()
     dataset.meta.name = "My Test Dataset"
 
@@ -83,7 +83,7 @@ def test_scan_report_can_be_exported_to_avid():
 
 def test_avid_artifacts_from_scan_report():
     model = Mock()
-    model.meta.name = "My Test Model"
+    model.name = "My Test Model"
 
     # Dataset with no name should not be included
     dataset = Mock()
@@ -103,23 +103,6 @@ def test_avid_artifacts_from_scan_report():
     assert len(report.to_avid()[0].affects.artifacts) == 1
     assert report.to_avid()[0].affects.artifacts[0].name == "My Test Model"
 
-    # Model with no name should give class name
-    model.meta.name = None
-    issues = [
-        Issue(
-            model,
-            dataset,
-            Harmfulness,
-            IssueLevel.MAJOR,
-            description="This is a test issue",
-            meta={"metric": "FPR", "metric_value": 0.23},
-            taxonomy=["avid-effect:performance:P0204", "avid-effect:ethics:E0301"],
-        ),
-    ]
-    report = ScanReport(issues=issues, model=model, dataset=dataset)
-    assert len(report.to_avid()[0].affects.artifacts) == 1
-    assert report.to_avid()[0].affects.artifacts[0].name == "Mock"
-
     # No dataset
     issues = [
         Issue(
@@ -136,7 +119,7 @@ def test_avid_artifacts_from_scan_report():
     assert len(report.to_avid()[0].affects.artifacts) == 1
 
     # Dataset and model with names are both included
-    model.meta.name = "My Test Model"
+    model.name = "My Test Model"
     dataset.meta.name = "My Test Dataset"
     issues = [
         Issue(


### PR DESCRIPTION
- Fixed an issue with AVID report generation when the `Dataset` object has no name
- Same for `Model` object with no name (we take the class name)
- Added more tests