### PR TITLE
[GSK-2920] Fallback to english if `num2words` does not implement in a language

### DIFF
--- a/giskard/scanner/robustness/text_transformations.py
+++ b/giskard/scanner/robustness/text_transformations.py
@@ -292,7 +292,11 @@ class TextNumberToWordTransformation(TextLanguageBasedTransformation):
             # Give up doing this now, wait for merging https://github.com/savoirfairelinux/num2words/pull/524
             return value
 
-        return self._regex.sub(lambda x: num2words(x.group(), lang=lang), value)
+        try:
+            return self._regex.sub(lambda x: num2words(x.group(), lang=lang), value)
+        except NotImplementedError:
+            # Fallback to english in case of unimplemented
+            return self._regex.sub(lambda x: num2words(x.group(), lang="en"), value)
 
 
 class TextReligionTransformation(TextLanguageBasedTransformation):


### PR DESCRIPTION
## Description

During the scan, I found failed Robustness detector for some models with some datasets.

The reason is that `num2words` does not implement all languages, it could raise `NotImplementedError`. In this case, the lib recommends to have a fallback to English.

## Related Issue

[GSK-2920] TextPerturbationDetector failed with error: 'NotImplementedError'

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
