### PR TITLE
[GSK-2270] Add the transformation column back & hide it only if not used

### DIFF
--- a/giskard/visualization/templates/scan_report/markdown/huggingface.md
+++ b/giskard/visualization/templates/scan_report/markdown/huggingface.md
@@ -6,9 +6,9 @@
 {% for issue in view.issues -%}
 {{ issue.description }}
 
-| Level | Data slice | Metric | Deviation |
-|-------|------------|--------|-----------|
-| <span style="color:{% if issue.level.value == "major" %} red {% else %} orange {% endif %} "> {{ issue.level.value }} {% if issue.level.value == "major" %} 🔴 {% else %} 🟡 {% endif %} </span> | {{ issue.slicing_fn if issue.slicing_fn else "—" }} | {% if "metric" in issue.meta %}{{ issue.meta.metric }} = {{ issue.meta.metric_value|format_metric }}{% else %} "—" {% endif %} | {{ issue.meta["deviation"] if "deviation" in issue.meta else "—" }} |
+| Level {% if issue.slicing_fn %}| Data slice {% endif %}| Metric {% if issue.transformation_fn %}| Transformation {% endif %}| Deviation |
+|-------{% if issue.slicing_fn %}|------------{% endif %}|--------{% if issue.transformation_fn %}|----------------{% endif %}|-----------|
+| <span style="color:{% if issue.level.value == "major" %} red {% else %} orange {% endif %} "> {{ issue.level.value }} {% if issue.level.value == "major" %} 🔴 {% else %} 🟡 {% endif %} </span> {% if issue.slicing_fn %}| {{ issue.slicing_fn }} {% endif %}| {% if "metric" in issue.meta %}{{ issue.meta.metric }} = {{ issue.meta.metric_value|format_metric }}{% else %} "—" {% endif %} {% if issue.transformation_fn %}| {{ issue.transformation_fn }} {% endif %}| {{ issue.meta["deviation"] if "deviation" in issue.meta else "—" }} |
 
 {% if issue.taxonomy %}
 <h4 class="font-bold text-sm mt-4">Taxonomy</h4>


### PR DESCRIPTION
## Description
Previously, we removed the transformation column, which was not what we want. Because it is not obvious in the description. This PR hides the columns (data slice, transformation) **only** when they are empty.

Test: locally tested with Titanic
Demo: the scan report template posted [here](https://huggingface.co/spaces/ZeroCommand/test-giskard-evaluator/discussions/13)
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
