### PR TITLE
chore(docs): replace llama3.1 with qwen2.5 on ollama docs

### DIFF
--- a/docs/open_source/scan/scan_llm/index.md
+++ b/docs/open_source/scan/scan_llm/index.md
@@ -111,7 +111,7 @@ import giskard
 api_base = "http://localhost:11434" # default api_base for local Ollama
 
 # See supported models here: https://docs.litellm.ai/docs/providers/ollama#ollama-models
-giskard.llm.set_llm_model("ollama/llama3.1", disable_structured_output=True, api_base=api_base)
+giskard.llm.set_llm_model("ollama/qwen2.5", disable_structured_output=True, api_base=api_base)
 giskard.llm.set_embedding_model("ollama/nomic-embed-text", api_base=api_base)
 ```
 

--- a/docs/open_source/setting_up/index.md
+++ b/docs/open_source/setting_up/index.md
@@ -104,7 +104,7 @@ import giskard
 api_base = "http://localhost:11434" # default api_base for local Ollama
 
 # See supported models here: https://docs.litellm.ai/docs/providers/ollama#ollama-models
-giskard.llm.set_llm_model("ollama/llama3.1", disable_structured_output=True, api_base=api_base)
+giskard.llm.set_llm_model("ollama/qwen2.5", disable_structured_output=True, api_base=api_base)
 giskard.llm.set_embedding_model("ollama/nomic-embed-text", api_base=api_base)
 ```
 

--- a/docs/open_source/testset_generation/testset_generation/index.md
+++ b/docs/open_source/testset_generation/testset_generation/index.md
@@ -149,7 +149,7 @@ import giskard
 api_base = "http://localhost:11434" # default api_base for local Ollama
 
 # See supported models here: https://docs.litellm.ai/docs/providers/ollama#ollama-models
-giskard.llm.set_llm_model("ollama/llama3.1", disable_structured_output=True, api_base=api_base)
+giskard.llm.set_llm_model("ollama/qwen2.5", disable_structured_output=True, api_base=api_base)
 giskard.llm.set_embedding_model("ollama/nomic-embed-text", api_base=api_base)
 ```
 


### PR DESCRIPTION
## Description

Sometimes `llama3.1` model doesn't generate JSON responses in a proper format. After doing some manual tests, we have seen that `qwen2.5` performs better on this task. Therefore, this PR updates the Ollama docs to showcase `qwen2.5` as model example instead of `llama3.1`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
