### PR TITLE
GSK-3241 Make `kernel_name` the last argument of `create_project`

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -229,7 +229,7 @@ class GiskardClient:
             },
         )
 
-    def create_project(self, project_key: str, name: str, kernel_name: str = None, description: str = None) -> Project:
+    def create_project(self, project_key: str, name: str, description: str = None, kernel_name: str = None) -> Project:
         """Function to create a project in Giskard
 
         Parameters
@@ -238,10 +238,10 @@ class GiskardClient:
             The unique value of the project which will be used to identify  and fetch the project in future
         name : str
             The name of the project
-        kernel_name : str
-            The name of the kernel to run on
         description : str, optional
             Describe your project, by default None
+        kernel_name : str
+            The name of the kernel to run on
 
         Returns
         -------


### PR DESCRIPTION
## Description

Make `kernel_name` the last argument of `create_project`

## Related Issue

- [GSK-3241 (Available on Linear)](https://linear.app/giskard/issue/GSK-3241/check-create-project-=-kernel-should-be-last-argument)

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
