### PR TITLE
[GSK-3419] Add mixpanel telemetry to new client methods 

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -195,8 +195,9 @@ class GiskardClient:
         kernel_name = f"{project_key}_kernel"
 
         analytics.track(
-            "Get kernel",
+            "Init kernel from env",
             {
+                "project_key": anonymize(project_key),
                 "kernel_name": anonymize(kernel_name),
                 "python_version": python_version,
             },

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -194,6 +194,14 @@ class GiskardClient:
         python_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
         kernel_name = f"{project_key}_kernel"
 
+        analytics.track(
+            "Get kernel",
+            {
+                "kernel_name": anonymize(kernel_name),
+                "python_version": python_version,
+            },
+        )
+
         kernels = self._session.get("kernels").json()
         frozen_dependencies = [f"{dist.name}=={dist.version}" for dist in importlib_metadata.distributions()]
 
@@ -217,6 +225,15 @@ class GiskardClient:
     def create_kernel(
         self, kernel_name: str, python_version: str, requestedDependencies: str = "", frozen_dependencies: str = ""
     ):
+        analytics.track(
+            "Create kernel",
+            {
+                "kernel_name": anonymize(kernel_name),
+                "python_version": python_version,
+                "requestedDependencies": requestedDependencies,
+            },
+        )
+
         self._session.post(
             "kernels",
             json={
@@ -230,10 +247,12 @@ class GiskardClient:
         )
 
     def start_managed_worker(self, kernel_name: str):
+        analytics.track("Start worker", {"kernel_name": anonymize(kernel_name)})
         self._session.post(f"kernels/start/{kernel_name}")
         logger.info("The worker is starting up")
 
     def stop_managed_worker(self, kernel_name: str):
+        analytics.track("Stop worker", {"kernel_name": anonymize(kernel_name)})
         self._session.post(f"kernels/stop/{kernel_name}")
         logger.info("The worker has been requested to stop")
 


### PR DESCRIPTION
## Description
This PR adds telemetry to the new methods regarding Multi ML Worker implemented in `GiskardClient`.

## Related Issue
[GSK-3419 (available on Linear)](https://linear.app/giskard/issue/GSK-3419/add-mixpanel-telemetry)

## Type of Change
- [ ] :books: Examples / docs / tutorials / dependencies update
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue)
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature)
- [ ] :rocket: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change)
- [ ] :closed_lock_with_key: Security fix