### PR TITLE
GSK-2407 Made metric None as default

### DIFF
--- a/giskard/core/test_result.py
+++ b/giskard/core/test_result.py
@@ -77,7 +77,7 @@ class TestResult:
     messages: List[TestMessage] = field(default_factory=list, repr=False)
     props: Dict[str, str] = field(default_factory=dict, repr=False)
     metric_name: str = "Metric"
-    metric: float = 0
+    metric: Optional[float] = None
     missing_count: int = 0
     missing_percent: float = 0
     unexpected_count: int = 0


### PR DESCRIPTION
## Description

In order to allow test to not show metrics by simply doing `TestResult(passed=True)` instead of `TestResult(passed=True, metric=None)` 

![image](https://github.com/Giskard-AI/giskard/assets/114553769/a366191b-4f1c-4b52-8405-91c5ac502f86)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
