### PR TITLE
[GSK-2323] Set content-type to json actively for dumped str

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -361,7 +361,7 @@ class GiskardClient:
 
         data = json.dumps(meta_json, cls=GiskardJSONSerializer)
 
-        response_json = self._session.put(endpoint, data=data).json()
+        response_json = self._session.put(endpoint, data=data, headers={"Content-Type": "application/json"}).json()
         return meta if response_json is None or "uuid" not in response_json else meta.from_json(response_json)
 
     def load_meta(self, endpoint: str, meta_class: SMT) -> TestFunctionMeta:


### PR DESCRIPTION
## Description

To fix the issue introduced in GSK-2184, actively set content-type to "application/json".

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
