### PR TITLE
Add force_ascii=False when generating JSONL

### DIFF
--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -156,18 +156,18 @@ class RAGReport:
 
         report_details = {"recommendation": self._recommendation}
         with open(path / "report_details.json", "w", encoding="utf-8") as f:
-            json.dump(report_details, f)
+            json.dump(report_details, f, ensure_ascii=False)
 
         self._knowledge_base._knowledge_base_df.to_json(path / "knowledge_base.jsonl", orient="records", lines=True, force_ascii=False)
         with open(path / "knowledge_base_meta.json", "w", encoding="utf-8") as f:
-            json.dump(self._knowledge_base.get_savable_data(), f)
+            json.dump(self._knowledge_base.get_savable_data(), f, ensure_ascii=False)
 
         with open(path / "agent_answer.json", "w", encoding="utf-8") as f:
-            json.dump([{"message": output.message, "documents": output.documents} for output in self._model_outputs], f)
+            json.dump([{"message": output.message, "documents": output.documents} for output in self._model_outputs], f, ensure_ascii=False)
 
         if self._metrics_results is not None:
             with open(path / "metrics_results.json", "w", encoding="utf-8") as f:
-                json.dump(self._metrics_results, f)
+                json.dump(self._metrics_results, f, ensure_ascii=False)
 
     @classmethod
     def load(

--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -158,7 +158,7 @@ class RAGReport:
         with open(path / "report_details.json", "w", encoding="utf-8") as f:
             json.dump(report_details, f)
 
-        self._knowledge_base._knowledge_base_df.to_json(path / "knowledge_base.jsonl", orient="records", lines=True)
+        self._knowledge_base._knowledge_base_df.to_json(path / "knowledge_base.jsonl", orient="records", lines=True, force_ascii=False)
         with open(path / "knowledge_base_meta.json", "w", encoding="utf-8") as f:
             json.dump(self._knowledge_base.get_savable_data(), f)
 

--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -158,7 +158,9 @@ class RAGReport:
         with open(path / "report_details.json", "w", encoding="utf-8") as f:
             json.dump(report_details, f, ensure_ascii=False)
 
-        self._knowledge_base._knowledge_base_df.to_json(path / "knowledge_base.jsonl", orient="records", lines=True, force_ascii=False)
+        self._knowledge_base._knowledge_base_df.to_json(
+            path / "knowledge_base.jsonl", orient="records", lines=True, force_ascii=False
+        )
         with open(path / "knowledge_base_meta.json", "w", encoding="utf-8") as f:
             json.dump(self._knowledge_base.get_savable_data(), f, ensure_ascii=False)
 

--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -165,7 +165,11 @@ class RAGReport:
             json.dump(self._knowledge_base.get_savable_data(), f, ensure_ascii=False)
 
         with open(path / "agent_answer.json", "w", encoding="utf-8") as f:
-            json.dump([{"message": output.message, "documents": output.documents} for output in self._model_outputs], f, ensure_ascii=False)
+            json.dump(
+                [{"message": output.message, "documents": output.documents} for output in self._model_outputs], 
+                f, 
+                ensure_ascii=False
+            )
 
         if self._metrics_results is not None:
             with open(path / "metrics_results.json", "w", encoding="utf-8") as f:

--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -166,8 +166,8 @@ class RAGReport:
 
         with open(path / "agent_answer.json", "w", encoding="utf-8") as f:
             json.dump(
-                [{"message": output.message, "documents": output.documents} for output in self._model_outputs], 
-                f, 
+                [{"message": output.message, "documents": output.documents} for output in self._model_outputs],
+                f,
                 ensure_ascii=False,
             )
 

--- a/giskard/rag/report.py
+++ b/giskard/rag/report.py
@@ -168,7 +168,7 @@ class RAGReport:
             json.dump(
                 [{"message": output.message, "documents": output.documents} for output in self._model_outputs], 
                 f, 
-                ensure_ascii=False
+                ensure_ascii=False,
             )
 
         if self._metrics_results is not None:

--- a/giskard/rag/testset.py
+++ b/giskard/rag/testset.py
@@ -96,7 +96,7 @@ class QATestset:
         path : str
             The path to the output JSONL file.
         """
-        self._dataframe.reset_index().to_json(path, orient="records", lines=True)
+        self._dataframe.reset_index().to_json(path, orient="records", lines=True, force_ascii=False)
 
     @classmethod
     def load(cls, path):

--- a/tests/rag/test_qa_testset.py
+++ b/tests/rag/test_qa_testset.py
@@ -87,6 +87,37 @@ def make_testset_samples():
     ]
 
 
+def make_swedish_testset_samples():
+    return [
+        QuestionSample(
+            id="1",
+            question="Vilken mjölk används för att göra Camembert?",
+            reference_answer="Komjölk används för att göra Camembert.",
+            reference_context="Camembert är en fuktig, mjuk, krämig, ytmognad ost av komjölk.",
+            conversation_history=[],
+            metadata={
+                "question_type": "enkel",
+                "color": "blå",
+                "topic": "Ost_1",
+                "seed_document_id": "1",
+            },
+        ),
+        QuestionSample(
+            id="2",
+            question="Varifrån kommer Scamorza?",
+            reference_answer="Scamorza kommer från södra Italien.",
+            reference_context="Scamorza är en ost av komjölk från södra Italien.",
+            conversation_history=[],
+            metadata={
+                "question_type": "enkel",
+                "color": "röd",
+                "topic": "Ost_1",
+                "seed_document_id": "2",
+            },
+        ),
+    ]
+
+
 def test_qa_testset_creation():
     question_samples = make_testset_samples()
     testset = QATestset(question_samples)
@@ -138,6 +169,20 @@ def test_qa_testset_saving_loading(tmp_path):
     loaded_testset = QATestset.load(path)
 
     assert len(testset._dataframe) == len(loaded_testset._dataframe)
+    assert all(
+        [
+            original == loaded
+            for original, loaded in zip(testset._dataframe["metadata"], loaded_testset._dataframe["metadata"])
+        ]
+    )
+
+
+def test_qa_testset_saving_loading_swedish(tmp_path):
+    testset = QATestset(make_swedish_testset_samples())
+    path = tmp_path / "testset.jsonl"
+    testset.save(path)
+    loaded_testset = QATestset.load(path)
+
     assert all(
         [
             original == loaded


### PR DESCRIPTION
## Description

Fixes #2046

## Related Issue

#2046

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [X] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
