### PR TITLE
[GSK-2378] Only persist/read cache when explicitly asked

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -60,11 +60,11 @@ jobs:
         langchain_minimal: [false]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         include:
-          - python-version: "3.10"
-            os: windows-2019
-            pydantic_v1: false
-            pandas_v1: false
-            langchain_minimal: false
+          # - python-version: "3.10" # Deactivating windows-2019, since it's trying to use python 3.7 to install PDM. Maybe try to reactivate later ?
+          #   os: windows-2019
+          #   pydantic_v1: false
+          #   pandas_v1: false
+          #   langchain_minimal: false
           - python-version: "3.10"
             os: windows-2022
             pydantic_v1: false
@@ -250,6 +250,7 @@ jobs:
         uses: pdm-project/setup-pdm@v3
         with:
           python-version: '3.10'
+          version: '2.10.4' # Fix to repair the CI, use latest version when fixed on pdm
           cache: false
       - name: Build wheel
         run: pdm build

--- a/giskard/ml_worker/websocket/listener.py
+++ b/giskard/ml_worker/websocket/listener.py
@@ -520,17 +520,20 @@ def run_test_suite(
     client: Optional[GiskardClient], params: websocket.TestSuiteParam, *args, **kwargs
 ) -> websocket.TestSuite:
     log_listener = LogListener()
+
+    loaded_artifacts = dict()
+
     try:
         tests = [
             {
                 "test": GiskardTest.download(t.testUuid, client, None),
-                "arguments": parse_function_arguments(client, t.arguments),
+                "arguments": parse_function_arguments(client, t.arguments, loaded_artifacts),
                 "id": t.id,
             }
             for t in params.tests
         ]
 
-        global_arguments = parse_function_arguments(client, params.globalArguments)
+        global_arguments = parse_function_arguments(client, params.globalArguments, loaded_artifacts)
 
         datasets = {arg.original_id: arg for arg in global_arguments.values() if isinstance(arg, Dataset)}
         for test in tests:

--- a/giskard/ml_worker/websocket/listener.py
+++ b/giskard/ml_worker/websocket/listener.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 import traceback
+from collections import defaultdict
 from concurrent.futures import CancelledError, Future
 from copy import copy
 from dataclasses import dataclass
@@ -521,7 +522,7 @@ def run_test_suite(
 ) -> websocket.TestSuite:
     log_listener = LogListener()
 
-    loaded_artifacts = dict()
+    loaded_artifacts = defaultdict(dict)
 
     try:
         tests = [

--- a/giskard/models/base/model.py
+++ b/giskard/models/base/model.py
@@ -146,7 +146,7 @@ class BaseModel(ABC):
         self._cache = ModelCache(
             model_type,
             str(self.id),
-            persist_cache=kwargs.get("prediction_cache_dir", False),
+            persist_cache=kwargs.get("persist_cache", False),
             cache_dir=kwargs.get("prediction_cache_dir"),
         )
 

--- a/giskard/models/base/model.py
+++ b/giskard/models/base/model.py
@@ -143,7 +143,12 @@ class BaseModel(ABC):
             if len(classification_labels) != len(set(classification_labels)):
                 raise ValueError("Duplicates are found in 'classification_labels', please only provide unique values.")
 
-        self._cache = ModelCache(model_type, str(self.id), cache_dir=kwargs.get("prediction_cache_dir"))
+        self._cache = ModelCache(
+            model_type,
+            str(self.id),
+            persist_cache=kwargs.get("prediction_cache_dir", False),
+            cache_dir=kwargs.get("prediction_cache_dir"),
+        )
 
         # sklearn and catboost will fill classification_labels before this check
         if model_type == SupportedModelTypes.CLASSIFICATION and not classification_labels:

--- a/giskard/models/cache/cache.py
+++ b/giskard/models/cache/cache.py
@@ -38,7 +38,7 @@ class ModelCache:
 
         if persist_cache:
             if cache_dir is None and self.id:
-                cache_dir = self._default_cache_dir_prefix.joinpath(self.id)
+                cache_dir = self._default_cache_dir_prefix / self.id
 
             self.cache_file = cache_dir / CACHE_CSV_FILENAME if cache_dir else None
         else:

--- a/giskard/models/cache/cache.py
+++ b/giskard/models/cache/cache.py
@@ -1,9 +1,9 @@
 import csv
 from pathlib import Path
-from typing import Any, Iterable, List, Optional
 
 import numpy as np
 import pandas as pd
+from typing import Any, Iterable, List, Optional
 
 from ...client.python_utils import warning
 from ...core.core import SupportedModelTypes
@@ -26,14 +26,22 @@ def flatten(xs):
 class ModelCache:
     _default_cache_dir_prefix = Path(settings.home_dir / settings.cache_dir / "global" / "prediction_cache")
 
-    def __init__(self, model_type: SupportedModelTypes, id: Optional[str] = None, cache_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        model_type: SupportedModelTypes,
+        id: Optional[str] = None,
+        persist_cache: bool = False,
+        cache_dir: Optional[Path] = None,
+    ):
         self.id = id
         self.prediction_cache = dict()
 
-        if cache_dir is None and self.id:
+        if persist_cache and cache_dir is None and self.id:
             cache_dir = self._default_cache_dir_prefix.joinpath(self.id)
 
-        self.cache_file = cache_dir / CACHE_CSV_FILENAME if cache_dir else None
+            self.cache_file = cache_dir / CACHE_CSV_FILENAME if cache_dir else None
+        else:
+            self.cache_file = None
 
         self.vectorized_get_cache_or_na = np.vectorize(self.get_cache_or_na, otypes=[object])
         self.model_type = model_type

--- a/giskard/models/cache/cache.py
+++ b/giskard/models/cache/cache.py
@@ -36,8 +36,9 @@ class ModelCache:
         self.id = id
         self.prediction_cache = dict()
 
-        if persist_cache and cache_dir is None and self.id:
-            cache_dir = self._default_cache_dir_prefix.joinpath(self.id)
+        if persist_cache:
+            if cache_dir is None and self.id:
+                cache_dir = self._default_cache_dir_prefix.joinpath(self.id)
 
             self.cache_file = cache_dir / CACHE_CSV_FILENAME if cache_dir else None
         else:

--- a/tests/communications/test_websocket_actor_tests.py
+++ b/tests/communications/test_websocket_actor_tests.py
@@ -1,13 +1,16 @@
+import random
 import uuid
 
 import pandas as pd
 import pytest
 
+import giskard
 from giskard import test
 from giskard.datasets.base import Dataset
 from giskard.ml_worker import websocket
 from giskard.ml_worker.testing.test_result import TestResult as GiskardTestResult, TestMessage, TestMessageLevel
 from giskard.ml_worker.websocket import listener
+from giskard.models.base import BaseModel
 from giskard.testing.tests import debug_prefix
 from tests import utils
 
@@ -60,6 +63,13 @@ def my_simple_test_legacy_debug(dataset: Dataset, debug: bool = False):
         output_ds = dataset.copy()
         output_ds.name = debug_prefix + "my_simple_test_debug"
     return GiskardTestResult(passed=False, output_df=output_ds)
+
+
+@giskard.test()
+def same_prediction(left: BaseModel, right: BaseModel, ds: giskard.Dataset):
+    left_pred = left.predict(ds)
+    right_pred = right.predict(ds)
+    return giskard.TestResult(passed=list(left_pred.raw_prediction) == list(right_pred.raw_prediction))
 
 
 def test_websocket_actor_run_ad_hoc_test_legacy_debug(enron_data: Dataset):
@@ -341,6 +351,97 @@ def test_websocket_actor_run_test_suite():
         assert 2 == reply.results[2].id
         assert reply.results[2].result.is_error
         assert not reply.results[2].result.passed
+
+
+def test_websocket_actor_run_test_suite_share_models_and_dataset_instance():
+    def random_prediction(df):
+        return [random.randint(0, 9) for _ in df.index]
+
+    # Use random model to ensure model prediction cache is shared (same instance loaded)
+    random_model = giskard.Model(random_prediction, "regression", feature_names=["feature"])
+    mock_dataset = giskard.Dataset(pd.DataFrame({"feature": range(100)}))
+
+    with utils.MockedClient(mock_all=False) as (client, mr):
+        params = websocket.TestSuiteParam(
+            projectKey=str(uuid.uuid4()),
+            tests=[
+                websocket.SuiteTestArgument(
+                    id=0,
+                    testUuid=same_prediction.meta.uuid,
+                    arguments=[
+                        websocket.FuncArgument(
+                            name="left",
+                            model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                            none=False,
+                        ),
+                        websocket.FuncArgument(
+                            name="right",
+                            model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                            none=False,
+                        ),
+                        websocket.FuncArgument(
+                            name="ds",
+                            dataset=websocket.ArtifactRef(project_key="project_key", id=str(mock_dataset.id)),
+                            none=False,
+                        ),
+                    ],
+                ),
+                websocket.SuiteTestArgument(
+                    id=1,
+                    testUuid=same_prediction.meta.uuid,
+                    arguments=[
+                        websocket.FuncArgument(
+                            name="left",
+                            model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                            none=False,
+                        )
+                    ],
+                ),
+                websocket.SuiteTestArgument(
+                    id=2,
+                    testUuid=same_prediction.meta.uuid,
+                    arguments=[
+                        websocket.FuncArgument(
+                            name="right",
+                            model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                            none=False,
+                        )
+                    ],
+                ),
+                websocket.SuiteTestArgument(id=2, testUuid=same_prediction.meta.uuid, arguments=[]),
+            ],
+            globalArguments=[
+                websocket.FuncArgument(
+                    name="left",
+                    model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                    none=False,
+                ),
+                websocket.FuncArgument(
+                    name="right",
+                    model=websocket.ArtifactRef(project_key="project_key", id=str(random_model.id)),
+                    none=False,
+                ),
+                websocket.FuncArgument(
+                    name="ds",
+                    dataset=websocket.ArtifactRef(project_key="project_key", id=str(mock_dataset.id)),
+                    none=False,
+                ),
+            ],
+        )
+        utils.register_uri_for_artifact_meta_info(mr, same_prediction, None)
+
+        utils.register_uri_for_model_meta_info(mr, random_model, "project_key")
+        utils.register_uri_for_model_artifact_info(mr, random_model, "project_key", register_file_contents=True)
+
+        utils.register_uri_for_dataset_meta_info(mr, mock_dataset, "project_key")
+        utils.register_uri_for_dataset_artifact_info(mr, mock_dataset, "project_key", register_file_contents=True)
+
+        reply = listener.run_test_suite(client, params)
+
+        assert isinstance(reply, websocket.TestSuite)
+        assert not reply.is_error
+        assert reply.is_pass
+        assert 4 == len(reply.results)
 
 
 def test_websocket_actor_run_test_suite_raise_error():

--- a/tests/models/test_model_cache.py
+++ b/tests/models/test_model_cache.py
@@ -7,13 +7,14 @@ import numpy as np
 import pandas as pd
 import pytest
 import xxhash
-from langchain import LLMChain, PromptTemplate
 from langchain.llms.fake import FakeListLLM
 
 import giskard
 from giskard import Dataset, Model
 from giskard.core.core import SupportedModelTypes
 from giskard.models.cache import ModelCache
+from langchain import LLMChain, PromptTemplate
+
 
 # https://symbl.cc/fr/unicode/blocks/
 
@@ -31,6 +32,7 @@ def test_unicode_prediction(keys, values):
     with TemporaryDirectory() as temp_cache_dir:
         cache = ModelCache(
             model_type=SupportedModelTypes.TEXT_GENERATION,
+            persist_cache=True,
             cache_dir=Path(temp_cache_dir),
         )
         key_series = pd.Series(keys)
@@ -43,6 +45,7 @@ def test_unicode_prediction(keys, values):
         warmed_up_cache = ModelCache(
             id="warmed_up",
             model_type=SupportedModelTypes.TEXT_GENERATION,
+            persist_cache=True,
             cache_dir=Path(temp_cache_dir),
         )
         # Ensure warm up works fine


### PR DESCRIPTION
## Description

- Only persist/read cache when explicitly asked
- Only load artifacts onces per test suite execution (model therefore share cache for a suite)
- For scan since only one model is loaded cache is also shared

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
