### PR TITLE
[GSK-3881] Fix RAGAS compatibility

### DIFF
--- a/giskard/rag/metrics/ragas_metrics.py
+++ b/giskard/rag/metrics/ragas_metrics.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 try:
     from langchain_core.outputs import LLMResult
     from langchain_core.outputs.generation import Generation
+    from langchain_core.prompt_values import PromptValue
     from ragas.embeddings import BaseRagasEmbeddings
     from ragas.llms import BaseRagasLLM
-    from ragas.llms.prompt import PromptValue
     from ragas.metrics import answer_relevancy, context_precision, context_recall, faithfulness
     from ragas.metrics.base import Metric as BaseRagasMetric
     from ragas.run_config import RunConfig


### PR DESCRIPTION
## Description

This PR fixes an import bug in which was making `giskard` not compatible with `ragas==0.2.2`.

## Related Issue
#2051 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
