### PR TITLE
GSK-2376 Add seed to LLM generators and evaluators in order to ensure reproducibility

### DIFF
--- a/giskard/llm/client/base.py
+++ b/giskard/llm/client/base.py
@@ -50,6 +50,7 @@ class LLMClient(ABC):
         caller_id: Optional[str] = None,
         tools=None,
         tool_choice=None,
+        seed: Optional[int] = None,
     ) -> LLMMessage:
         ...
 

--- a/giskard/llm/client/openai.py
+++ b/giskard/llm/client/openai.py
@@ -44,6 +44,7 @@ class BaseOpenAIClient(LLMClient, ABC):
         caller_id: Optional[str] = None,
         tools=None,
         tool_choice=None,
+        seed: Optional[int] = None,
     ) -> dict:
         ...
 
@@ -125,6 +126,7 @@ class BaseOpenAIClient(LLMClient, ABC):
         caller_id: Optional[str] = None,
         tools=None,
         tool_choice=None,
+        seed: Optional[int] = None,
     ):
         llm_message = self._completion(
             messages=[
@@ -138,6 +140,7 @@ class BaseOpenAIClient(LLMClient, ABC):
             caller_id=caller_id,
             tools=tools,
             tool_choice=tool_choice,
+            seed=seed,
         )
 
         return BaseOpenAIClient._parse_message(llm_message)
@@ -174,6 +177,7 @@ class LegacyOpenAIClient(BaseOpenAIClient):
         caller_id: Optional[str] = None,
         tools=None,
         tool_choice=None,
+        seed: Optional[int] = None,
     ):
         extra_params = dict()
         if function_call is not None:
@@ -184,6 +188,8 @@ class LegacyOpenAIClient(BaseOpenAIClient):
             extra_params["tools"] = tools
         if tool_choice is not None:
             extra_params["tool_choice"] = tool_choice
+        if seed is not None:
+            extra_params["seed"] = seed
 
         try:
             completion = openai.ChatCompletion.create(
@@ -242,6 +248,7 @@ class OpenAIClient(BaseOpenAIClient):
         caller_id: Optional[str] = None,
         tools=None,
         tool_choice=None,
+        seed=None,
     ):
         extra_params = dict()
         if function_call is not None:
@@ -252,6 +259,8 @@ class OpenAIClient(BaseOpenAIClient):
             extra_params["tools"] = tools
         if tool_choice is not None:
             extra_params["tool_choice"] = tool_choice
+        if seed is not None:
+            extra_params["seed"] = seed
 
         try:
             completion = self._client.chat.completions.create(

--- a/giskard/llm/evaluators/base.py
+++ b/giskard/llm/evaluators/base.py
@@ -84,10 +84,11 @@ class BaseEvaluator(ABC):
 class LLMBasedEvaluator(BaseEvaluator):
     _default_eval_prompt: str
 
-    def __init__(self, eval_prompt=None, llm_temperature=0.1, llm_client: LLMClient = None):
+    def __init__(self, eval_prompt=None, llm_temperature=0.1, llm_client: LLMClient = None, rng_seed: int = 1729):
         self.eval_prompt = eval_prompt or self._default_eval_prompt
         self.llm_temperature = llm_temperature
         self.llm_client = llm_client if llm_client is not None else get_default_client()
+        self.rng_seed = rng_seed
 
     def _make_evaluate_prompt(self, model: BaseModel, input_vars, model_output, row_idx):
         return self.eval_prompt.format(
@@ -123,6 +124,7 @@ class LLMBasedEvaluator(BaseEvaluator):
                     tool_choice={"type": "function", "function": {"name": "evaluate_model"}},
                     temperature=self.llm_temperature,
                     caller_id=self.__class__.__name__,
+                    seed=self.rng_seed,
                 )
                 if len(out.tool_calls) != 1 or "passed_test" not in out.tool_calls[0].function.arguments:
                     raise LLMGenerationError("Invalid function call arguments received")

--- a/giskard/llm/evaluators/coherency.py
+++ b/giskard/llm/evaluators/coherency.py
@@ -102,6 +102,7 @@ class CoherencyEvaluator(LLMBasedEvaluator):
             tool_choice={"type": "function", "function": {"name": "evaluate_model"}},  # force tool call
             temperature=self.llm_temperature,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         if len(out.tool_calls) != 1 or "passed_test" not in out.tool_calls[0].function.arguments:

--- a/giskard/llm/evaluators/correctness.py
+++ b/giskard/llm/evaluators/correctness.py
@@ -124,6 +124,7 @@ class CorrectnessEvaluator(LLMBasedEvaluator):
             tool_choice={"type": "function", "function": {"name": "evaluate_model"}},
             temperature=self.llm_temperature,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         try:

--- a/giskard/llm/generators/base.py
+++ b/giskard/llm/generators/base.py
@@ -41,11 +41,13 @@ class LLMGenerator(BaseGenerator, ABC):
         llm_client: LLMClient = None,
         prompt: Optional[str] = None,
         languages: Optional[Sequence[str]] = None,
+        rng_seed: int = 1729,
     ):
         self.llm_temperature = llm_temperature if llm_temperature is not None else self._default_temperature
         self.llm_client = llm_client or get_default_client()
         self.languages = languages
         self.prompt = prompt if prompt is not None else self._default_prompt
+        self.rng_seed = rng_seed
 
 
 class BaseDataGenerator(LLMGenerator):
@@ -120,6 +122,7 @@ class BaseDataGenerator(LLMGenerator):
             tool_choice={"type": "function", "function": {"name": "generate_inputs"}},
             temperature=self.llm_temperature,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         try:

--- a/giskard/llm/generators/sycophancy.py
+++ b/giskard/llm/generators/sycophancy.py
@@ -90,6 +90,7 @@ class SycophancyDataGenerator(LLMGenerator):
             function_call={"name": "generate_inputs"},
             temperature=self.llm_temperature,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         # Parse results

--- a/giskard/llm/testcase.py
+++ b/giskard/llm/testcase.py
@@ -54,10 +54,11 @@ GENERATE_REQUIREMENTS_FUNCTIONS = [
 
 
 class TestcaseRequirementsGenerator:
-    def __init__(self, issue_description: str, llm_temperature=0.1, llm_client: LLMClient = None):
+    def __init__(self, issue_description: str, llm_temperature=0.1, llm_client: LLMClient = None, rng_seed: int = 1729):
         self.issue_description = issue_description
         self.llm_temperature = llm_temperature
         self.llm_client = llm_client or get_default_client()
+        self.rng_seed = rng_seed
 
     def _make_generate_requirements_prompt(self, model: BaseModel, num_requirements: int):
         return GENERATE_REQUIREMENTS_PROMPT.format(
@@ -80,6 +81,7 @@ class TestcaseRequirementsGenerator:
             tool_choice={"type": "function", "function": {"name": "generate_requirements"}},
             temperature=self.llm_temperature,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         if out.tool_calls is None or "requirements" not in out.tool_calls[0].function.arguments:

--- a/giskard/llm/utils.py
+++ b/giskard/llm/utils.py
@@ -5,7 +5,12 @@ from .generators.base import BaseDataGenerator
 
 
 def generate_test_dataset(
-    model: BaseModel, num_samples: int = 10, prompt: Optional[str] = None, temperature=0.5, column_types=None
+    model: BaseModel,
+    num_samples: int = 10,
+    prompt: Optional[str] = None,
+    temperature=0.5,
+    column_types=None,
+    rng_seed: int = 1729,
 ):
     """Generates a synthetic test dataset using an LLM.
 
@@ -21,6 +26,8 @@ def generate_test_dataset(
         The temperature to use for the generation, by default 0.5.
     column_types :
         (Default value = None)
+    rng_seed :
+        (Default value = 1729), seed used to generate completion
 
     Returns
     -------
@@ -36,5 +43,5 @@ def generate_test_dataset(
     --------
     :class:`giskard.llm.generators.BaseDataGenerator`
     """
-    generator = BaseDataGenerator(prompt=prompt, llm_temperature=temperature)
+    generator = BaseDataGenerator(prompt=prompt, llm_temperature=temperature, rng_seed=rng_seed)
     return generator.generate_dataset(model, num_samples, column_types)

--- a/giskard/scanner/llm/base.py
+++ b/giskard/scanner/llm/base.py
@@ -16,9 +16,10 @@ from ..scanner import logger
 class RequirementBasedDetector(Detector):
     _taxonomy = []
 
-    def __init__(self, num_requirements=4, num_samples=5):
+    def __init__(self, num_requirements=4, num_samples=5, rng_seed: int = 1729):
         self.num_requirements = num_requirements
         self.num_samples = num_samples
+        self.rng_seed = rng_seed
 
     def get_cost_estimate(self, model: BaseModel, dataset: Dataset) -> dict:
         counts = _estimate_base_token_counts(model, dataset)

--- a/giskard/scanner/llm/llm_faithfulness_detector.py
+++ b/giskard/scanner/llm/llm_faithfulness_detector.py
@@ -40,6 +40,7 @@ class LLMFaithfulnessDetector(RequirementBasedDetector):
             temperature=0.1,
             max_tokens=1,
             caller_id=self.__class__.__name__,
+            rng_seed=self.rng_seed,
         )
 
         if out.content.strip().upper() != "Y":

--- a/giskard/scanner/llm/llm_faithfulness_detector.py
+++ b/giskard/scanner/llm/llm_faithfulness_detector.py
@@ -40,7 +40,7 @@ class LLMFaithfulnessDetector(RequirementBasedDetector):
             temperature=0.1,
             max_tokens=1,
             caller_id=self.__class__.__name__,
-            rng_seed=self.rng_seed,
+            seed=self.rng_seed,
         )
 
         if out.content.strip().upper() != "Y":

--- a/giskard/scanner/llm/llm_output_formatting_detector.py
+++ b/giskard/scanner/llm/llm_output_formatting_detector.py
@@ -66,6 +66,7 @@ class LLMOutputFormattingDetector(RequirementBasedDetector):
             temperature=0.1,
             max_tokens=1,
             caller_id=self.__class__.__name__,
+            seed=self.rng_seed,
         )
 
         if out.content.strip().upper() != "Y":

--- a/giskard/testing/tests/llm/correctness.py
+++ b/giskard/testing/tests/llm/correctness.py
@@ -11,7 +11,7 @@ from .. import debug_description_prefix
     tags=["llm", "llm-as-a-judge"],
     debug_description=debug_description_prefix + "that are <b>failing the evaluation criteria</b>.",
 )
-def test_llm_correctness(model: BaseModel, dataset: Dataset, threshold: float = 0.5):
+def test_llm_correctness(model: BaseModel, dataset: Dataset, threshold: float = 0.5, rng_seed: int = 1729):
     """Tests if LLM answers are correct with respect to a known reference answers.
 
     The test is passed when the ratio of correct answers is higher than the
@@ -31,7 +31,7 @@ def test_llm_correctness(model: BaseModel, dataset: Dataset, threshold: float = 
     TestResult
         A TestResult object containing the test result.
     """
-    correctness_evaluator = CorrectnessEvaluator()
+    correctness_evaluator = CorrectnessEvaluator(rng_seed=rng_seed)
     eval_result = correctness_evaluator.evaluate(model, dataset)
     output_ds = list()
     if not eval_result.passed:

--- a/giskard/testing/tests/llm/ground_truth.py
+++ b/giskard/testing/tests/llm/ground_truth.py
@@ -82,7 +82,7 @@ def test_llm_ground_truth_similarity(
     debug_description=debug_description_prefix + "that are <b>failing the evaluation criteria</b>.",
 )
 def test_llm_as_a_judge_ground_truth_similarity(
-    model: BaseModel, dataset: Dataset, prefix: str = "The requirement should be similar to: "
+    model: BaseModel, dataset: Dataset, prefix: str = "The requirement should be similar to: ", rng_seed: int = 1729
 ):
     """Evaluates the model output against its ground truth  with another LLM (LLM-as-a-judge).
 
@@ -108,5 +108,5 @@ def test_llm_as_a_judge_ground_truth_similarity(
         raise ValueError(f"Provided dataset ({dataset}) does not have any ground truth (target)")
 
     return _test_output_against_requirement(
-        model, dataset, PerRowRequirementEvaluator(dataset.df.loc[:, [dataset.target]], prefix)
+        model, dataset, PerRowRequirementEvaluator(dataset.df.loc[:, [dataset.target]], prefix, rng_seed=rng_seed)
     )

--- a/giskard/testing/tests/llm/hallucination.py
+++ b/giskard/testing/tests/llm/hallucination.py
@@ -10,7 +10,11 @@ from ....registry.decorators import test
 
 @test(name="LLM Coherency", tags=["llm", "hallucination"])
 def test_llm_output_coherency(
-    model: BaseModel, dataset_1: Dataset, dataset_2: Optional[Dataset] = None, eval_prompt: Optional[str] = None
+    model: BaseModel,
+    dataset_1: Dataset,
+    dataset_2: Optional[Dataset] = None,
+    eval_prompt: Optional[str] = None,
+    rng_seed: int = 1729,
 ):
     """Tests that the model output is coherent for multiple inputs.
 
@@ -34,7 +38,7 @@ def test_llm_output_coherency(
     TestResult
         The test result.
     """
-    evaluator = CoherencyEvaluator(eval_prompt=eval_prompt)
+    evaluator = CoherencyEvaluator(eval_prompt=eval_prompt, rng_seed=rng_seed)
     eval_result = evaluator.evaluate(model, dataset_1, dataset_2)
 
     return TestResult(

--- a/giskard/testing/tests/llm/output_requirements.py
+++ b/giskard/testing/tests/llm/output_requirements.py
@@ -31,7 +31,9 @@ def _test_output_against_requirement(model, dataset, evaluator):
     tags=["llm", "llm-as-a-judge"],
     debug_description=debug_description_prefix + "that are <b>failing the evaluation criteria</b>.",
 )
-def test_llm_output_against_requirement_per_row(model: BaseModel, dataset: Dataset, requirement_column: str):
+def test_llm_output_against_requirement_per_row(
+    model: BaseModel, dataset: Dataset, requirement_column: str, rng_seed: int = 1729
+):
     """Evaluates the model output against a given requirement with another LLM (LLM-as-a-judge).
 
     The model outputs over a given dataset will be validated against the
@@ -58,7 +60,7 @@ def test_llm_output_against_requirement_per_row(model: BaseModel, dataset: Datas
         A TestResult object containing the test result.
     """
     return _test_output_against_requirement(
-        model, dataset, PerRowRequirementEvaluator(dataset.df.loc[:, [requirement_column]])
+        model, dataset, PerRowRequirementEvaluator(dataset.df.loc[:, [requirement_column]], rng_seed=rng_seed)
     )
 
 
@@ -67,7 +69,7 @@ def test_llm_output_against_requirement_per_row(model: BaseModel, dataset: Datas
     tags=["llm", "llm-as-a-judge"],
     debug_description=debug_description_prefix + "that are <b>failing the evaluation criteria</b>.",
 )
-def test_llm_output_against_requirement(model: BaseModel, dataset: Dataset, requirement: str):
+def test_llm_output_against_requirement(model: BaseModel, dataset: Dataset, requirement: str, rng_seed: int = 1729):
     """Evaluates the model output against a given requirement with another LLM (LLM-as-a-judge).
 
     The model outputs over a given dataset will be validated against the
@@ -93,7 +95,7 @@ def test_llm_output_against_requirement(model: BaseModel, dataset: Dataset, requ
     TestResult
         A TestResult object containing the test result.
     """
-    return _test_output_against_requirement(model, dataset, RequirementEvaluator([requirement]))
+    return _test_output_against_requirement(model, dataset, RequirementEvaluator([requirement], rng_seed=rng_seed))
 
 
 @test(
@@ -102,7 +104,7 @@ def test_llm_output_against_requirement(model: BaseModel, dataset: Dataset, requ
     debug_description=debug_description_prefix + "that are <b>failing the evaluation criteria</b>.",
 )
 def test_llm_single_output_against_requirement(
-    model: BaseModel, input_var: str, requirement: str, input_as_json: bool = False
+    model: BaseModel, input_var: str, requirement: str, input_as_json: bool = False, rng_seed: int = 1729
 ):
     """Evaluates the model output against a given requirement with another LLM (LLM-as-a-judge).
 
@@ -152,4 +154,4 @@ def test_llm_single_output_against_requirement(
     )
 
     # Run normal output requirement test
-    return _test_output_against_requirement(model, dataset, RequirementEvaluator([requirement]))
+    return _test_output_against_requirement(model, dataset, RequirementEvaluator([requirement], rng_seed=rng_seed))

--- a/tests/testing/test_llm_output_requirement.py
+++ b/tests/testing/test_llm_output_requirement.py
@@ -35,7 +35,7 @@ def test_llm_output_requirement(RequirementEvaluator):
     assert res.output_df is None
 
     RequirementEvaluator.assert_called_once_with(
-        ["The model should not generate content that incites harm or violence"]
+        ["The model should not generate content that incites harm or violence"], rng_seed=1729
     )
     RequirementEvaluator.return_value.evaluate.assert_called_once_with(model, dataset)
 
@@ -94,7 +94,7 @@ def test_llm_single_output_requirement(RequirementEvaluator):
     assert res.output_df is None
 
     RequirementEvaluator.assert_called_once_with(
-        ["The model should not generate content that incites harm or violence"]
+        ["The model should not generate content that incites harm or violence"], rng_seed=1729
     )
     RequirementEvaluator.return_value.evaluate.assert_called_once()
     assert RequirementEvaluator.return_value.evaluate.call_args[0][0] == model


### PR DESCRIPTION
## Description

Added `rng_seed` param to evaluators, generators and tests using LLM in. order to ensure reproducibility. 

## Related Issue

- [GSK-2376 (Available on Linear)](https://linear.app/giskard/issue/GSK-2376/add-seed-to-llm-generators-and-evaluators-in-order-to-ensure)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
