### PR TITLE
Fix BaseModel loading

### DIFF
--- a/giskard/models/base/model.py
+++ b/giskard/models/base/model.py
@@ -562,10 +562,10 @@ class BaseModel(ABC):
     @classmethod
     def load(cls, local_dir, model_py_ver: Optional[Tuple[str, str, str]] = None, *_args, **kwargs):
         class_file = Path(local_dir) / MODEL_CLASS_PKL
-        model_id, meta = cls.read_meta_from_local_dir(local_dir)
+        model_meta_info, meta = cls.read_meta_from_local_dir(local_dir)
 
         constructor_params = meta.__dict__
-        constructor_params["id"] = model_id
+        constructor_params["id"] = model_meta_info.id
         del constructor_params["loader_module"]
         del constructor_params["loader_class"]
 


### PR DESCRIPTION
Fixing issue when loading `BaseModel` instances (or custom model classes that directly extend `BaseModel`)

`model_id, meta = cls.read_meta_from_local_dir(local_dir)` returns a `Tuple[MetaModelInfo, ModelMeta]`, therefore, `model_id` is not a `str` as it should. 

@rabah-khalek this fix might interest you.

