### PR TITLE
Fixed system prompt extraction inside of the bedrock client

### DIFF
--- a/giskard/llm/client/bedrock.py
+++ b/giskard/llm/client/bedrock.py
@@ -45,7 +45,7 @@ class ClaudeBedrockClient(LLMClient):
         for msg in messages:
             if msg.role.lower() == "system":
                 system_prompts = system_prompts.append(msg.content)
-            if msg.role.lower() == "assistant":
+            elif msg.role.lower() == "assistant":
                 input_msg_prompt.append({"role": "assistant", "content": [{"type": "text", "text": msg.content}]})
             else:
                 input_msg_prompt.append({"role": "user", "content": [{"type": "text", "text": msg.content}]})

--- a/giskard/llm/client/bedrock.py
+++ b/giskard/llm/client/bedrock.py
@@ -39,16 +39,12 @@ class ClaudeBedrockClient(LLMClient):
         if "claude-3" not in self.model:
             raise LLMConfigurationError(f"Only claude-3 models are supported as of now, got {self.model}")
 
-        # extract system prompt from messages
-        system_prompt = ""
-        if len(messages) > 1:
-            if messages[0].role.lower() == "user" and messages[1].role.lower() == "user":
-                system_prompt = messages[0].content
-                messages = messages[1:]
-
         # Create the messages format needed for bedrock specifically
         input_msg_prompt = []
+        system_prompts = []
         for msg in messages:
+            if msg.role.lower() == "system":
+                system_prompts = system_prompts.append(msg.content)
             if msg.role.lower() == "assistant":
                 input_msg_prompt.append({"role": "assistant", "content": [{"type": "text", "text": msg.content}]})
             else:
@@ -60,7 +56,7 @@ class ClaudeBedrockClient(LLMClient):
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": max_tokens,
                 "temperature": temperature,
-                "system": system_prompt,
+                "system": "\n".join(system_prompts),
                 "messages": input_msg_prompt,
             }
         )

--- a/giskard/llm/client/bedrock.py
+++ b/giskard/llm/client/bedrock.py
@@ -44,7 +44,7 @@ class ClaudeBedrockClient(LLMClient):
         system_prompts = []
         for msg in messages:
             if msg.role.lower() == "system":
-                system_prompts = system_prompts.append(msg.content)
+                system_prompts.append(msg.content)
             elif msg.role.lower() == "assistant":
                 input_msg_prompt.append({"role": "assistant", "content": [{"type": "text", "text": msg.content}]})
             else:


### PR DESCRIPTION
## Description

Currently, system prompt are extracted by taking the first message (if it is from `user` and second message is also from `user`). Furthermore, `system` role are being changed to `user`, but only after trying to extract the system prompt creating inconsistencies.

This is not clear and create bug when using `giskard.rag.generate_testset` (system followed by user is translated to two user messages which is forbidden by the bedrock client):

```
2024-05-14 09:16:03,949 pid:43435 MainThread giskard.rag  ERROR    An error occurred (ValidationException) when calling the InvokeModel operation: messages: roles must alternate between "user" and "assistant", but found multiple "user" roles in a row
Traceback (most recent call last):
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/giskard/rag/question_generators/base.py", line 57, in generate_questions
    yield self.generate_single_question(knowledge_base, *args, **kwargs)
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/giskard/rag/question_generators/simple_questions.py", line 96, in generate_single_question
    generated_qa = self._llm_complete(messages=messages)
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/giskard/rag/question_generators/base.py", line 42, in _llm_complete
    out = self._llm_client.complete(
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/giskard/llm/client/bedrock.py", line 72, in complete
    response = self._client.invoke_model(body=body, modelId=self.model, accept=accept, contentType=contentType)
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/botocore/client.py", line 565, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/botocore/client.py", line 1021, in _make_api_call
    raise error_class(parsed_response, operation_name)
```

## Solution

Remove the previous logic and extract `system_prompt` by using the `system` role. This is cleaner and way easier to understand.  

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
