### PR TITLE
Fix tests run on enron

### DIFF
--- a/giskard/scanner/robustness/text_transformations.py
+++ b/giskard/scanner/robustness/text_transformations.py
@@ -283,7 +283,11 @@ class TextNumberToWordTransformation(TextLanguageBasedTransformation):
 
     def make_perturbation(self, row):
         # Replace numbers with words
-        return self._regex.sub(lambda x: num2words(x.group(), lang=row["language__gsk__meta"]), row[self.column])
+        value = row[self.column]
+        lang = row["language__gsk__meta"]
+        if pd.isna(value) or pd.isna(lang):
+            return value
+        return self._regex.sub(lambda x: num2words(x.group(), lang=lang), value)
 
 
 class TextReligionTransformation(TextLanguageBasedTransformation):

--- a/giskard/scanner/robustness/text_transformations.py
+++ b/giskard/scanner/robustness/text_transformations.py
@@ -284,9 +284,9 @@ class TextNumberToWordTransformation(TextLanguageBasedTransformation):
     def make_perturbation(self, row):
         # Replace numbers with words
         value = row[self.column]
-        lang = row["language__gsk__meta"]
-        if pd.isna(value) or pd.isna(lang):
+        if pd.isna(value):
             return value
+        lang = row["language__gsk__meta"] if not pd.isna(row["language__gsk__meta"]) else "en"
         return self._regex.sub(lambda x: num2words(x.group(), lang=lang), value)
 
 

--- a/giskard/scanner/scanner.py
+++ b/giskard/scanner/scanner.py
@@ -152,7 +152,7 @@ class Scanner:
             try:
                 detected_issues = detector.run(model, dataset, features=features)
             except Exception as err:
-                logger.error(f"Detector {detector.__class__.__name__} failed with error: {err}")
+                logger.exception(f"Detector {detector.__class__.__name__} failed with error: {err}")
                 errors.append((detector, err))
                 analytics.track(
                     "scan:run-detector:error",


### PR DESCRIPTION
## Description

TextNumberToWordTransformation was failing if row["language__gsk__meta"] was nan 

Before : https://github.com/Giskard-AI/giskard/actions/runs/7750039265
After : https://github.com/Giskard-AI/giskard/actions/runs/7753720227

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
