### PR TITLE
Cast to string in text slicer [GSK-2185]

### DIFF
--- a/giskard/slicing/text_slicer.py
+++ b/giskard/slicing/text_slicer.py
@@ -93,8 +93,9 @@ class TextSlicer(BaseSlicer):
         return [QueryBasedSliceFunction(Query([ContainsWord(feature, token)])) for token in tokens]
 
     def _get_top_tokens(self, feature, target):
-        vectorizer = _make_vectorizer(self.dataset.df[feature], tfidf=True)
-        tfidf = vectorizer.transform(self.dataset.df[feature])
+        data = self.dataset.df[feature].astype(str)
+        vectorizer = _make_vectorizer(data, tfidf=True)
+        tfidf = vectorizer.transform(data)
 
         # Get top tokens by TF-IDF
         order = np.argsort(tfidf.max(axis=0).toarray().squeeze())[::-1]
@@ -106,8 +107,9 @@ class TextSlicer(BaseSlicer):
         from scipy import stats
 
         max_tokens = self.MAX_TOKENS
-        vectorizer = _make_vectorizer(self.dataset.df[feature], tfidf=True)
-        tfidf = vectorizer.transform(self.dataset.df[feature])
+        data = self.dataset.df[feature].astype(str)
+        vectorizer = _make_vectorizer(data, tfidf=True)
+        tfidf = vectorizer.transform(data)
 
         lrank = self.dataset.df[target].rank(pct=True)
 
@@ -128,8 +130,9 @@ class TextSlicer(BaseSlicer):
     def _get_deviant_tokens(self, feature, target):
         from scipy import stats
 
-        vectorizer = _make_vectorizer(self.dataset.df[feature], tfidf=False, binary=True)
-        X = vectorizer.transform(self.dataset.df[feature])
+        data = self.dataset.df[feature].astype(str)
+        vectorizer = _make_vectorizer(data, tfidf=False, binary=True)
+        X = vectorizer.transform(data)
 
         critical_target = self.dataset.df[target].quantile(0.75)
         y = self.dataset.df[target] > critical_target

--- a/tests/scan/test_slicers.py
+++ b/tests/scan/test_slicers.py
@@ -1,10 +1,9 @@
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
 
 from giskard import Dataset
-from giskard.slicing.slice import QueryBasedSliceFunction
-from giskard.slicing.slice import GreaterThan, LowerThan
+from giskard.slicing.slice import GreaterThan, LowerThan, QueryBasedSliceFunction
 from giskard.slicing.text_slicer import TextSlicer
 from giskard.slicing.tree_slicer import DecisionTreeSlicer
 
@@ -74,7 +73,18 @@ def test_text_slicer_enforces_cast_to_string():
     dataset = _make_demo_dataset(column_types={"feature1": "text", "loss": "numeric"})
 
     slicer = TextSlicer(dataset)
-    slices = slicer.find_metadata_slices("feature1", "loss")
+    slices = slicer.find_slices(["feature1"], "loss")
+    assert len(slices) > 0
+
+
+def test_text_slicer_works_with_na_values():
+    dataset = _make_demo_dataset(column_types={"feature1": "text", "loss": "numeric"})
+    dataset.df.loc[3, "feature1"] = pd.NA
+    dataset.df.loc[10, "feature1"] = np.nan
+    dataset.df.loc[5, "feature1"] = None
+
+    slicer = TextSlicer(dataset)
+    slices = slicer.find_slices(["feature1"], "loss")
     assert len(slices) > 0
 
 


### PR DESCRIPTION
Prevents detectors from breaking when a column declared as text contains non-textual values.