### PR TITLE
[GSK-3318] Make it possible to define a Project Type when creating a Hub project

### DIFF
--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from enum import Enum
 
-from pydantic import Field
+from pydantic import Field, field_serializer, model_serializer
 
 from giskard.core.core import TestResultStatusEnum
 from giskard.core.validation import ConfiguredBaseModel
@@ -142,3 +142,27 @@ class DatasetMetaInfo(ConfiguredBaseModel):
     compressedSizeBytes: int
     createdDate: str
     id: str
+
+
+class ProjectPostDTO(ConfiguredBaseModel):
+    key: str
+    name: str
+    project_type: str
+    description: Optional[str] = None
+
+    @field_serializer('project_type')
+    def serialize_project_type(self, project_type: str) -> str:
+        mapped_type = {
+            "llm": "LLM",
+            "tabular": "Tabular",
+        }
+        return mapped_type[project_type]
+
+    @model_serializer(when_used='always')
+    def ser_model(self) -> Dict[str, Any]:
+        return {
+            "key": self.key,
+            "name": self.name,
+            "type": self.serialize_project_type(self.project_type),
+            "description": self.description
+        }

--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -4,7 +4,6 @@ from enum import Enum
 
 from pydantic import Field, field_serializer, model_serializer
 
-from giskard.client.project import ProjectType
 from giskard.core.core import TestResultStatusEnum
 from giskard.core.validation import ConfiguredBaseModel
 from giskard.utils.artifacts import serialize_parameter
@@ -143,6 +142,11 @@ class DatasetMetaInfo(ConfiguredBaseModel):
     compressedSizeBytes: int
     createdDate: str
     id: str
+
+
+class ProjectType(Enum):
+    TABULAR = "tabular"
+    LLM = "llm"
 
 
 class ProjectPostDTO(ConfiguredBaseModel):

--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -4,10 +4,10 @@ from enum import Enum
 
 from pydantic import Field, field_serializer, model_serializer
 
+from giskard.client.project import ProjectType
 from giskard.core.core import TestResultStatusEnum
 from giskard.core.validation import ConfiguredBaseModel
 from giskard.utils.artifacts import serialize_parameter
-from giskard.client.project import ProjectType
 
 
 class TestInputDTO(ConfiguredBaseModel):
@@ -154,7 +154,7 @@ class ProjectPostDTO(ConfiguredBaseModel):
     class Config:
         use_enum_values = True
 
-    @field_serializer('project_type')
+    @field_serializer("project_type")
     def serialize_project_type(self, project_type: ProjectType) -> str:
         mapped_type = {
             "llm": "LLM",
@@ -162,11 +162,11 @@ class ProjectPostDTO(ConfiguredBaseModel):
         }
         return mapped_type[project_type]
 
-    @model_serializer(when_used='always')
+    @model_serializer(when_used="always")
     def ser_model(self) -> Dict[str, Any]:
         return {
             "key": self.key,
             "name": self.name,
             "type": self.serialize_project_type(self.project_type),
-            "description": self.description
+            "description": self.description,
         }

--- a/giskard/client/dtos.py
+++ b/giskard/client/dtos.py
@@ -7,6 +7,7 @@ from pydantic import Field, field_serializer, model_serializer
 from giskard.core.core import TestResultStatusEnum
 from giskard.core.validation import ConfiguredBaseModel
 from giskard.utils.artifacts import serialize_parameter
+from giskard.client.project import ProjectType
 
 
 class TestInputDTO(ConfiguredBaseModel):
@@ -147,11 +148,14 @@ class DatasetMetaInfo(ConfiguredBaseModel):
 class ProjectPostDTO(ConfiguredBaseModel):
     key: str
     name: str
-    project_type: str
+    project_type: ProjectType
     description: Optional[str] = None
 
+    class Config:
+        use_enum_values = True
+
     @field_serializer('project_type')
-    def serialize_project_type(self, project_type: str) -> str:
+    def serialize_project_type(self, project_type: ProjectType) -> str:
         mapped_type = {
             "llm": "LLM",
             "tabular": "Tabular",

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -171,7 +171,7 @@ class GiskardClient:
     def list_projects(self) -> List[Project]:
         analytics.track("List Projects")
         response = self._session.get("projects").json()
-        return [Project(self._session, p["key"], p["id"]) for p in response]
+        return [Project(self._session, p["key"], p["id"], p["type"].lower()) for p in response]
 
     def get_project(self, project_key: str) -> Project:
         """
@@ -185,7 +185,7 @@ class GiskardClient:
         """
         analytics.track("Get Project", {"project_key": anonymize(project_key)})
         response = self._session.get("project", params={"key": project_key}).json()
-        return Project(self._session, response["key"], response["id"])
+        return Project(self._session, response["key"], response["id"], response["type"].lower())
 
     def create_project(
         self, project_key: str, name: str, description: str = None, project_type: ProjectType = "tabular"
@@ -232,9 +232,10 @@ class GiskardClient:
             raise e
         actual_project_key = response.get("key")
         actual_project_id = response.get("id")
+        actual_project_type = response.get("type").lower()
         if actual_project_key != project_key:
             print(f"Project created with a key : {actual_project_key}")
-        return Project(self._session, actual_project_key, actual_project_id)
+        return Project(self._session, actual_project_key, actual_project_id, actual_project_type)
 
     def get_suite(self, project_id: int, suite_id: int) -> SuiteInfo:
         analytics.track("Get suite", {"suite_id": suite_id})

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -187,7 +187,9 @@ class GiskardClient:
         response = self._session.get("project", params={"key": project_key}).json()
         return Project(self._session, response["key"], response["id"])
 
-    def create_project(self, project_key: str, name: str, project_type: ProjectType, description: str = None) -> Project:
+    def create_project(
+        self, project_key: str, name: str, description: str = None,  project_type: ProjectType = "tabular"
+    ) -> Project:
         """
         Function to create a project in Giskard
         Args:
@@ -195,10 +197,10 @@ class GiskardClient:
                 The unique value of the project which will be used to identify  and fetch the project in future
             name:
                 The name of the project
-            project_type:
-                The type of the project ["tabular", "llm"]
             description:
                 Describe your project
+            project_type:
+                The type of the project ["tabular", "llm"]
         Returns:
             Project:
                 The project created in giskard
@@ -207,12 +209,15 @@ class GiskardClient:
             "Create Project",
             {
                 "project_key": anonymize(project_key),
+                "project_type": project_type,
                 "description": anonymize(description),
                 "name": anonymize(name),
             },
         )
         try:
-            project_post_dto = ProjectPostDTO(key=project_key, name=name, project_type=project_type, description=description)
+            project_post_dto = ProjectPostDTO(
+                key=project_key, name=name, project_type=project_type, description=description
+            )
 
             response = self._session.post(
                 "project",

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -241,7 +241,11 @@ class GiskardClient:
 
     def get_suite(self, project_id: int, suite_id: int) -> SuiteInfo:
         analytics.track("Get suite", {"suite_id": suite_id})
-        return SuiteInfo.parse_obj(self._session.get(f"testing/project/{project_id}/suite/{suite_id}").json())
+
+        response = self._session.get(f"testing/project/{project_id}/suite/{suite_id}").json()
+        del response["type"]
+
+        return SuiteInfo.parse_obj(response)
 
     def load_model_meta(self, project_key: str, uuid: str) -> ModelMetaInfo:
         res = self._session.get(f"project/{project_key}/models/{uuid}").json()

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -22,9 +22,10 @@ from giskard.client.dtos import (
     ServerInfo,
     SuiteInfo,
     TestSuiteDTO,
+    ProjectPostDTO,
 )
 from giskard.client.io_utils import GiskardJSONSerializer
-from giskard.client.project import Project
+from giskard.client.project import Project, ProjectType
 from giskard.client.python_utils import warning
 from giskard.core.core import SMT, DatasetMeta, ModelMeta, TestFunctionMeta
 from giskard.utils.analytics_collector import analytics, anonymize
@@ -186,7 +187,7 @@ class GiskardClient:
         response = self._session.get("project", params={"key": project_key}).json()
         return Project(self._session, response["key"], response["id"])
 
-    def create_project(self, project_key: str, name: str, description: str = None) -> Project:
+    def create_project(self, project_key: str, name: str, project_type: ProjectType, description: str = None) -> Project:
         """
         Function to create a project in Giskard
         Args:
@@ -194,6 +195,8 @@ class GiskardClient:
                 The unique value of the project which will be used to identify  and fetch the project in future
             name:
                 The name of the project
+            project_type:
+                The type of the project ["tabular", "llm"]
             description:
                 Describe your project
         Returns:
@@ -209,9 +212,11 @@ class GiskardClient:
             },
         )
         try:
+            project_post_dto = ProjectPostDTO(key=project_key, name=name, project_type=project_type, description=description)
+
             response = self._session.post(
                 "project",
-                json={"description": description, "key": project_key, "name": name},
+                json=project_post_dto.model_dump(),
             ).json()
         except GiskardError as e:
             if e.code == "error.http.409":

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -18,11 +18,11 @@ import giskard
 from giskard.client.dtos import (
     DatasetMetaInfo,
     ModelMetaInfo,
+    ProjectPostDTO,
     SaveSuiteExecutionDTO,
     ServerInfo,
     SuiteInfo,
     TestSuiteDTO,
-    ProjectPostDTO,
 )
 from giskard.client.io_utils import GiskardJSONSerializer
 from giskard.client.project import Project, ProjectType
@@ -188,7 +188,7 @@ class GiskardClient:
         return Project(self._session, response["key"], response["id"])
 
     def create_project(
-        self, project_key: str, name: str, description: str = None,  project_type: ProjectType = "tabular"
+        self, project_key: str, name: str, description: str = None, project_type: ProjectType = "tabular"
     ) -> Project:
         """
         Function to create a project in Giskard

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -1,4 +1,5 @@
 """API Client to interact with the Giskard app"""
+
 from typing import List
 
 import json
@@ -19,13 +20,14 @@ from giskard.client.dtos import (
     DatasetMetaInfo,
     ModelMetaInfo,
     ProjectPostDTO,
+    ProjectType,
     SaveSuiteExecutionDTO,
     ServerInfo,
     SuiteInfo,
     TestSuiteDTO,
 )
 from giskard.client.io_utils import GiskardJSONSerializer
-from giskard.client.project import Project, ProjectType
+from giskard.client.project import Project
 from giskard.client.python_utils import warning
 from giskard.core.core import SMT, DatasetMeta, ModelMeta, TestFunctionMeta
 from giskard.utils.analytics_collector import analytics, anonymize

--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -1,7 +1,8 @@
+from enum import Enum
+
 from requests_toolbelt.sessions import BaseUrlSession
 
 from giskard.utils.analytics_collector import analytics, anonymize
-from enum import Enum
 
 
 class ProjectType(Enum):

--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -1,6 +1,12 @@
 from requests_toolbelt.sessions import BaseUrlSession
 
 from giskard.utils.analytics_collector import analytics, anonymize
+from enum import Enum
+
+
+class ProjectType(Enum):
+    TABULAR = "tabular"
+    LLM = "llm"
 
 
 class Project:

--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -11,11 +11,14 @@ class ProjectType(Enum):
 
 
 class Project:
-    def __init__(self, session: BaseUrlSession, project_key: str, project_id: int) -> None:
+    def __init__(
+        self, session: BaseUrlSession, project_key: str, project_id: int, project_type: ProjectType = "tabular"
+    ) -> None:
         self.project_key = project_key
         self._session = session
         self.url = self._session.base_url.replace("/api/v2/", "")
         self.project_id = project_id
+        self.project_type = project_type
 
     def _update_test_suite_params(self, actual_ds_id, reference_ds_id, model_id, test_id=None, test_suite_id=None):
         assert test_id is not None or test_suite_id is not None, "Either test_id or test_suite_id should be specified"
@@ -89,4 +92,4 @@ class Project:
         return [self._execution_dto_filter(test) for test in answer_json]
 
     def __repr__(self) -> str:
-        return f"GiskardProject(project_key='{self.project_key}')"
+        return f"GiskardProject(project_key='{self.project_key}', project_type='{self.project_type}')"

--- a/giskard/client/project.py
+++ b/giskard/client/project.py
@@ -1,13 +1,7 @@
-from enum import Enum
-
 from requests_toolbelt.sessions import BaseUrlSession
 
+from giskard.client.dtos import ProjectType
 from giskard.utils.analytics_collector import analytics, anonymize
-
-
-class ProjectType(Enum):
-    TABULAR = "tabular"
-    LLM = "llm"
 
 
 class Project:

--- a/tests/integrations/test_wandb.py
+++ b/tests/integrations/test_wandb.py
@@ -1,6 +1,6 @@
 import pytest
-import wandb
 
+import wandb
 from giskard import scan
 from giskard.models.model_explanation import explain_with_shap
 

--- a/tests/integrations/test_wandb.py
+++ b/tests/integrations/test_wandb.py
@@ -1,6 +1,6 @@
 import pytest
-
 import wandb
+
 from giskard import scan
 from giskard.models.model_explanation import explain_with_shap
 

--- a/tests/test_programmatic.py
+++ b/tests/test_programmatic.py
@@ -297,7 +297,7 @@ def test_save_suite_real_debug(german_credit_data: Dataset, german_credit_model:
     from giskard.client.giskard_client import GiskardClient
 
     client = GiskardClient("http://localhost:9000", "API_KEY")
-    client.create_project("test_debug", "test_debug", "test_debug")
+    client.create_project("test_debug", "test_debug", "test_debug", "tabular")
 
     german_credit_data.upload(client, "test_debug")
     german_credit_data_actual = german_credit_data.copy()
@@ -432,6 +432,7 @@ def test_download_suite_run_and_upload_results():
                 ],
                 "id": 2,
                 "projectKey": "test_project",
+                "type": "Tabular",
             },
         )
         register_uri_for_artifact_meta_info(mr, test_auc)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -86,7 +86,7 @@ class MockedClient:
         self.mocked_requests.register_uri(
             requests_mock.GET,
             "http://giskard-host:12345/api/v2/project?key=test_project",
-            json={"key": "test_project", "id": 1},
+            json={"key": "test_project", "id": 1, "type": "Tabular"},
         )
         self.mocked_requests.register_uri(
             requests_mock.GET,


### PR DESCRIPTION
## Description

This PR modifies the current `Project` entity, adding a new property called `project_type`. In a first moment, we'll have two `project_type` values available: `tabular` and `llm`. 

If no `project_type` is set when calling `GiskardClient.create_project(...)`, the project type will assume the default value as `tabular`.

## Related Issue

[GSK-3318 (available on Linear)](https://linear.app/giskard/issue/GSK-3318/as-an-engineer-i-want-to-create-a-llm-project-from-python-code)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
