### PR TITLE
[GSK-3303] Fix validation issue with tuple, also fixes param names

### DIFF
--- a/giskard/llm/evaluators/string_matcher.py
+++ b/giskard/llm/evaluators/string_matcher.py
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 
 @dataclass(frozen=True)
 class StringMatcherConfig:
-    expected_strings: Tuple[str]
+    expected_strings: Tuple[str, ...]
     all_expected_strings_must_be_found: bool = True
     exact_matching: bool = False
     word_matching: bool = False

--- a/giskard/testing/tests/llm/injections.py
+++ b/giskard/testing/tests/llm/injections.py
@@ -317,25 +317,25 @@ def test_llm_single_output_against_strings(
     dataset : Dataset
         A dataset of adversarial prompts.
     expected_strings : List[str]
-        A list of substrings that needs to be found in the model's output in
+        A list of expected_strings that needs to be found in the model's output in
         order to classify it as a failure.
     all_expected_strings_must_be_found : bool
         A flag to indicate whether all (True, default) or any (False) of the
-        substrings must be found in order to
+        expected_strings must be found in order to
         classify the output as a failure. Default: True
     exact_matching : bool
-        A flag to indicate whether the substrings (typically one) needs to match
+        A flag to indicate whether the expected_strings (typically one) needs to match
         exactly the model's output in order to classify it as a failure.
         Default: False.
     word_matching : bool
-        A flag to indicate whether the substrings should be found as independent
+        A flag to indicate whether the expected_strings should be found as independent
         words in the model's output in order to classify it as a failure.
         Default: False
     case_sensitive : bool
-        A flag to indicate whether the substrings matching should be
+        A flag to indicate whether the expected_strings matching should be
         case-sensitive or not. Default: True
     punctuation_sensitive : bool
-        A flag to indicate whether the substrings matching should be
+        A flag to indicate whether the expected_strings matching should be
         punctuation-sensitive or not. Default: True
     threshold : float
         Threshold for the fail rate, by default 0.5. If the fail rate is above
@@ -404,21 +404,21 @@ def test_llm_output_against_strings(
         A dataset of adversarial prompts.
     evaluator_configs : List[StringMatcherConfig]
         A list of StringMatcherConfig that has the following attributes:
-            - substrings : List[str]
-                A list of substrings that needs to be found in the model's output in order to classify it as a failure.
-            - all_substrings_must_be_found : bool
-                A flag to indicate whether all (True, default) or any (False) of the substrings must be found in order to
+            - expected_strings : List[str]
+                A list of expected_strings that needs to be found in the model's output in order to classify it as a failure.
+            - all_expected_strings_must_be_found : bool
+                A flag to indicate whether all (True, default) or any (False) of the expected_strings must be found in order to
                 classify the output as a failure. Default: True
             - exact_matching : bool
-                A flag to indicate whether the substrings (typically one) needs to match exactly the model's output in order to
+                A flag to indicate whether the expected_strings (typically one) needs to match exactly the model's output in order to
                 classify it as a failure. Default: False
             - word_matching : bool
-                A flag to indicate whether the substrings should be found as independent words in the model's output in order to
+                A flag to indicate whether the expected_strings should be found as independent words in the model's output in order to
                 classify it as a failure. Default: False
             - case_sensitive : bool
-                A flag to indicate whether the substrings matching should be case-sensitive or not. Default: True
+                A flag to indicate whether the expected_strings matching should be case-sensitive or not. Default: True
             - punctuation_sensitive : bool
-                A flag to indicate whether the substrings matching should be punctuation-sensitive or not. Default: True
+                A flag to indicate whether the expected_strings matching should be punctuation-sensitive or not. Default: True
     threshold : float
         Threshold for the fail rate, by default 0.5. If the fail rate is above
         this threshold, the test will fail.

--- a/giskard/testing/tests/llm/injections.py
+++ b/giskard/testing/tests/llm/injections.py
@@ -292,9 +292,9 @@ def _test_llm_output_against_strings(model, dataset, configs, threshold, **_kwar
 def test_llm_single_output_against_strings(
     model: BaseModel,
     input_var: str,
-    substrings: List[str],
+    expected_strings: List[str],
     input_as_json: bool = False,
-    all_substrings_must_be_found: bool = True,
+    all_expected_strings_must_be_found: bool = True,
     exact_matching: bool = False,
     word_matching: bool = False,
     case_sensitive: bool = True,
@@ -316,10 +316,10 @@ def test_llm_single_output_against_strings(
         The model to test.
     dataset : Dataset
         A dataset of adversarial prompts.
-    substrings : List[str]
+    expected_strings : List[str]
         A list of substrings that needs to be found in the model's output in
         order to classify it as a failure.
-    all_substrings_must_be_found : bool
+    all_expected_strings_must_be_found : bool
         A flag to indicate whether all (True, default) or any (False) of the
         substrings must be found in order to
         classify the output as a failure. Default: True
@@ -357,8 +357,8 @@ def test_llm_single_output_against_strings(
 
     # The evaluation method is fixed for all the prompts in the dataset
     config_kwargs = {
-        "expected_strings": substrings,
-        "all_expected_strings_must_be_found": all_substrings_must_be_found,
+        "expected_strings": expected_strings,
+        "all_expected_strings_must_be_found": all_expected_strings_must_be_found,
         "exact_matching": exact_matching,
         "word_matching": word_matching,
         "case_sensitive": case_sensitive,

--- a/giskard/testing/tests/llm/injections.py
+++ b/giskard/testing/tests/llm/injections.py
@@ -357,8 +357,8 @@ def test_llm_single_output_against_strings(
 
     # The evaluation method is fixed for all the prompts in the dataset
     config_kwargs = {
-        "substrings": substrings,
-        "all_substrings_must_be_found": all_substrings_must_be_found,
+        "expected_strings": substrings,
+        "all_expected_strings_must_be_found": all_substrings_must_be_found,
         "exact_matching": exact_matching,
         "word_matching": word_matching,
         "case_sensitive": case_sensitive,
@@ -378,7 +378,7 @@ def test_llm_single_output_against_strings(
         column_types={k: "text" for k in input_sample.keys()},
     )
 
-    return _test_llm_output_against_strings(model, dataset, configs, threshold, debug)
+    return _test_llm_output_against_strings(model, dataset, configs, threshold, debug=debug)
 
 
 @test(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
