### PR TITLE
[GSK-3667] Remove disclaimer about GPT4 dependency on LLM detectors

### DIFF
--- a/giskard/scanner/llm/llm_basic_sycophancy_detector.py
+++ b/giskard/scanner/llm/llm_basic_sycophancy_detector.py
@@ -38,8 +38,6 @@ class LLMBasicSycophancyDetector:
 
     Note that we will generate case specific adversarial inputs based on the model name and description, so that the
     inputs and biases are relevant and adapted to the model.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     def __init__(self, num_samples=10):

--- a/giskard/scanner/llm/llm_harmful_content_detector.py
+++ b/giskard/scanner/llm/llm_harmful_content_detector.py
@@ -21,8 +21,6 @@ class LLMHarmfulContentDetector(RequirementBasedDetector):
     purposes or promote harmful actions. This detector will probe if the model is affected by this issue by generating
     ad hoc adversarial inputs (based on the model name & description) and checking that the model outputs do not contain
     potentially harmful information.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     _issue_group = Harmfulness

--- a/giskard/scanner/llm/llm_implausible_output_detector.py
+++ b/giskard/scanner/llm/llm_implausible_output_detector.py
@@ -25,8 +25,6 @@ class LLMImplausibleOutputDetector(Detector):
 
     The detector will stimulate the model in producing outputs that are implausible or controversial by generating a
     set of ad hoc adversarial inputs. This can be seen as a proxy for hallucination and misinformation detection.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     def __init__(self, num_samples=10):

--- a/giskard/scanner/llm/llm_information_disclosure_detector.py
+++ b/giskard/scanner/llm/llm_information_disclosure_detector.py
@@ -22,8 +22,6 @@ class LLMInformationDisclosureDetector(RequirementBasedDetector):
     undesired availability of private information to the model (for example, confidential data acquired during fine
     tuning), or the tendency to hallucinate information such as phone numbers or personal emails even if those details
     were not provided to the model.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     _issue_group = SensitiveInformationDisclosure

--- a/giskard/scanner/llm/llm_output_formatting_detector.py
+++ b/giskard/scanner/llm/llm_output_formatting_detector.py
@@ -35,8 +35,6 @@ class LLMOutputFormattingDetector(RequirementBasedDetector):
     """Detects output formatting issues in LLM-based models.
 
     This detector checks that the model output is consistent with format requirements indicated in the model description, if any.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     _issue_group = OutputFormatting

--- a/giskard/scanner/llm/llm_stereotypes_detector.py
+++ b/giskard/scanner/llm/llm_stereotypes_detector.py
@@ -23,8 +23,6 @@ class LLMStereotypesDetector(RequirementBasedDetector):
     This detector checks that the model does not generate responses containing stereotypes, discriminatory content, or
     biased opinions. We do that by generating ad hoc adversarial inputs based on the model name & description, aimed at
     eliciting responses that could be considered stereotypical or discriminatory.
-
-    Attention: this detector depends on OpenAI's GPT-4 model, which may not be publicly available or free to use.
     """
 
     _issue_group = Stereotypes


### PR DESCRIPTION
## Description

This PR removes the disclaimer about GPT4 dependency on LLM detectors, since now the LLM detectors are compatible with any LLM client/model.

## Related Issue

[GSK-3667 (available on Linear)](https://linear.app/giskard/issue/GSK-3667/remove-disclaimer-about-gpt4-dependency)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
