### PR TITLE
Fix incorrect temperature usage in `_LLMBasedQuestionGenerator`

### DIFF
--- a/giskard/rag/question_generators/base.py
+++ b/giskard/rag/question_generators/base.py
@@ -41,7 +41,7 @@ class _LLMBasedQuestionGenerator(QuestionGenerator):
     def _llm_complete(self, messages: Sequence[ChatMessage]) -> dict:
         out = self._llm_client.complete(
             messages=messages,
-            temperature=0.5,
+            temperature=self._llm_temperature,
             caller_id=self.__class__.__name__,
         )
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR fixes incorrect temperature usage in the `_llm_complete` method of the `_LLMBasedQuestionGenerator` class as described in the related issue. It replaces the hardcoded temperature value of 0.5 with `self._llm_temperature`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

#1998 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
