### PR TITLE
Fixed error from contribution push when model is text generation

### DIFF
--- a/giskard/push/contribution.py
+++ b/giskard/push/contribution.py
@@ -9,6 +9,8 @@ Functions:
 - existing_shap_values: Check if SHAP values exist.
 
 """
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 from scipy.stats import zscore
@@ -126,7 +128,7 @@ def _create_text_contribution_push(shap_feature, sliced_ds, model, raw_predictio
         )
 
 
-def create_contribution_push(model: BaseModel, ds: Dataset, df: pd.DataFrame) -> ContributionPush:
+def create_contribution_push(model: BaseModel, ds: Dataset, df: pd.DataFrame) -> Optional[ContributionPush]:
     """
     Create contribution notification from SHAP values.
 
@@ -143,6 +145,9 @@ def create_contribution_push(model: BaseModel, ds: Dataset, df: pd.DataFrame) ->
     Returns:
         ContributionPush if outlier contribution found, else None
     """
+    if model.is_text_generation:
+        return None
+
     # Check if there is only one feature type in the dataset, and if it's "text"
     _text_is_the_only_feature = len(ds.column_types.values()) == 1 and list(ds.column_types.values())[0] == "text"
 


### PR DESCRIPTION
## Description

Fixed error from contribution push when model is text generation

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

[GSK-2321 (available on Linear)](https://linear.app/giskard/issue/GSK-2321/push-feature-error-no-attribute-keys)

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
