### PR TITLE
GSK-2822 Don't edit global logger level

### DIFF
--- a/giskard/cli_utils.py
+++ b/giskard/cli_utils.py
@@ -15,7 +15,6 @@ from giskard.path_utils import run_dir
 from giskard.settings import settings
 
 logger = logging.getLogger(__name__)
-logging.getLogger().setLevel(logging.INFO)
 logging.getLogger("giskard").setLevel(logging.INFO)
 
 

--- a/giskard/commands/cli_worker.py
+++ b/giskard/commands/cli_worker.py
@@ -91,7 +91,21 @@ def start_stop_options(func):
     default=None,
     help="Number of processes to use for parallelism (None for number of cpu)",
 )
-def start_command(url: AnyHttpUrl, is_server, api_key, is_daemon, hf_token, nb_workers):
+@click.option(
+    "--log-level",
+    "log_level",
+    default=logging.getLevelName(logging.INFO),
+    type=click.Choice(
+        [
+            logging.getLevelName(logging.DEBUG),
+            logging.getLevelName(logging.INFO),
+            logging.getLevelName(logging.WARNING),
+            logging.getLevelName(logging.ERROR),
+        ]
+    ),
+    help="Global log level",
+)
+def start_command(url: AnyHttpUrl, is_server, api_key, is_daemon, hf_token, nb_workers, log_level):
     """\b
     Start ML Worker.
 
@@ -104,8 +118,11 @@ def start_command(url: AnyHttpUrl, is_server, api_key, is_daemon, hf_token, nb_w
     """
     analytics.track(
         "giskard-worker:start",
-        {"is_server": is_server, "url": anonymize(url), "is_daemon": is_daemon},
+        {"is_server": is_server, "url": anonymize(url), "is_daemon": is_daemon, "log_level": log_level},
     )
+
+    logging.root.setLevel(logging.getLevelName(log_level))
+
     api_key = initialize_api_key(api_key, is_server)
     hf_token = initialize_hf_token(hf_token, is_server)
     _start_command(is_server, url, api_key, is_daemon, hf_token, int(nb_workers) if nb_workers is not None else None)

--- a/giskard/utils/logging_utils.py
+++ b/giskard/utils/logging_utils.py
@@ -4,8 +4,6 @@ from datetime import timedelta
 from functools import wraps
 from timeit import default_timer
 
-from giskard.settings import settings
-
 logger = logging.getLogger(__name__)
 
 
@@ -13,13 +11,12 @@ def configure_logging():
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     logging.getLogger("shap").setLevel(logging.WARNING)
     logging.getLogger("pyngrok").setLevel(logging.ERROR)
-    logging.getLogger("giskard").setLevel(logging.WARNING)
+    logging.getLogger("giskard").setLevel(logging.INFO)
     configure_basic_logging(stdout_handler)
 
 
 def configure_basic_logging(handler, force=False):
     logging.basicConfig(
-        level=settings.loglevel,
         format="%(asctime)s pid:%(process)d %(threadName)s %(name)-12s %(levelname)-8s %(message)s",
         handlers=[handler],
         force=force,

--- a/giskard/utils/logging_utils.py
+++ b/giskard/utils/logging_utils.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 def configure_logging():
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
-    logging.getLogger("shap").setLevel(logging.WARNING)
     logging.getLogger("pyngrok").setLevel(logging.ERROR)
     logging.getLogger("giskard").setLevel(logging.INFO)
     configure_basic_logging(stdout_handler)

--- a/giskard/utils/logging_utils.py
+++ b/giskard/utils/logging_utils.py
@@ -80,3 +80,23 @@ def timer(message=None):
         return wrap
 
     return timing_decorator
+
+
+class TemporaryRootLogLevel:
+    def __init__(self, log_level=logging.NOTSET):
+        """Temporarily update the root log level
+
+        Parameters
+        ----------
+        log_level : int
+            The log level to be set, nothing happens if the level is 0 (NOTSET).
+        """
+        self.previous_log_level = logging.root.level
+        self.log_level = log_level
+
+    def __enter__(self):
+        if self.log_level != logging.NOTSET:
+            logging.root.setLevel(self.log_level)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logging.root.setLevel(self.previous_log_level)

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+import giskard
 from giskard.utils.worker_pool import GiskardMLWorkerException, PoolState, WorkerPoolExecutor
 
 
@@ -66,7 +67,7 @@ def sleep_add_one(timer, value):
 def print_stuff():
     print("stuff stdout")
     print("other stuff", file=sys.stderr)
-    logging.getLogger().info("info log")
+    logging.getLogger(giskard.__name__).info("info log")
     logging.getLogger("truc").error("toto")
     logging.getLogger(__name__).warning("Warning")
     return

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,0 +1,20 @@
+import logging
+
+import giskard
+from giskard.llm.client import openai
+
+
+def test_giskard_log_level():
+    assert (
+        logging.getLogger(giskard.__name__).level == logging.INFO
+    ), "giskard log level should be set to INFO when importing giskard"
+
+
+def test_other_package_log_level_unset():
+    assert (
+        logging.getLogger(openai.__name__).level == logging.NOTSET
+    ), "Non giskard package log level should't be touched by giskard (NOTSET)"
+
+
+def test_root_log_level_default_warning():
+    assert logging.root.level == logging.WARNING, 'Root package log level should be set to default "WARNING"'


### PR DESCRIPTION
## Description

Updated logger to only update giskard log level to INFO by default

## Related Issue

- [GSK-2822 (Available on Linear)](https://linear.app/giskard/issue/GSK-2822/dont-edit-global-logger-level)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
