### PR TITLE
[GSK-2626] Fix run test action for custom tests

### DIFF
--- a/giskard/ml_worker/websocket/listener.py
+++ b/giskard/ml_worker/websocket/listener.py
@@ -504,7 +504,7 @@ def dataset_processing(
 def run_ad_hoc_test(
     client: Optional[GiskardClient], params: websocket.RunAdHocTestParam, *args, **kwargs
 ) -> websocket.RunAdHocTest:
-    test: GiskardTest = GiskardTest.download(params.testUuid, client, None)
+    test: GiskardTest = GiskardTest.download(params.testUuid, client, params.projectKey)
 
     arguments = parse_function_arguments(client, params.arguments)
     if params.debug:
@@ -535,7 +535,7 @@ def run_test_suite(
     try:
         tests = [
             {
-                "test": GiskardTest.download(t.testUuid, client, None),
+                "test": GiskardTest.download(t.testUuid, client, params.projectKey),
                 "arguments": parse_function_arguments(client, t.arguments, loaded_artifacts),
                 "id": t.id,
             }

--- a/tests/communications/test_websocket_actor_tests.py
+++ b/tests/communications/test_websocket_actor_tests.py
@@ -95,7 +95,7 @@ def test_websocket_actor_run_ad_hoc_test_legacy_debug(enron_data: Dataset):
             projectKey="projectKey",
         )
         with utils.MockedClient(mock_all=False) as (client, mr):
-            utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug, None)
+            utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug, project_key)
             utils.register_uri_for_dataset_meta_info(mr, enron_data, project_key)
             utils.register_uri_for_any_dataset_artifact_info_upload(mr, register_files=True)
 
@@ -300,7 +300,7 @@ def test_websocket_actor_run_ad_hoc_test_legacy_debug_no_name(enron_data: Datase
             projectKey="projectKey",
         )
         with utils.MockedClient(mock_all=False) as (client, mr):
-            utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug_no_name, None)
+            utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug_no_name, project_key)
             utils.register_uri_for_dataset_meta_info(mr, enron_data, project_key)
             utils.register_uri_for_any_dataset_artifact_info_upload(mr, register_files=True)
 

--- a/tests/communications/test_websocket_actor_tests.py
+++ b/tests/communications/test_websocket_actor_tests.py
@@ -333,9 +333,9 @@ def test_websocket_actor_run_test_suite():
             ],
             globalArguments=[],
         )
-        utils.register_uri_for_artifact_meta_info(mr, my_simple_test, None)
-        utils.register_uri_for_artifact_meta_info(mr, my_simple_test_successful, None)
-        utils.register_uri_for_artifact_meta_info(mr, my_simple_test_error, None)
+        utils.register_uri_for_artifact_meta_info(mr, my_simple_test, params.projectKey)
+        utils.register_uri_for_artifact_meta_info(mr, my_simple_test_successful, params.projectKey)
+        utils.register_uri_for_artifact_meta_info(mr, my_simple_test_error, params.projectKey)
 
         reply = listener.run_test_suite(client, params)
 
@@ -429,7 +429,7 @@ def test_websocket_actor_run_test_suite_share_models_and_dataset_instance():
                 ),
             ],
         )
-        utils.register_uri_for_artifact_meta_info(mr, same_prediction, None)
+        utils.register_uri_for_artifact_meta_info(mr, same_prediction, params.projectKey)
 
         utils.register_uri_for_model_meta_info(mr, random_model, "project_key")
         utils.register_uri_for_model_artifact_info(mr, random_model, "project_key", register_file_contents=True)
@@ -494,7 +494,7 @@ def test_websocket_actor_run_test_suite_with_global_arguments():
                 websocket.FuncArgument(name="value", int=MY_TEST_GLOBAL_VALUE, none=False),
             ],
         )
-        utils.register_uri_for_artifact_meta_info(mr, my_test_return, None)
+        utils.register_uri_for_artifact_meta_info(mr, my_test_return, params.projectKey)
 
         reply = listener.run_test_suite(client, params)
 
@@ -529,7 +529,7 @@ def test_websocket_actor_run_test_suite_with_test_input():
                 websocket.FuncArgument(name="value", int=MY_TEST_GLOBAL_VALUE, none=False),
             ],
         )
-        utils.register_uri_for_artifact_meta_info(mr, my_test_return, None)
+        utils.register_uri_for_artifact_meta_info(mr, my_test_return, params.projectKey)
 
         reply = listener.run_test_suite(client, params)
 
@@ -566,7 +566,7 @@ def test_websocket_actor_run_test_suite_with_legacy_debug():
                 websocket.FuncArgument(name="value", int=MY_TEST_GLOBAL_VALUE, none=False),
             ],
         )
-        utils.register_uri_for_artifact_meta_info(mr, my_simple_test__legacy_debug, None)
+        utils.register_uri_for_artifact_meta_info(mr, my_simple_test__legacy_debug, params.projectKey)
         utils.register_uri_for_any_dataset_artifact_info_upload(mr, True)
 
         reply = listener.run_test_suite(client, params)
@@ -600,7 +600,7 @@ def test_websocket_actor_run_test_suite_with_kwargs():
                 websocket.FuncArgument(name="value", int=MY_TEST_GLOBAL_VALUE, none=False),
             ],
         )
-        utils.register_uri_for_artifact_meta_info(mr, my_test_return, None)
+        utils.register_uri_for_artifact_meta_info(mr, my_test_return, params.projectKey)
 
         reply = listener.run_test_suite(client, params)
 

--- a/tests/communications/test_websocket_actor_tests.py
+++ b/tests/communications/test_websocket_actor_tests.py
@@ -92,7 +92,7 @@ def test_websocket_actor_run_ad_hoc_test_legacy_debug(enron_data: Dataset):
                 ),
             ],
             debug=True,
-            projectKey="projectKey",
+            projectKey=project_key,
         )
         with utils.MockedClient(mock_all=False) as (client, mr):
             utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug, project_key)
@@ -297,7 +297,7 @@ def test_websocket_actor_run_ad_hoc_test_legacy_debug_no_name(enron_data: Datase
                 ),
             ],
             debug=True,
-            projectKey="projectKey",
+            projectKey=project_key,
         )
         with utils.MockedClient(mock_all=False) as (client, mr):
             utils.register_uri_for_artifact_meta_info(mr, my_simple_test_legacy_debug_no_name, project_key)


### PR DESCRIPTION
## Description

This PR fixes a bug in which custom testing functions could not be run from the Hub.

## Related Issue

[GSK-2626 (available on Linear)](https://linear.app/giskard/issue/GSK-2626/custom-uploaded-test-doesnt-run-on-catalog)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix