### PR TITLE
[GSK-2326] Handle environment variable when starting hub using cli

### DIFF
--- a/giskard/commands/cli_hub.py
+++ b/giskard/commands/cli_hub.py
@@ -315,7 +315,6 @@ def start(attached, skip_version_check, version, environment, env_file):
     By default, the server starts detached and will run in the background.
     You can attach to it by using -a
     """
-    print(env_file)
     analytics.track(
         "giskard-server:start",
         {

--- a/giskard/commands/cli_hub.py
+++ b/giskard/commands/cli_hub.py
@@ -327,7 +327,7 @@ def start(attached, skip_version_check, version, environment, env_file):
     environment = list(environment)
     if env_file is not None:
         with open(env_file, "r") as f:
-            environment += f.readlines()
+            environment = f.readlines() + environment
 
     _start(attached, skip_version_check, version, environment)
 

--- a/giskard/commands/cli_hub.py
+++ b/giskard/commands/cli_hub.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import logging
 import os
 import time
@@ -15,6 +13,7 @@ from docker.models.containers import Container
 from packaging import version
 from packaging.version import InvalidVersion, Version
 from tenacity import retry, wait_exponential
+from typing import Optional
 
 import giskard
 from giskard.cli_utils import common_options
@@ -121,7 +120,7 @@ def wait_backend_ready(port: int, host="localhost", is_cli=True, wait_sec=3 * 60
     return up
 
 
-def _start(attached=False, skip_version_check=False, version=None):
+def _start(attached=False, skip_version_check=False, version=None, environment=None):
     logger.info("Starting Giskard Hub")
 
     settings = _get_settings() or {}
@@ -155,6 +154,7 @@ We recommend you to upgrade giskard by running `giskard hub stop && giskard hub 
             name=get_container_name(version),
             ports={7860: port},
             volumes={home_volume.name: {"bind": "/home/giskard/datadir", "mode": "rw"}},
+            environment=environment,
         )
     container.start()
 
@@ -293,15 +293,29 @@ client = giskard.GiskardClient(\"{http_tunnel.public_url}\", token)
     default=False,
     help="Force the server to start with a different version of the giskard python library.",
 )
+@click.option(
+    "--env",
+    "-e",
+    "environment",
+    multiple=True,
+    default=[],
+    help="Set environment variables to the server.",
+)
+@click.option(
+    "--env-file",
+    "env_file",
+    help="Read in a file of environment variables.",
+)
 @click.option("--version", "version", required=False, help="Version of Giskard hub to start")
 @common_options
-def start(attached, skip_version_check, version):
+def start(attached, skip_version_check, version, environment, env_file):
     """\b
     Start Giskard Hub.
 
     By default, the server starts detached and will run in the background.
     You can attach to it by using -a
     """
+    print(env_file)
     analytics.track(
         "giskard-server:start",
         {
@@ -310,7 +324,13 @@ def start(attached, skip_version_check, version):
             "version": version,
         },
     )
-    _start(attached, skip_version_check, version)
+
+    environment = list(environment)
+    if env_file is not None:
+        with open(env_file, "r") as f:
+            environment += f.readlines()
+
+    _start(attached, skip_version_check, version, environment)
 
 
 @hub.command("stop")


### PR DESCRIPTION
## Description

Handle environment variable when starting hub using cli

To set env file use:
`python -m giskard.hub --env-file prod.env` 

To set env manually use:
`python -m giskard.hub --env OPENAI_API_KEY=sk-... -e ANOTHER_KEY=...` 

## Related Issue

[GSK-2326 (available on Linear)
](https://linear.app/giskard/issue/GSK-2326/add-possibility-to-specify-db-url-and-userpassword-when-starting-the)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
