### PR TITLE
Disable sentry by default and handle connection error when network is not available

### DIFF
--- a/giskard/utils/logging_utils.py
+++ b/giskard/utils/logging_utils.py
@@ -11,6 +11,7 @@ def configure_logging():
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     logging.getLogger("pyngrok").setLevel(logging.ERROR)
     logging.getLogger("giskard").setLevel(logging.INFO)
+    logging.getLogger("urllib3").setLevel(logging.ERROR)
     configure_basic_logging(stdout_handler)
 
 


### PR DESCRIPTION
## Description

Fixed an issue making `import giskard` throwing a `ConnectionError` when network access is not available.
Furthermore made Sentry reporting an opt-in: `DISABLE_SENTRY_ENV_VARIABLE_NAME=False`

## Related Issue

N/A

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix