### PR TITLE
Fix seed not supported by gemini

### DIFF
--- a/giskard/llm/client/gemini.py
+++ b/giskard/llm/client/gemini.py
@@ -64,9 +64,8 @@ class GeminiClient(LLMClient):
         seed: Optional[int] = None,
         format=None,
     ) -> ChatMessage:
-        extra_params = dict()
         if seed is not None:
-            extra_params["seed"] = seed
+            warning("Unsupported seed, ignoring.")
 
         if format:
             warning(f"Unsupported format '{format}', ignoring.")
@@ -74,11 +73,7 @@ class GeminiClient(LLMClient):
         try:
             completion = self._client.generate_content(
                 contents=_format(messages),
-                generation_config=genai.types.GenerationConfig(
-                    temperature=temperature,
-                    max_output_tokens=max_tokens,
-                    **extra_params,
-                ),
+                generation_config=genai.types.GenerationConfig(temperature=temperature, max_output_tokens=max_tokens),
             )
         except RuntimeError as err:
             raise LLMConfigurationError(AUTH_ERROR_MESSAGE) from err


### PR DESCRIPTION
## Description

The [generate_content](https://ai.google.dev/api/python/google/generativeai/GenerativeModel#generate_content) method does not support seed on the [GenerationConfig](https://ai.google.dev/api/python/google/generativeai/types/GenerationConfig) param

## Related Issue

#1901 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
