### PR TITLE
GSK-2425 Add test to assert how long `import giskard` is running

### DIFF
--- a/tests/test_import_giskard.py
+++ b/tests/test_import_giskard.py
@@ -1,0 +1,17 @@
+import subprocess
+from time import time
+
+# As of today. The import of giskard takes about 2.5-3 seconds
+IMPORT_TIME_THRESHOLD_SECOND = 4
+
+
+def test_import_giskard():
+    start = time()
+
+    # Start subprocess to ensure that giskard is not already imported
+    subprocess.run(["python", "-c", "import giskard"])
+
+    end = time()
+    assert (
+        end - start < IMPORT_TIME_THRESHOLD_SECOND
+    ), f"Import of Giskard took {end - start} seconds (maximum threshold is set to {IMPORT_TIME_THRESHOLD_SECOND} second)"

--- a/tests/test_import_giskard.py
+++ b/tests/test_import_giskard.py
@@ -1,8 +1,8 @@
 import subprocess
 from time import time
 
-# As of today. The import of giskard takes about 2.5-3 seconds
-IMPORT_TIME_THRESHOLD_SECOND = 4
+# As of 17.01.2024. The import of giskard takes about 2.5-3 seconds on a 2021 MacBook Pro.
+IMPORT_TIME_THRESHOLD_SECOND = 6
 
 
 def test_import_giskard():


### PR DESCRIPTION
## Description

Add test to assert how long `import giskard` is running
Did local tests and took on average 3 seconds so put the threshold to 4, to confirm with runner output


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
