### PR TITLE
[GSK-2834] Show only light theme logo in PyPI package description

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Edit pyproject.toml
         run:  sed -i 's/^\(version *= *\).*$/\1"${{ inputs.version }}"/' pyproject.toml
 
+      - name: Remove dark theme logo from README
+        run:  sed -i 's/.*#gh-dark-mode-only.*//' -- README.md
+
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
         run:  sed -i 's/^\(version *= *\).*$/\1"${{ inputs.version }}"/' pyproject.toml
 
       - name: Remove dark theme logo from README
-        run:  sed -i 's/.*#gh-dark-mode-only.*//' -- README.md
+        run:  sed -i 's/.*#gh-dark-mode-only.*//' README.md
 
       - name: Setup PDM
         uses: pdm-project/setup-pdm@v4


### PR DESCRIPTION
## Description

In order to only have the light theme logo display in PyPI, we simply remove the dark theme logo `img` tag from the README as we build the release candidate wheel (which eventually gets published to PyPI in the current release flow).

(Assuming PyPI looks in the wheel rather than the tarball when fetching the package's description. Otherwise, we would rather make the edit in `post-release.yml`).

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
