### PR TITLE
[GSK-2782] Allow GiskardClient to read api key from env

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -128,7 +128,7 @@ def _limit_str_size(json, field, limit=255):
 class GiskardClient:
     def __init__(self, url: str, key: str = None, hf_token: str = None):
         self.host_url = url
-        self.key = key or os.getenv('GSK_API_KEY')
+        self.key = key or os.getenv("GSK_API_KEY")
         self.hf_token = hf_token
         base_url = urljoin(url, "/api/v2/")
 
@@ -139,7 +139,7 @@ class GiskardClient:
         self._session.mount(url, adapter)
 
         if self.key is None:
-            raise RuntimeError('You must provide an API key to connect to the Giskard Hub.')
+            raise RuntimeError("You must provide an API key to connect to the Giskard Hub.")
 
         self._session.auth = BearerAuth(key)
 

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -139,7 +139,7 @@ class GiskardClient:
         self._session.mount(url, adapter)
 
         if self.key is None:
-            raise RuntimeError("You must provide an API key to connect to the Giskard Hub.")
+            raise RuntimeError("You must provide an API key for the client to connect to the hub")
 
         self._session.auth = BearerAuth(key)
 

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -126,9 +126,9 @@ def _limit_str_size(json, field, limit=255):
 
 
 class GiskardClient:
-    def __init__(self, url: str, key: str, hf_token: str = None):
+    def __init__(self, url: str, key: str = None, hf_token: str = None):
         self.host_url = url
-        self.key = key
+        self.key = key or os.getenv('GSK_API_KEY')
         self.hf_token = hf_token
         base_url = urljoin(url, "/api/v2/")
 
@@ -137,6 +137,9 @@ class GiskardClient:
         adapter = ErrorHandlingAdapter()
 
         self._session.mount(url, adapter)
+
+        if self.key is None:
+            raise RuntimeError('You must provide an API key to connect to the Giskard Hub.')
 
         self._session.auth = BearerAuth(key)
 


### PR DESCRIPTION
## Description

There exists an env var called `GSK_API_KEY` used to [auto-provide the API key](https://github.com/Giskard-AI/giskard/blob/6f9bc5f9008f9688a5f894ad498d4f1ec45bf265/giskard/commands/cli_worker.py#L71) in the giskard worker CLI. It makes sense to reuse the name here.

We may want to also delete it from the environment once it's loaded to prevent leaks [as done in the CLI](https://github.com/Giskard-AI/giskard/blob/6f9bc5f9008f9688a5f894ad498d4f1ec45bf265/giskard/commands/cli_worker.py#L109).

I'm worried though that it may destroy the env var in the kernel itself, which would need to be restarted to properly instantiate a new client (or if the user was to reload the same cell where the client gets created).

## Todo

- [ ] Update client instantiation documentation to include (or update) a section on setting environment variables so they get picked up by `GiskardClient`.

## Testing Checklist

- [ ] Spin up a notebook with previously set env vars among which `GSK_API_KEY`
- [ ] Spin up a client without `key` kwarg and connect to the hub
- [ ] Destroy env var (`del os.environ['GSK_API_KEY']`) and attempt to re-instantiate client
  - This operation should ideally be idempotent. We could store the env var value as a class field or another property that will not get uploaded with the test code.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
