### PR TITLE
[GSK-3941] Fix Azure/OpenAI client setup docs

### DIFF
--- a/docs/open_source/scan/scan_llm/index.md
+++ b/docs/open_source/scan/scan_llm/index.md
@@ -87,7 +87,7 @@ os.environ['OPENAI_API_VERSION'] = '2023-07-01-preview'
 # You'll need to provide the name of the model that you've deployed
 # Beware, the model provided must be capable of using function calls
 giskard.llm.set_llm_model('my-gpt-4-model')
-giskard.llm.embeddings.set_embedding_model('my-embedding-model')
+giskard.llm.embeddings.openai.set_embedding_model('my-embedding-model')
 ```
 
 ::::::

--- a/docs/open_source/setting_up/index.md
+++ b/docs/open_source/setting_up/index.md
@@ -40,7 +40,7 @@ os.environ['OPENAI_API_VERSION'] = '2023-07-01-preview'
 # You'll need to provide the name of the model that you've deployed
 # Beware, the model provided must be capable of using function calls
 giskard.llm.set_llm_model('my-gpt-4-model')
-giskard.llm.embeddings.set_embedding_model('my-embedding-model')
+giskard.llm.embeddings.openai.set_embedding_model('my-embedding-model')
 ```
 
 ## Mistral Client Setup

--- a/docs/open_source/testset_generation/testset_generation/index.md
+++ b/docs/open_source/testset_generation/testset_generation/index.md
@@ -121,7 +121,7 @@ os.environ['OPENAI_API_VERSION'] = '2023-07-01-preview'
 # You'll need to provide the name of the model that you've deployed
 # Beware, the model provided must be capable of using function calls
 giskard.llm.set_llm_model('my-gpt-4-model')
-giskard.llm.embeddings.set_embedding_model('my-embedding-model')
+giskard.llm.embeddings.openai.set_embedding_model('my-embedding-model')
 ```
 
 ::::::


### PR DESCRIPTION
## Description

In the docs, there was a missing word (`openai`) when trying to call `set_embedding_model`.
This PR fixes the Azure/OpenAI docs, updating the code to call.

## Related Issue

Linear card: [GSK-3941](https://linear.app/giskard/issue/GSK-3941/fix-azure-openai-client-setup-docs)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

