### PR TITLE
[GSK-2329] Use object instead of string for documentation

### DIFF
--- a/giskard/core/core.py
+++ b/giskard/core/core.py
@@ -334,12 +334,7 @@ class CallableMeta(SavableMeta, ABC):
             "name": self.name,
             "display_name": self.display_name,
             "module": self.module,
-            "doc": None
-            if self.doc is None
-            else {
-                "description": self.doc.description,
-                "parameters": {name: value for name, value in self.doc.parameters.items()},
-            },
+            "doc": self.doc.__dict__ if self.doc else None,
             "module_doc": self.module_doc,
             "code": self.code,
             "tags": self.tags,

--- a/giskard/core/core.py
+++ b/giskard/core/core.py
@@ -1,13 +1,11 @@
-import typing
-
 import inspect
-import json
 import logging
 from abc import ABC
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+import typing
 from griffe import Docstring
 from griffe.docstrings.dataclasses import (
     DocstringSection,
@@ -174,7 +172,7 @@ class CallableMeta(SavableMeta, ABC):
     name: str
     display_name: str
     module: str
-    doc: str
+    doc: CallableDocumentation
     module_doc: str
     tags: List[str]
     version: Optional[int]
@@ -275,14 +273,14 @@ class CallableMeta(SavableMeta, ABC):
         return code
 
     @staticmethod
-    def default_doc(description: str) -> str:
+    def default_doc(description: str) -> CallableDocumentation:
         doc = CallableDocumentation()
         doc.description = description
         doc.parameters = {}
-        return json.dumps(doc.to_dict())
+        return doc
 
     @staticmethod
-    def extract_doc(func) -> Optional[str]:
+    def extract_doc(func) -> Optional[CallableDocumentation]:
         if not func.__doc__:
             return None
 
@@ -328,8 +326,7 @@ class CallableMeta(SavableMeta, ABC):
             else:
                 logger.warning(f"Unexpected documentation element for {func.__name__}: {d.kind}")
 
-        func_doc = json.dumps(res.to_dict())
-        return func_doc
+        return res
 
     def to_json(self):
         return {

--- a/giskard/core/core.py
+++ b/giskard/core/core.py
@@ -334,7 +334,12 @@ class CallableMeta(SavableMeta, ABC):
             "name": self.name,
             "display_name": self.display_name,
             "module": self.module,
-            "doc": self.doc,
+            "doc": None
+            if self.doc is None
+            else {
+                "description": self.doc.description,
+                "parameters": {name: value for name, value in self.doc.parameters.items()},
+            },
             "module_doc": self.module_doc,
             "code": self.code,
             "tags": self.tags,

--- a/giskard/core/core.py
+++ b/giskard/core/core.py
@@ -334,7 +334,7 @@ class CallableMeta(SavableMeta, ABC):
             "name": self.name,
             "display_name": self.display_name,
             "module": self.module,
-            "doc": self.doc.__dict__ if self.doc else None,
+            "doc": self.doc.to_dict() if self.doc else None,
             "module_doc": self.module_doc,
             "code": self.code,
             "tags": self.tags,

--- a/giskard/ml_worker/websocket/__init__.py
+++ b/giskard/ml_worker/websocket/__init__.py
@@ -38,6 +38,11 @@ class TestFunctionArgument(ConfiguredBaseModel):
     argOrder: int
 
 
+class Documentation(ConfiguredBaseModel):
+    description: str
+    parameters: Dict[str, str]
+
+
 # CallableMeta shows that all fields can be none,
 # but we have a pre-check here for Database constraints except auto-created "version":
 # referring to `ai.giskard.domain.Callable` and `ai.giskard.domain.TestFunction`.
@@ -47,7 +52,7 @@ class FunctionMeta(ConfiguredBaseModel):
     displayName: Optional[str] = None
     version: Optional[int] = None
     module: Optional[str] = None
-    doc: Optional[str] = None
+    doc: Optional[Documentation] = None
     moduleDoc: Optional[str] = None
     args: Optional[List[TestFunctionArgument]] = None
     tags: Optional[List[str]] = None
@@ -66,7 +71,7 @@ class DatasetProcessFunctionMeta(ConfiguredBaseModel):
     displayName: Optional[str] = None
     version: Optional[int] = None
     module: Optional[str] = None
-    doc: Optional[str] = None
+    doc: Optional[Documentation] = None
     moduleDoc: Optional[str] = None
     args: Optional[List[TestFunctionArgument]] = None
     tags: Optional[List[str]] = None

--- a/giskard/ml_worker/websocket/utils.py
+++ b/giskard/ml_worker/websocket/utils.py
@@ -2,10 +2,10 @@ import logging
 import os
 import shutil
 import uuid
-from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from mlflow.store.artifact.artifact_repo import verify_artifact_path
+from typing import Any, Dict, List, Optional
 
 from giskard.client.giskard_client import GiskardClient
 from giskard.core.suite import DatasetInput, ModelInput, SuiteInput
@@ -28,6 +28,7 @@ from giskard.ml_worker.websocket import (
     RunModelForDataFrameParam,
     RunModelParam,
     TestSuiteParam,
+    Documentation,
 )
 from giskard.ml_worker.websocket.action import MLWorkerAction
 from giskard.models.base import BaseModel
@@ -90,7 +91,9 @@ def map_function_meta_ws(callable_type):
             name=test.name,
             displayName=test.display_name,
             module=test.module,
-            doc=test.doc,
+            doc=None
+            if test.doc is None
+            else Documentation(description=test.doc.description, parameters=test.doc.parameters),
             code=test.code,
             moduleDoc=test.module_doc,
             tags=test.tags,
@@ -134,7 +137,9 @@ def map_dataset_process_function_meta_ws(callable_type):
             name=test.name,
             displayName=test.display_name,
             module=test.module,
-            doc=test.doc,
+            doc=None
+            if test.doc is None
+            else Documentation(description=test.doc.description, parameters=test.doc.parameters),
             code=test.code,
             moduleDoc=test.module_doc,
             tags=test.tags,

--- a/tests/communications/fixtures/with_alias.json
+++ b/tests/communications/fixtures/with_alias.json
@@ -25,7 +25,10 @@
           "displayName": "iCKJtwAOBuzbcKZEuiAZ",
           "version": 3268,
           "module": "CSmAXExoCXaOQUMQADwc",
-          "doc": "TDkAzsrCGFxbljESPPQn",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "RJeaaNmfGrdiBioLxqyb",
           "args": [
             {
@@ -51,7 +54,10 @@
           "displayName": "fAVpUhVbqUPVRMJjwiLI",
           "version": 4138,
           "module": "OJxwnwBaRizPWYaJEEhZ",
-          "doc": "oDiezjqUVWHlqJXLrFLH",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "YlVNHtAPkppCiKyegFAt",
           "args": [],
           "tags": [
@@ -71,7 +77,10 @@
           "displayName": "tAMiHLQoFmDiPTrlYKRb",
           "version": 6596,
           "module": "qwNOjGiYxVLFnBhhLsNm",
-          "doc": "LLpfuzfjcFUlbKQYFrRg",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "KeuztimQyElLrEVZcPSq",
           "args": [
             {
@@ -101,7 +110,10 @@
           "displayName": "CYiHZMDtuWUIUWStyPtM",
           "version": 7887,
           "module": "NuPzhhZQtgOXvWovorVl",
-          "doc": "RXuwdkhLfiOfHjawXclv",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "cHWMJRMZJjPKclHTgxJz",
           "args": [
             {
@@ -127,7 +139,10 @@
           "displayName": "siOVqTsIZOcwtpQwKHAc",
           "version": 1859,
           "module": "UiHzrKYbUtRjLfrYIOxy",
-          "doc": "zOLkwCDWRhtfbdjNIPpi",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "YQXauGMVBuaPZVIrmOWX",
           "args": [
             {
@@ -155,7 +170,10 @@
           "displayName": "TvsrntKNmPNuoOeKVXvg",
           "version": 9024,
           "module": "LnkoyMpTYQdqWSgwsMbq",
-          "doc": "MUcEITwYkfgEgnkcYrYL",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "lWaZbnCaNeQbBkpztuHk",
           "args": [],
           "tags": [
@@ -177,7 +195,10 @@
           "displayName": "fPThRhcorExPIgkMgXQl",
           "version": 4687,
           "module": "LBTLLNqsNVTtJeWRzrjH",
-          "doc": "mOwopYrRvsqXAtppgCLi",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "HhiQnsqoyeisxfiqJybc",
           "args": [],
           "tags": [
@@ -195,7 +216,10 @@
           "displayName": "mHCSwTkhWcsrQDyDTFxi",
           "version": 3413,
           "module": "ZZgnZrjVGqCwxCiGXEOo",
-          "doc": "iaZgtIMGwQxRcLfuxjxS",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "bkYxuVOjFjOCPdWlSwUf",
           "args": [],
           "tags": [
@@ -215,7 +239,10 @@
           "displayName": "YVkhmmuOweiQBcSogmOt",
           "version": 6794,
           "module": "OEcxJBEsRmHwhagoybdP",
-          "doc": "YwyFfCJXHCvVByMwdETt",
+          "doc": {
+            "description": "Automatically generated",
+            "parameters": {}
+          },
           "moduleDoc": "ffVfIeAVmpFDDucEoGwn",
           "args": [],
           "tags": [
@@ -318,6 +345,25 @@
       "target": "ZSgrLKWvRIpETSAEbmPv"
     }
   ],
+  "Documentation": [
+    {
+      "description": "Automatically generated",
+      "parameters": {}
+    },
+    {
+      "description": "Test the accuracy",
+      "parameters": {
+        "threshold": "Default value of 0.5",
+        "dataset": "The dataset to be tested"
+      }
+    },
+    {
+      "description": "Recall test",
+      "parameters": {
+        "dataset": "The dataset to be tested"
+      }
+    }
+  ],
   "DatasetProcessFunctionMeta": [
     {
       "uuid": "gSNnzxHPebRwNaxLlXUb",
@@ -325,7 +371,10 @@
       "displayName": "ZSgrLKWvRIpETSAEbmPv",
       "version": 2834,
       "module": "tTOMeIfiRtMyqSFEHila",
-      "doc": "kVCvrSsVIFLtSXWAgOkX",
+      "doc": {
+        "description": "Automatically generated",
+        "parameters": {}
+      },
       "moduleDoc": "zsCWvQvaCOrFPHCjeCSW",
       "args": [],
       "tags": [
@@ -343,7 +392,12 @@
       "displayName": "PjOEixJiRwYPCQCLqkqb",
       "version": 4842,
       "module": "LquudqFxnOOUTysjkksQ",
-      "doc": "eNeDrlYcjPEVmfFPelQu",
+      "doc": {
+        "description": "Recall test",
+        "parameters": {
+          "dataset": "The dataset to be tested"
+        }
+      },
       "moduleDoc": "nTLbaNsySfOrAIjhhTpK",
       "args": [
         {
@@ -369,7 +423,12 @@
       "displayName": "LiOuojdOaVPvJpyniAof",
       "version": 9676,
       "module": "vsIbAXJuJFkkUndRBtAM",
-      "doc": "iHLQoFmDiPTrlYKRbUGq",
+      "doc": {
+        "description": "Recall test",
+        "parameters": {
+          "dataset": "The dataset to be tested"
+        }
+      },
       "moduleDoc": "wNOjGiYxVLFnBhhLsNmL",
       "args": [
         {
@@ -893,7 +952,10 @@
       "displayName": "ZSgrLKWvRIpETSAEbmPv",
       "version": 2834,
       "module": "tTOMeIfiRtMyqSFEHila",
-      "doc": "kVCvrSsVIFLtSXWAgOkX",
+      "doc": {
+        "description": "Automatically generated",
+        "parameters": {}
+      },
       "moduleDoc": "zsCWvQvaCOrFPHCjeCSW",
       "args": [],
       "tags": [
@@ -909,7 +971,10 @@
       "displayName": "hgfEWdCDXspBfUfcpFav",
       "version": 655,
       "module": "jOEixJiRwYPCQCLqkqbO",
-      "doc": "WLquudqFxnOOUTysjkks",
+      "doc": {
+        "description": "Automatically generated",
+        "parameters": {}
+      },
       "moduleDoc": "QeNeDrlYcjPEVmfFPelQ",
       "args": [
         {
@@ -933,7 +998,10 @@
       "displayName": "gLsCrMDfVtCZHLMLkWFA",
       "version": 5002,
       "module": "KxIkBJEYrGYKYdZmYpbL",
-      "doc": "iOuojdOaVPvJpyniAofE",
+      "doc": {
+        "description": "Automatically generated",
+        "parameters": {}
+      },
       "moduleDoc": "ddxiKieHopBmrdKVIyCc",
       "args": [
         {

--- a/tests/communications/test_dto_serialization.py
+++ b/tests/communications/test_dto_serialization.py
@@ -42,6 +42,7 @@ MANDATORY_FIELDS = {
     "ExplainTextParam": ["model", "feature_name", "columns", "column_types"],
     "Explanation": ["per_feature"],
     "FuncArgument": ["name", "none"],
+    "Documentation": ["description", "parameters"],
     "FunctionMeta": ["uuid", "name", "code"],
     "GenerateTestSuite": [],
     "GenerateTestSuiteParam": ["project_key"],
@@ -129,6 +130,7 @@ OPTIONAL_FIELDS = {
         "kwargs",
         "args",
     ],
+    "Documentation": [],
     "FunctionMeta": [
         "displayName",
         "version",

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -1,8 +1,5 @@
-from typing import Optional
-
-import json
-
 from pydantic import BaseModel
+from typing import Optional
 
 from giskard.core.core import CallableMeta
 from giskard.datasets.base import Dataset
@@ -49,9 +46,8 @@ def func_test_func_doc_google(
 
 def test_extract_doc(caplog):
     doc = CallableMeta.extract_doc(test_diff_rmse_push)
-    params = json.loads(doc)
-    assert "Test for difference in RMSE between a slice and full dataset" in params["description"]
-    assert {"model", "dataset", "slicing_function", "threshold", "direction"} == set(params["parameters"].keys())
+    assert "Test for difference in RMSE between a slice and full dataset" in doc.description
+    assert {"model", "dataset", "slicing_function", "threshold", "direction"} == set(doc.parameters.keys())
 
     assert caplog.text == ""
 
@@ -63,7 +59,6 @@ def test_extract_doc_warnings(caplog):
 
 def test_extract_doc_google(caplog):
     doc = CallableMeta.extract_doc(func_test_func_doc_google)
-    params = json.loads(doc)
-    assert "Test for difference in RMSE between a slice and full dataset" in params["description"]
-    assert {"model", "dataset", "slicing_function", "threshold", "direction"} == set(params["parameters"].keys())
+    assert "Test for difference in RMSE between a slice and full dataset" in doc.description
+    assert {"model", "dataset", "slicing_function", "threshold", "direction"} == set(doc.parameters.keys())
     assert caplog.text == ""


### PR DESCRIPTION
## Description

Use object instead of string for documentation

## Related Issue

[GSK-2329 (Available on Linear)](https://linear.app/giskard/issue/GSK-2329/add-validator-for-callabledto-doc-property-to-be-valid-format)

## Type of Change


- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
