### PR TITLE
Update calibration detectors to display `metric_value_perc` with 2 decimals

### DIFF
--- a/giskard/scanner/calibration/overconfidence_detector.py
+++ b/giskard/scanner/calibration/overconfidence_detector.py
@@ -81,7 +81,7 @@ class OverconfidenceDetector(LossBasedDetector):
                 description = (
                     "For records in the dataset where {slicing_fn}, we found a significantly higher number of "
                     "overconfident wrong predictions ({num_overconfident_samples} samples, corresponding to "
-                    "{metric_value_perc}% of the wrong predictions in the data slice)."
+                    "{metric_value_perc:.2f}% of the wrong predictions in the data slice)."
                 )
                 issue = Issue(
                     model,

--- a/giskard/scanner/calibration/underconfidence_detector.py
+++ b/giskard/scanner/calibration/underconfidence_detector.py
@@ -81,7 +81,7 @@ class UnderconfidenceDetector(LossBasedDetector):
                 description = (
                     "For records in your dataset where {slicing_fn}, we found a significantly higher number of "
                     "underconfident predictions ({num_underconfident_samples} samples, corresponding to "
-                    "{metric_value_perc:.1f}% of the predictions in the data slice)."
+                    "{metric_value_perc:.2f}% of the predictions in the data slice)."
                 )
                 issue = Issue(
                     model,


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

I updated `OverconfidenceDetector` and `UnderconfidenceDetector` to display `metric_value_perc` with 2 decimals.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

#1730 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
