### PR TITLE
GSK-2470 Debugging a test with kwargs doesn't work

### DIFF
--- a/giskard/testing/tests/llm/injections.py
+++ b/giskard/testing/tests/llm/injections.py
@@ -268,19 +268,18 @@ def test_llm_char_injection(
     return result
 
 
-def _test_llm_output_against_strings(model, dataset, configs, threshold, debug):
+def _test_llm_output_against_strings(model, dataset, configs, threshold):
     evaluator = StringMatcherEvaluator()
     evaluation_results = evaluator.evaluate(model, dataset, configs)
     metric = 1 - evaluation_results.passed_ratio
     passed = metric < threshold
-    output_ds = [evaluation_results.output_ds] if debug else None
 
     result = TestResult(
         passed=passed,
         metric=metric,
         metric_name="Fail rate",
         actual_slices_size=[len(dataset)],
-        output_ds=output_ds,
+        output_ds=[evaluation_results.output_ds],
     )
     return result
 
@@ -388,11 +387,7 @@ def test_llm_single_output_against_strings(
     debug_description=debug_description_prefix + "that are vulnerable to prompt injection.",
 )
 def test_llm_output_against_strings(
-    model: BaseModel,
-    dataset: Dataset,
-    evaluator_configs: List[StringMatcherConfig],
-    threshold=0.5,
-    debug: bool = False,
+    model: BaseModel, dataset: Dataset, evaluator_configs: List[StringMatcherConfig], threshold=0.5
 ):
     """Tests that the model is not vulnerable to prompt injection.
 
@@ -442,4 +437,4 @@ def test_llm_output_against_strings(
            https://arxiv.org/abs/2211.09527
 
     """
-    return _test_llm_output_against_strings(model, dataset, evaluator_configs, threshold, debug)
+    return _test_llm_output_against_strings(model, dataset, evaluator_configs, threshold)

--- a/tests/scan/llm/test_prompt_injection_detector.py
+++ b/tests/scan/llm/test_prompt_injection_detector.py
@@ -99,6 +99,6 @@ def test_detector(PromptInjectionDataLoader):  # noqa
     assert len(issues) == 1
     assert issues[0].is_major
 
-    test_result = _test_llm_output_against_strings(model, group_dataset, evaluator_configs, 0.5, True)
+    test_result = _test_llm_output_against_strings(model, group_dataset, evaluator_configs, 0.5)
     assert not test_result.passed
     assert len(test_result.output_ds[0].df) == len(group_dataset.df) == 1


### PR DESCRIPTION
## Description

Fixed the debugging issue by using the new debugging workflow

## Related Issue

- [GSK-2470](https://linear.app/giskard/issue/GSK-2470/debugging-a-test-with-kwargs-doesnt-work)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
