### PR TITLE
GSK-2819 Pydantic models cannot be serialised with our code

### DIFF
--- a/tests/models/test_model_serialization.py
+++ b/tests/models/test_model_serialization.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 import pandas as pd
+import pydantic
 import pytest
 
 from giskard.datasets import Dataset
@@ -10,6 +11,8 @@ from giskard.exceptions.giskard_exception import GiskardPythonDepException
 from giskard.models.automodel import Model
 from giskard.models.base.serialization import CloudpickleSerializableModel
 from tests.registry.module_utils import PythonFile, PythonModule, TmpModule
+
+PYDANTIC_V2 = pydantic.__version__.startswith("2.")
 
 
 @mock.patch("giskard.models.base.serialization.cloudpickle.dump")
@@ -106,6 +109,7 @@ def test_load_model_from_external_module(module_def):
         assert list(model.predict(dataset).raw_prediction) == inputs
 
 
+@pytest.mark.skipif(not PYDANTIC_V2, reason="Cloudpickle only fails to save Pydantic BaseModel after v2")
 def test_load_model_with_error_saving_by_value():
     with tempfile.TemporaryDirectory() as tmp_test_folder:
         with TmpModule(UNPICKABLE_BY_VALUE_MODULE) as module:


### PR DESCRIPTION
## Description

### Issue

By default we try to serialise models by value using cloudpickle in order to be able to execute them in ML Worker without having to install the referenced dependency. However cloudpickle is not able to serialise everything causing the serialisation to fail.

### Solution

For complex code that aren't pickable, it's always possible to save the code in a module and install it into the ML worker. Therefore when cloudpickle fail to save objects by value, we fallback into saving by reference with a warning.  

## Related Issue

- [GSK-2819 (Available on Linear)](https://linear.app/giskard/issue/GSK-2819/pydantic-models-cannot-be-serialised-with-our-code)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
