### PR TITLE
[GSK-3513] Fix RAGAS metric computation

### DIFF
--- a/giskard/rag/metrics/__init__.py
+++ b/giskard/rag/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .base import Metric
+from .base import Metric, ModelOutput
 from .correctness import CorrectnessMetric, correctness_metric
 
-__all__ = ["Metric", "correctness_metric", "CorrectnessMetric"]
+__all__ = ["Metric", "correctness_metric", "CorrectnessMetric", "ModelOutput"]

--- a/giskard/rag/metrics/base.py
+++ b/giskard/rag/metrics/base.py
@@ -1,6 +1,15 @@
+from typing import Sequence
+
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 from ...llm.client.base import LLMClient
+
+
+@dataclass
+class ModelOutput:
+    message: str
+    documents: Sequence[str] = field(default_factory=list)
 
 
 class Metric(ABC):
@@ -14,7 +23,7 @@ class Metric(ABC):
         self._llm_client = llm_client
 
     @abstractmethod
-    def __call__(self, question_sample: dict, answer: str):
+    def __call__(self, question_sample: dict, answer: ModelOutput):
         """
         Compute the metric on a single question and its associated answer.
 
@@ -28,6 +37,6 @@ class Metric(ABC):
         Returns
         -------
         dict
-            The result of the metric. The keys should be the names of the metrics computed.
+            The result of the metric computation. The keys should be the names of the metrics computed.
         """
         pass

--- a/giskard/rag/metrics/ragas_metrics.py
+++ b/giskard/rag/metrics/ragas_metrics.py
@@ -5,7 +5,8 @@ import logging
 import nest_asyncio
 
 from ...llm.client import ChatMessage, LLMClient, get_default_client
-from .base import Metric
+from ...llm.embeddings import BaseEmbedding, get_default_embedding
+from .base import Metric, ModelOutput
 
 nest_asyncio.apply()
 logger = logging.getLogger(__name__)
@@ -50,29 +51,38 @@ class RagasLLMWrapper(BaseRagasLLM):
 
 
 class RagasEmbeddingsWrapper(BaseRagasEmbeddings):
-    def __init__(self, llm_client):
-        self.llm_client = llm_client
+    def __init__(self, embedding_model):
+        self.embedding_model = embedding_model
 
     def embed_query(self, text: str) -> Sequence[float]:
-        return self.llm_client.embeddings([text])[0]
+        return self.embedding_model.embed([text])[0]
 
     def embed_documents(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
-        return self.llm_client.embeddings(texts)
+        return self.embedding_model.embed(texts)
 
 
 class RagasMetric(Metric):
     def __init__(
-        self, name: str, metric: BaseRagasMetric, context_window_length: int = 8192, llm_client: LLMClient = None
+        self,
+        name: str,
+        metric: BaseRagasMetric,
+        context_window_length: int = 8192,
+        llm_client: LLMClient = None,
+        embedding_model: BaseEmbedding = None,
+        requires_context=False,
     ) -> None:
         self.name = name
         self.metric = metric
         self.context_window_length = context_window_length
         self._llm_client = llm_client
+        self._embedding_model = embedding_model
+        self.requires_context = requires_context
 
-    def __call__(self, question_sample: dict, answer: str) -> dict:
+    def __call__(self, question_sample: dict, answer: ModelOutput) -> dict:
         llm_client = self._llm_client or get_default_client()
+        embedding_model = self._embedding_model or get_default_embedding()
         ragas_llm = RagasLLMWrapper(llm_client, self.context_window_length)
-        ragas_embedddings = RagasEmbeddingsWrapper(llm_client)
+        ragas_embedddings = RagasEmbeddingsWrapper(embedding_model)
 
         run_config = RunConfig()
 
@@ -82,17 +92,23 @@ class RagasMetric(Metric):
             self.metric.embeddings = ragas_embedddings
 
         self.metric.init(run_config)
+        if self.requires_context and answer.documents is None:
+            logger.warn(
+                "No retrieved documents are passed to the evaluation function, computation of {self.name} cannot be done without it."
+                "Make sure you pass 'retrieved_documents' to the evaluate function or that the 'answer_fn' return documents alongside the answer."
+            )
+            return {self.name: 0}
 
         ragas_sample = {
             "question": question_sample["question"],
-            "answer": answer,
-            "contexts": question_sample["reference_context"].split("\n\n"),
+            "answer": answer.message,
+            "contexts": answer.documents,
             "ground_truth": question_sample["reference_answer"],
         }
         return {self.name: self.metric.score(ragas_sample)}
 
 
-ragas_context_precision = RagasMetric(name="RAGAS Context Precision", metric=context_precision)
-ragas_faithfulness = RagasMetric(name="RAGAS Faithfulness", metric=faithfulness)
+ragas_context_precision = RagasMetric(name="RAGAS Context Precision", metric=context_precision, requires_context=True)
+ragas_faithfulness = RagasMetric(name="RAGAS Faithfulness", metric=faithfulness, requires_context=True)
 ragas_answer_relevancy = RagasMetric(name="RAGAS Answer Relevancy", metric=answer_relevancy)
-ragas_context_recall = RagasMetric(name="RAGAS Context Recall", metric=context_recall)
+ragas_context_recall = RagasMetric(name="RAGAS Context Recall", metric=context_recall, requires_context=True)

--- a/giskard/visualization/templates/rag_report/static/style.css
+++ b/giskard/visualization/templates/rag_report/static/style.css
@@ -162,6 +162,10 @@ label {
   justify-content: center;
 }
 
+#gsk-metrics{
+  width:100%;
+}
+
 #recommendation {
   margin-top: 20px;
   padding: 20px;


### PR DESCRIPTION
According to [this issue](https://github.com/Giskard-AI/giskard/issues/1924), some RAGAS metrics are not properly computed by RAGAS (this includes context recall, context precision and faithfulness). 

To fix it: 
- added a `retrieved_documents` argument to the evaluate method 
- allowed the `answer_fn` to return retrieved documents alongside the answer to a question