### PR TITLE
[GSK-3430] Check if we can detect the version of giskard library

### DIFF
--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -235,7 +235,7 @@ class GiskardClient:
             {
                 "kernel_name": anonymize(kernel_name),
                 "python_version": python_version,
-                "requestedDependencies": requestedDependencies,
+                "requestedDependencies": requested_dependencies,
             },
         )
 

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -29,7 +29,7 @@ from giskard.client.dtos import (
 )
 from giskard.client.io_utils import GiskardJSONSerializer
 from giskard.client.project import Project
-from giskard.client.python_utils import warning
+from giskard.client.python_utils import format_pylib_extras, warning
 from giskard.core.core import SMT, DatasetMeta, ModelMeta, TestFunctionMeta
 from giskard.utils.analytics_collector import analytics, anonymize
 
@@ -190,12 +190,15 @@ class GiskardClient:
         response = self._session.get("project", params={"key": project_key}).json()
         return Project(self._session, response["key"], response["id"])
 
-    def initialize_kernel(self, project_key: str):
+    def initialize_kernel(self, project_key: str, exact_deps: bool = False):
         python_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
         kernel_name = f"{project_key}_kernel"
 
         kernels = self._session.get("kernels").json()
-        frozen_dependencies = [f"{dist.name}=={dist.version}" for dist in importlib_metadata.distributions()]
+        frozen_dependencies = [
+            f"{dist.name}{format_pylib_extras(dist.name) if exact_deps or dist.name == 'giskard' else ''}=={dist.version}"
+            for dist in importlib_metadata.distributions()
+        ]
 
         existing_kernel = next((kernel for kernel in kernels if kernel["name"] == kernel_name), None)
 
@@ -215,14 +218,14 @@ class GiskardClient:
         return kernel_name
 
     def create_kernel(
-        self, kernel_name: str, python_version: str, requestedDependencies: str = "", frozen_dependencies: str = ""
+        self, kernel_name: str, python_version: str, requested_dependencies: str = "", frozen_dependencies: str = ""
     ):
         self._session.post(
             "kernels",
             json={
                 "name": kernel_name,
                 "pythonVersion": python_version,
-                "requestedDependencies": requestedDependencies,
+                "requestedDependencies": requested_dependencies,
                 "frozenDependencies": frozen_dependencies,
                 "type": "PROCESS",
                 "version": 0,

--- a/giskard/client/giskard_client.py
+++ b/giskard/client/giskard_client.py
@@ -29,7 +29,7 @@ from giskard.client.dtos import (
 )
 from giskard.client.io_utils import GiskardJSONSerializer
 from giskard.client.project import Project
-from giskard.client.python_utils import format_pylib_extras, warning
+from giskard.client.python_utils import EXCLUDED_PYLIBS, format_pylib_extras, warning
 from giskard.core.core import SMT, DatasetMeta, ModelMeta, TestFunctionMeta
 from giskard.utils.analytics_collector import analytics, anonymize
 
@@ -190,7 +190,7 @@ class GiskardClient:
         response = self._session.get("project", params={"key": project_key}).json()
         return Project(self._session, response["key"], response["id"])
 
-    def initialize_kernel(self, project_key: str, exact_deps: bool = False):
+    def initialize_kernel(self, project_key: str, exact_deps: bool = False, excludes: List[str] = EXCLUDED_PYLIBS):
         python_version = f"{sys.version_info[0]}.{sys.version_info[1]}"
         kernel_name = f"{project_key}_kernel"
 
@@ -198,6 +198,7 @@ class GiskardClient:
         frozen_dependencies = [
             f"{dist.name}{format_pylib_extras(dist.name) if exact_deps or dist.name == 'giskard' else ''}=={dist.version}"
             for dist in importlib_metadata.distributions()
+            if dist.name not in excludes
         ]
 
         existing_kernel = next((kernel for kernel in kernels if kernel["name"] == kernel_name), None)

--- a/giskard/client/python_utils.py
+++ b/giskard/client/python_utils.py
@@ -7,6 +7,12 @@ from platform import python_version
 
 import importlib_metadata
 
+# Libs to be excluded when create a kernel automatically from the current env
+EXCLUDED_PYLIBS = [
+    "setuptools",
+    "pip",
+]
+
 
 def get_python_requirements() -> str:
     pip_requirements = os.popen(f"{sys.executable} -m pip list --format freeze").read()

--- a/giskard/client/python_utils.py
+++ b/giskard/client/python_utils.py
@@ -5,6 +5,8 @@ import sys
 import warnings
 from platform import python_version
 
+import importlib_metadata
+
 
 def get_python_requirements() -> str:
     pip_requirements = os.popen(f"{sys.executable} -m pip list --format freeze").read()
@@ -24,3 +26,11 @@ def get_python_version() -> str:
 
 def warning(content: str):
     warnings.warn(content, stacklevel=2)
+
+
+def format_pylib_extras(name):
+    extras = importlib_metadata.metadata(name).get_all("Provides-Extra")
+    if not extras or len(extras) == 0:
+        return ""
+    else:
+        return f"[{', '.join(extras)}]"


### PR DESCRIPTION
## Description

Extract extra package information using `importlib_meta`:
- allows to set `exact_deps` in `initialize_kernel` to take all extra package information (but it could fail on managed side)
- otherwise, we just add for our "giskard"

The output should be:

```
giskard[hub, llm]==2.8.0
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
