### PR TITLE
Fixed boolean indexer mismatching issue

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -295,7 +295,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
-          version: 3.19.3 # pdm init broken with pdm>=3.20
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
       - name: Build wheel
         run: pdm build
@@ -303,7 +303,7 @@ jobs:
         run: |
           mkdir ./install-run
           cd ./install-run
-          pdm init --python 3.10 -n .
+          pdm init --python 3.10 -n
           sed -i 's/^\(requires-python *= *\).*$/\1">=3.10,<3.12"/' pyproject.toml
           pdm add "$(ls ../dist/*.whl)"
           pdm run python -c "import giskard"

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -120,6 +120,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ matrix.python-version }}
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
 
       - name: Cache Giskard test resources
@@ -251,6 +252,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
       - name: Build wheel
         run: pdm build
@@ -273,6 +275,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
       - name: Build wheel
         run: pdm build
@@ -292,7 +295,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
-          version: "2.10.4" # Fix to repair the CI, use latest version when fixed on pdm
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
       - name: Build wheel
         run: pdm build
@@ -336,6 +339,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
 
       - name: Set up Pandoc (needed for doc)

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -295,7 +295,6 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
-          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
       - name: Build wheel
         run: pdm build

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -295,6 +295,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
+          version: 3.19.3 # pdm init broken with pdm>=3.20
           cache: false
       - name: Build wheel
         run: pdm build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,6 +52,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: '3.10'
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
 
       - name: "@slack Release process started"

--- a/.github/workflows/lock-deps.yml
+++ b/.github/workflows/lock-deps.yml
@@ -55,6 +55,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
+          version: head # Issue with PDM 2.20.1: https://github.com/pdm-project/pdm/issues/3271
           cache: false
 
       - name: Install dependencies

--- a/giskard/testing/tests/statistic.py
+++ b/giskard/testing/tests/statistic.py
@@ -145,14 +145,12 @@ def test_output_in_range(
         output = prediction_results.raw_prediction
 
     elif model.is_classification:
-        output = prediction_results.all_predictions[classification_label]
+        output = prediction_results.all_predictions[classification_label].values
 
     else:
         raise ValueError(f"Prediction task is not supported: {model.meta.model_type}")
 
-    passed_idx = dataset.df.loc[
-        ((output <= max_range) & (output >= min_range)).reindex(dataset.df.index, fill_value=False)
-    ].index.values
+    passed_idx = dataset.df.loc[(output <= max_range) & (output >= min_range)].index.values
 
     passed_ratio = len(passed_idx) / len(dataset)
     passed = bool(passed_ratio >= threshold)

--- a/giskard/testing/tests/statistic.py
+++ b/giskard/testing/tests/statistic.py
@@ -150,7 +150,9 @@ def test_output_in_range(
     else:
         raise ValueError(f"Prediction task is not supported: {model.meta.model_type}")
 
-    passed_idx = dataset.df.loc[(output <= max_range) & (output >= min_range)].index.values
+    passed_idx = dataset.df.loc[
+        ((output <= max_range) & (output >= min_range)).reindex(dataset.df.index, fill_value=False)
+    ].index.values
 
     passed_ratio = len(passed_idx) / len(dataset)
     passed = bool(passed_ratio >= threshold)


### PR DESCRIPTION
## Description

### Issue 

The boolean indexer of the `test_output_in_range` is mismatching the sliced dataset.

### Solution

Since we want to keep the original indexes for debugging purpose, to solution was to reindex the  boolean indexer used as mask to the sliced dataset index

## Related Issue

#2061 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist
