### PR TITLE
Fixed newline issue when reading env file

### DIFF
--- a/giskard/commands/cli_hub.py
+++ b/giskard/commands/cli_hub.py
@@ -2,7 +2,6 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Optional
 
 import click
 import docker
@@ -14,6 +13,7 @@ from docker.models.containers import Container
 from packaging import version
 from packaging.version import InvalidVersion, Version
 from tenacity import retry, wait_exponential
+from typing import Optional
 
 import giskard
 from giskard.cli_utils import common_options
@@ -334,7 +334,9 @@ def start(attached, skip_version_check, version, environment, env_file):
     environment = list(environment)
     if env_file is not None:
         with open(env_file, "r") as f:
-            environment = f.readlines() + environment
+            environment = f.read().splitlines() + environment
+
+    print(environment)
 
     _start(attached, skip_version_check, version, environment)
 

--- a/giskard/commands/cli_hub.py
+++ b/giskard/commands/cli_hub.py
@@ -336,8 +336,6 @@ def start(attached, skip_version_check, version, environment, env_file):
         with open(env_file, "r") as f:
             environment = f.read().splitlines() + environment
 
-    print(environment)
-
     _start(attached, skip_version_check, version, environment)
 
 


### PR DESCRIPTION
## Description

Fixed newline issue when reading env file

## Related Issue

[GSK-2403](https://linear.app/giskard/issue/GSK-2403/starting-container-with-env-file-add-new-line-after-env-variables)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
