### PR TITLE
Fixed dependencies installation on macos

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -72,7 +72,7 @@ jobs:
             pandas_v1: false
             langchain_minimal: false
           - python-version: "3.10"
-            os: macos-latest
+            os: macos-12
             pydantic_v1: false
             pandas_v1: false
             langchain_minimal: false
@@ -144,7 +144,7 @@ jobs:
           df -h
 
       - name: Re-install lightgbm from sources for MacOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-12' }}
         run: |
           pdm run pip uninstall lightgbm -y
           pdm run pip install --no-binary lightgbm lightgbm --config-settings=cmake.define.USE_OPENMP=OFF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ ml_runtime = [
     "tensorflow-text==2.14.0; python_version < '3.11' and (sys_platform == 'linux' or sys_platform == 'darwin') and platform_machine == 'x86_64'",
     "mlflow>2,<2.12", # version 2.12 throws error with imbalance-learn
     "wandb",
-    "tensorflow-io-gcs-filesystem<0.32; platform_machine != 'arm64'",                                                                              # Tensorflow io does not work for windows from 0.32, but does not work for arm64 before...
+    "tensorflow-io-gcs-filesystem<0.32; platform_machine != 'arm64'", # Tensorflow io does not work for windows from 0.32, but does not work for arm64 before...
 ]
 test = [
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
## Description

Fixed dependencies installation on macos build by using fixing macos-12.

To fix the installation on macos-14 (arm64), we would require to have two different groups: https://github.com/pdm-project/pdm/issues/2189#issuecomment-1682455896 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
