### PR TITLE
[GSK-3495] Remove `eval_prompt` parameter from hallucination tests

### DIFF
--- a/giskard/testing/tests/llm/hallucination.py
+++ b/giskard/testing/tests/llm/hallucination.py
@@ -13,7 +13,6 @@ def test_llm_output_coherency(
     model: BaseModel,
     dataset_1: Dataset,
     dataset_2: Optional[Dataset] = None,
-    eval_prompt: Optional[str] = None,
     rng_seed: int = 1729,
 ):
     """Tests that the model output is coherent for multiple inputs.
@@ -29,16 +28,13 @@ def test_llm_output_coherency(
     dataset_2 : Optional[Dataset]
         Another sample dataset of inputs, with same index as ``dataset_1``. If
         not passed, we will rerun the model on ``dataset_1``.
-    eval_prompt : Optional[str]
-        Optional custom prompt to use for evaluation. If not provided, the
-        default prompt of :class:`.CoherencyEvaluator` will be used.
 
     Returns
     -------
     TestResult
         The test result.
     """
-    evaluator = CoherencyEvaluator(eval_prompt=eval_prompt, llm_seed=rng_seed)
+    evaluator = CoherencyEvaluator(llm_seed=rng_seed)
     eval_result = evaluator.evaluate(model, dataset_1, dataset_2)
 
     return TestResult(
@@ -50,7 +46,7 @@ def test_llm_output_coherency(
 
 
 @test(name="LLM Plausibility", tags=["llm", "hallucination"])
-def test_llm_output_plausibility(model: BaseModel, dataset: Dataset, eval_prompt: Optional[str] = None):
+def test_llm_output_plausibility(model: BaseModel, dataset: Dataset):
     """Tests that the model output is plausible.
 
     Parameters
@@ -59,16 +55,13 @@ def test_llm_output_plausibility(model: BaseModel, dataset: Dataset, eval_prompt
         The model to test.
     dataset : Dataset
         A sample dataset of inputs.
-    eval_prompt : Optional[str]
-        Optional custom prompt to use for evaluation. If not provided, the
-        default prompt of `CoherencyEvaluator` will be used.
 
     Returns
     -------
     TestResult
         The test result.
     """
-    evaluator = PlausibilityEvaluator(eval_prompt=eval_prompt)
+    evaluator = PlausibilityEvaluator()
     eval_result = evaluator.evaluate(model, dataset)
 
     return TestResult(


### PR DESCRIPTION
## Description
Hallucination tests, such as `test_llm_output_coherency` and `test_llm_output_plausibility`, have a `eval_prompt` parameter which is not used by the `_BaseLLMEvaluator`. These tests are trying to instantiate an evaluator passing this parameter, which outputs an error:

```
 Traceback (most recent call last):
  File "/Users/hchaves/GitHub/Giskard/giskard/giskard/core/suite.py", line 573, in run
    result = test_partial.giskard_test(**test_params).execute()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hchaves/GitHub/Giskard/giskard/giskard/registry/giskard_test.py", line 192, in execute
    return configured_validate_arguments(self.test_fn)(*self.args, **self.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hchaves/GitHub/Giskard/giskard/.venv/lib/python3.11/site-packages/pydantic/validate_call_decorator.py", line 59, in wrapper_function
    return validate_call_wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hchaves/GitHub/Giskard/giskard/.venv/lib/python3.11/site-packages/pydantic/_internal/_validate_call.py", line 81, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hchaves/GitHub/Giskard/giskard/giskard/testing/tests/llm/hallucination.py", line 41, in test_llm_output_coherency
    passed=eval_result.passed,
            ^^^^^^^^^^^^^^^^^^^
TypeError: _BaseLLMEvaluator.__init__() got an unexpected keyword argument 'eval_prompt'
```

To fix that issue, this PR removes the `eval_prompt` from hallucination tests.

## Related Issue

[GSK-3495 (available on Linear)](https://linear.app/giskard/issue/GSK-3495/unexpected-keyword-argument-eval-prompt)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
