### PR TITLE
Removed hub version input from the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/giskard_bug_template.yaml
@@ -37,14 +37,6 @@ body:
     validations:
       required: true
   - type: input
-    id: giskard-hub-version
-    attributes:
-      label: Giskard Hub Version
-      description: You can obtain the Giskard Hub version by logging to http://localhost:19000 (if running on docker) or http://localhost:9000 (if running on local) using admin credentials. Navigate to admin page on left bottom. Giskard hub version is available under "Application"
-      placeholder: e.g., 1.3.0
-    validations:
-      required: true
-  - type: input
     id: os
     attributes:
       label: OS Platform and Distribution


### PR DESCRIPTION
## Description

Removed the "Giskard hub version" input from the bug template since this is not relevant anymore

## Related Issue

Removed hub version input from the bug template

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
