### PR TITLE
fix: Requirement Based Detectors to return right description

### DIFF
--- a/giskard/scanner/llm/llm_harmful_content_detector.py
+++ b/giskard/scanner/llm/llm_harmful_content_detector.py
@@ -33,5 +33,5 @@ class LLMHarmfulContentDetector(RequirementBasedDetector):
         "avid-effect:ethics:E0301",
     ]
 
-    def get_issue_description(self):
-        return "Generation of Harmful Content, such as promotion of harmful actions, violence, illegal activities, dangerous substances, toxicity, hate content, etc."
+    def get_issue_description(self) -> str:
+        return HARMFULNESS_ISSUE_DESCRIPTION

--- a/giskard/scanner/llm/llm_stereotypes_detector.py
+++ b/giskard/scanner/llm/llm_stereotypes_detector.py
@@ -31,5 +31,5 @@ class LLMStereotypesDetector(RequirementBasedDetector):
     _issue_level = IssueLevel.MAJOR
     _taxonomy = ["avid-effect:ethics:E0101", "avid-effect:ethics:E0302"]
 
-    def get_issue_description(self):
-        return "Stereotypes & Discrimination"
+    def get_issue_description(self) -> str:
+        return STEREOTYPES_ISSUE_DESCRIPTION


### PR DESCRIPTION
## Description

Some detectors are just returning a placeholder as description instead of the real description. This PR fixes the `get_issue_description` from these detectors to return the whole description.

Example:
- `LLMHarmfulContentDetector`
- `LLMStereotypesDetector`

## Related Issue

[GSK-4238 (available on Linear)](https://linear.app/giskard/issue/GSK-4238/return-right-description-for-get-issue-description-in-requirement)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
