### PR TITLE
Temporary fix for docs links to notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ html_theme_options = {
 add_function_parentheses = False
 # Do not execute the notebooks when building the docs
 docs_version = os.getenv("READTHEDOCS_VERSION", "latest")
-if docs_version == "latest":
+if docs_version == "latest" or docs_version == "stable":
     branch = "main"
 else:
     branch = docs_version.replace("-", "/")


### PR DESCRIPTION
Docs now use the `stable` version by default, but our links to notebook only mapped version `latest` to branch `main`.

Temporary fix while we understand how to link to the released tag.