### PR TITLE
Add ggshield to pre-commit

### DIFF
--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -9,6 +9,7 @@ on:
 env:
   GSK_DISABLE_ANALYTICS: true
   SENTRY_ENABLED: false
+  GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
 defaults:
   run:
     shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,14 @@ repos:
           - "pyproject.toml"
 
   - repo: https://github.com/ambv/black
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
         files: '^.*\.py$'
         args:
           - "--config"
           - "pyproject.toml"
-
+        stages: [commit]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.6
     hooks:
@@ -27,3 +27,10 @@ repos:
           - "pyproject.toml"
           - "--fix"
           - "--exit-non-zero-on-fix"
+
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.23.0
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]


### PR DESCRIPTION
Note : in addition, everyone should follow step 1 and 2 from https://docs.gitguardian.com/ggshield-docs/integrations/git-hooks/pre-commit#global-pre-commit-hook 