### PR TITLE
Introducing Giskard Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Giskard-AI/giskard/blob/main/LICENSE)
   [![CI](https://github.com/Giskard-AI/giskard/actions/workflows/build-python.yml/badge.svg?branch=main)](https://github.com/Giskard-AI/giskard/actions/workflows/build-python.yml?query=branch%3Amain)
   [![Giskard on Discord](https://img.shields.io/discord/939190303397666868?label=Discord)](https://gisk.ar/discord)
+  [![](https://img.shields.io/badge/Gurubase-Ask%20Giskard%20Guru-006BFF)](https://gurubase.io/g/giskard)
 
   <a rel="me" href="https://fosstodon.org/@Giskard"></a>
 
@@ -18,7 +19,8 @@
    <a href="https://docs.giskard.ai/en/stable/getting_started/index.html"><b>Docs</b></a> &bull;
    <a href="https://www.giskard.ai/knowledge-categories/news/?utm_source=github&utm_medium=github&utm_campaign=github_readme&utm_id=readmeblog"><b>Blog</b></a> &bull;
   <a href="https://www.giskard.ai/?utm_source=github&utm_medium=github&utm_campaign=github_readme&utm_id=readmeblog"><b>Website</b></a> &bull;
-  <a href="https://gisk.ar/discord"><b>Discord</b></a>
+  <a href="https://gisk.ar/discord"><b>Discord</b></a> &bull;
+  <a href="https://gurubase.io/g/giskard"><b>Giskard Guru</b></a>
  </h3>
 <br />
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Giskard Guru](https://gurubase.io/g/giskard) to Gurubase. Giskard Guru uses the data from this repo and data from the [docs](https://docs.giskard.ai/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Giskard Guru", which highlights that Giskard now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Giskard Guru in Gurubase, just let me know that's totally fine.