### PR TITLE
[GSK-2184] Fix error when uploading dataset with bool column

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -1,4 +1,5 @@
 """API Client to interact with the Giskard app"""
+import json
 import logging
 import os
 import posixpath
@@ -17,6 +18,7 @@ from typing import List
 
 import giskard
 from giskard.client.dtos import DatasetMetaInfo, ModelMetaInfo, ServerInfo, SuiteInfo, TestSuiteDTO
+from giskard.client.io_utils import GiskardJSONSerializer
 from giskard.client.project import Project
 from giskard.client.python_utils import warning
 from giskard.core.core import SMT, DatasetMeta, ModelMeta, TestFunctionMeta
@@ -357,8 +359,10 @@ class GiskardClient:
         _limit_str_size(meta_json, "name")
         _limit_str_size(meta_json, "display_name")
 
-        json = self._session.put(endpoint, json=meta_json).json()
-        return meta if json is None or "uuid" not in json else meta.from_json(json)
+        data = json.dumps(meta_json, cls=GiskardJSONSerializer)
+
+        response_json = self._session.put(endpoint, data=data).json()
+        return meta if response_json is None or "uuid" not in response_json else meta.from_json(response_json)
 
     def load_meta(self, endpoint: str, meta_class: SMT) -> TestFunctionMeta:
         return meta_class.from_json(self._session.get(endpoint).json())

--- a/giskard/client/io_utils.py
+++ b/giskard/client/io_utils.py
@@ -2,9 +2,11 @@
 
 import re
 from io import BytesIO
+import json
 from typing import Any, Optional
 
 import cloudpickle
+import numpy as np
 import pandas as pd
 from zstandard import ZstdCompressor, ZstdDecompressor
 
@@ -68,3 +70,11 @@ def decompress(
     else:
         raise ValueError("Invalid compression method: {method}. Choose 'zstd' or None.")
     return decompressed_data
+
+
+class GiskardJSONSerializer(json.JSONEncoder):
+    def default(self, obj):
+        # Wrap numpy bool_ to avoid "TypeError: Object of type bool_ is not JSON serializable"
+        if isinstance(obj, np.bool_):
+            return super().encode(bool(obj))
+        return super().default(obj)

--- a/tests/client/test_save_meta.py
+++ b/tests/client/test_save_meta.py
@@ -1,0 +1,22 @@
+import numpy as np
+import requests_mock
+
+from giskard.core.core import SavableMeta
+from tests.utils import MockedClient
+
+
+class MetaWithBool(SavableMeta):
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "one_numpy_bool": np.bool_(True),
+        }
+
+
+def test_upload_meta_with_numpy_bool():
+    META_URL = "https://localhost:12500/meta"
+    meta = MetaWithBool()
+
+    with MockedClient() as (client, mr):
+        mr.register_uri(requests_mock.PUT, META_URL, json="")
+        assert client.save_meta(META_URL, meta=meta) == meta

--- a/tests/client/test_save_meta.py
+++ b/tests/client/test_save_meta.py
@@ -10,6 +10,8 @@ class MetaWithBool(SavableMeta):
         return {
             **super().to_json(),
             "one_numpy_bool": np.bool_(True),
+            "array_of_bool": [np.bool_(True), np.bool_(False)],
+            "dict_of_bool": {"True": np.bool_(True), "False": np.bool_(False)},
         }
 
 


### PR DESCRIPTION
## Description

For some reasons, there could be `numpy.bool_` in our metadata, which is not serializable by json.

Provide a customized Json encoding rule to convert it as a bool.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
