### PR TITLE
Knowledgebase embeddings

### DIFF
--- a/giskard/rag/knowledge_base.py
+++ b/giskard/rag/knowledge_base.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+import pickle
 from typing import Dict, Optional, Sequence
 
 import logging
@@ -6,6 +8,11 @@ import uuid
 import numpy as np
 import pandas as pd
 from sklearn.cluster import HDBSCAN
+
+import tempfile
+import os
+import json
+from huggingface_hub import DatasetCard, HfApi, HfFolder, upload_file, hf_hub_download
 
 from ..llm.client import ChatMessage, LLMClient, get_default_client
 from ..llm.embeddings import get_default_embedding
@@ -104,6 +111,16 @@ class KnowledgeBase:
         The number of document to embed in a single batch.
     """
 
+    # file names to save and load the knowledge base
+    _saving_filenames = [
+        "knowledge_base.parquet", 
+        "embeddings.npy", 
+        "reduced_embeddings.npy", 
+        "config.json", 
+        "llm_client.pkl", 
+        "embedding_model.pkl"
+    ]
+
     def __init__(
         self,
         data: pd.DataFrame,
@@ -134,6 +151,7 @@ class KnowledgeBase:
         self._knowledge_base_df = data
         self._columns = columns
 
+        self.seed = seed
         self._rng = np.random.default_rng(seed=seed)
         self._llm_client = llm_client or get_default_client()
         self._embedding_model = embedding_model or get_default_embedding()
@@ -146,6 +164,7 @@ class KnowledgeBase:
         self._topics_inst = None
         self._index_inst = None
         self._reduced_embeddings_inst = None
+        self._config_inst = None
 
         # Detect language of the documents, use only the first characters of a few documents to speed up the process
         document_languages = [
@@ -167,6 +186,302 @@ class KnowledgeBase:
             },
         )
 
+    def save(self, dirpath: str):
+        """Save the KnowledgeBase to a directory.
+
+        Parameters
+        ----------
+        dirpath : str
+            The directory path where the KnowledgeBase will be saved.
+        """
+        os.makedirs(dirpath, exist_ok=True)
+
+        # save raw data
+        self._knowledge_base_df.to_parquet(os.path.join(dirpath, "knowledge_base.parquet"))
+    
+        # save embeddings
+        if self._embeddings_inst is not None:
+            np.save(os.path.join(dirpath, "embeddings.npy"), self._embeddings_inst)
+        if self._reduced_embeddings_inst is not None:
+            np.save(os.path.join(dirpath, "reduced_embeddings.npy"), self._reduced_embeddings_inst)
+        
+        # save llm and embedding objects
+        with open(os.path.join(dirpath, "llm_client.pkl"), "wb") as f:
+            pickle.dump(self._llm_client, f)
+        with open(os.path.join(dirpath, "embedding_model.pkl"), "wb") as f:
+            pickle.dump(self._embedding_model, f)
+
+        # save config
+        with open(os.path.join(dirpath, "config.json"), "w") as f:
+            json.dump(self._config, f, indent=2)
+        
+        logger.info("KnowledgeBase saved successfully.")
+
+    @classmethod
+    def load(cls, dirpath: str, llm_client: Optional[LLMClient] = None,
+        embedding_model: Optional[BaseEmbedding] = None) -> "KnowledgeBase":
+        """
+        Load a KnowledgeBase instance from a specified directory.
+
+        Parameters
+        ----------
+        dirpath : str
+            The path to the directory containing the saved KnowledgeBase data.
+        llm_client : LLMClient, optional
+            An optional LLMClient instance. If not provided, it will be loaded from the directory.
+        embedding_model : BaseEmbedding, optional
+            An optional embedding model instance. If not provided, it will be loaded from the directory.
+
+        Returns
+        -------
+        KnowledgeBase
+            An instance of the KnowledgeBase class loaded with the data, configuration, and models from the specified directory.
+
+        Raises
+        ------
+        ValueError
+            If the specified directory does not exist or the required "knowledge_base.parquet" file is missing.
+
+        Notes
+        -----
+        The directory must contain the following files:
+        - "knowledge_base.parquet": The raw data for the KnowledgeBase.
+
+        Optional files:
+        - "llm_client.pkl": A serialized LLMClient object (if llm_client is not provided).
+        - "embedding_model.pkl": A serialized embedding model object (if embedding_model is not provided).
+        - "config.json": A JSON file containing configuration parameters.
+        - "embeddings.npy": A NumPy file containing precomputed embeddings.
+        - "reduced_embeddings.npy": A NumPy file containing reduced embeddings.
+
+        Missing optional files will result in warnings, and the KnowledgeBase will be created without those components.
+        """
+        
+        dirpath = Path(dirpath)
+        if not dirpath.exists():
+            raise ValueError(f"Cannot load the KnowledgeBase. Directory {dirpath} does not exist.")
+        
+        filepaths = {}
+        for filename in cls._saving_filenames:
+            key = filename.split('.')[0] + "_filepath"
+            try:
+                fp = dirpath / filename
+                assert fp.exists(), f"File {filename} not found in {dirpath}."
+                filepaths[key] = str(fp)
+            except Exception as e:
+                logger.warning(str(e))
+                if filename == "knowledge_base.parquet":
+                    raise ValueError("Cannot load the KnowledgeBase. Could not find knowledge_base.parquet file.")
+                filepaths[key] = None
+
+        return cls._load(**filepaths, llm_client=llm_client, embedding_model=embedding_model)
+
+    def push_to_hf_hub(self, repo_id: str, hf_token: Optional[str] = None, private: bool = False):
+        """
+        Push the KnowledgeBase to the Hugging Face Hub.
+
+        Parameters
+        ----------
+        repo_id : str
+            The repo ID on Hugging Face Hub (e.g., "org-name/my-knowledge-base").
+        hf_token : str, optional
+            Hugging Face token for authentication. If None, will use local token.
+        private : bool
+            Whether to make the repo private or public.
+        """
+
+        api = HfApi(token=hf_token or HfFolder.get_token())
+        api.create_repo(repo_id, repo_type="dataset", private=private, exist_ok=True)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+
+                self.save(tmpdir)
+                
+                # push the files to the hub
+                for filename in self._saving_filenames:
+                    filepath = os.path.join(tmpdir, filename)
+                    if os.path.exists(filepath):
+                        upload_file(
+                            path_or_fileobj=filepath,
+                            path_in_repo=filename,
+                            repo_id=repo_id,
+                            repo_type="dataset",
+                            token=hf_token,
+                        )
+            logger.info(f"KnowledgeBase pushed to https://huggingface.co/datasets/{repo_id}")
+
+            # Load the dataset card template
+            template_path = Path(__file__).parent / "knowledge_base_card_template.md"
+            template = template_path.read_text()
+
+            # Make and push the dataset card
+            content = template.format(repo_id=repo_id, num_items=len(self._knowledge_base_df), config=json.dumps(self._config_inst, indent=4))
+            return DatasetCard(content=content).push_to_hub(repo_id=repo_id, token=hf_token, repo_type="dataset")
+        
+        except Exception as e:
+            logger.error(f"Error pushing to Hugging Face Hub: {e}")
+
+    @classmethod
+    def _load(cls, 
+            config_filepath: str, 
+            knowledge_base_filepath: str, 
+            llm_client_filepath: str, 
+            embedding_model_filepath: str, 
+            embeddings_filepath: str, 
+            reduced_embeddings_filepath: str, 
+            llm_client: Optional[LLMClient] = None,
+            embedding_model: Optional[BaseEmbedding] = None) -> "KnowledgeBase":
+        """
+        Load a KnowledgeBase instance by loading data from specified file paths.
+
+        This method initializes a KnowledgeBase object using the provided file paths for configuration, data, 
+        embeddings, and models. It handles loading and deserialization of the necessary components, such as 
+        the knowledge base data, LLM client, embedding model, and precomputed embeddings.
+
+        Parameters
+        ----------
+        config_filepath : str
+            Path to the JSON file containing the KnowledgeBase configuration.
+        knowledge_base_filepath : str
+            Path to the Parquet file containing the knowledge base data.
+        llm_filepath : str
+            Path to the pickle file containing the serialized LLM client.
+        embedding_model_filepath : str
+            Path to the pickle file containing the serialized embedding model.
+        embeddings_filepath : str
+            Path to the NumPy file containing precomputed embeddings.
+        reduced_embeddings_filepath : str
+            Path to the NumPy file containing reduced embeddings.
+        llm_client : LLMClient, optional
+            An optional LLMClient instance. If not provided, it will be loaded from the specified file path.
+        embedding_model : BaseEmbedding, optional
+            An optional embedding model instance. If not provided, it will be loaded from the specified file path.
+
+        Returns
+        -------
+        KnowledgeBase
+            An instance of the KnowledgeBase class loaded with the data, configuration, and models.
+
+        Notes
+        -----
+        - If any of the optional file paths (e.g., embeddings or reduced embeddings) are missing or fail to load, 
+          warnings will be logged, and the KnowledgeBase will still be created without those components.
+        - Default values will be used for missing configuration parameters or models if they cannot be loaded.
+        """
+
+        data = pd.read_parquet(knowledge_base_filepath)
+
+        config = {}
+        if config_filepath:
+            try:
+                config = json.loads(open(config_filepath, "r").read())
+            except Exception as e:
+                logger.warning(f"Could not load config: {e}. Using default values.")
+        
+        llm_client = None
+        if not llm_client and llm_client_filepath:
+            try:
+                llm_client = pickle.load(open(llm_client_filepath, "rb"))
+            except Exception as e:
+                logger.warning(f"Could not load LLM client: {e}. Using default client.")
+        
+        embedding_model = None
+        if not embedding_model and embedding_model_filepath:
+            try:
+                embedding_model = pickle.load(open(embedding_model_filepath, "rb"))
+            except Exception as e:
+                logger.warning(f"Could not load embedding model: {e}. Using default embedding model.")
+
+        logger.info("Building the KnowledgeBase instance...")
+        kb = cls(
+            data=data,
+            columns=config.get("columns"),
+            llm_client=llm_client,
+            embedding_model=embedding_model,
+            chunk_size=config.get("chunk_size", 2048),
+            seed = config.get("seed"),
+            min_topic_size=config.get("min_topic_size"),
+        )
+
+        # Load embeddings if available
+        if embeddings_filepath:
+            try:
+                kb._store_embeddings_inst(np.load(embeddings_filepath))
+            except Exception as e:
+                logger.warning(f"Could not load embeddings: {e}.")
+        
+        if reduced_embeddings_filepath:
+            try:
+                kb._store_reduced_embeddings_inst(np.load(reduced_embeddings_filepath))
+            except Exception as e:
+                logger.warning(f"Could not load reduced embeddings: {e}.")
+
+        logger.info("KnowledgeBase loaded successfully.")
+        return kb
+
+    @classmethod
+    def load_from_hf_hub(
+        cls, 
+        repo_id: str, 
+        hf_token: Optional[str] = None, 
+        llm_client: Optional[LLMClient] = None,
+        embedding_model: Optional[BaseEmbedding] = None,
+        **hf_hub_kwargs) -> "KnowledgeBase":
+        """
+        Load a KnowledgeBase from the Hugging Face Hub.
+
+        This method retrieves the necessary files from the specified Hugging Face Hub repository
+        and reconstructs a KnowledgeBase instance using the stored data, embeddings, and configuration.
+
+        Parameters
+        ----------
+        repo_id : str
+            The repository ID on the Hugging Face Hub (e.g., "org-name/my-knowledge-base").
+        hf_token : str, optional
+            Hugging Face token for authentication. If None, the local token will be used.
+        llm_client : LLMClient, optional
+            An optional LLMClient instance. If not provided, it will be loaded from the repository.
+        embedding_model : BaseEmbedding, optional
+            An optional embedding model instance. If not provided, it will be loaded from the repository.
+        **hf_hub_kwargs : dict
+            Additional keyword arguments to pass to the Hugging Face Hub download function.
+
+        Returns
+        -------
+        KnowledgeBase
+            An instance of the KnowledgeBase class loaded with the data, configuration, and models from the specified repository.
+
+        Raises
+        ------
+        ValueError
+            If the required "knowledge_base.parquet" file cannot be downloaded.
+
+        Notes
+        -----
+        - The repository must contain the following files:
+          - "knowledge_base.parquet": The raw data for the KnowledgeBase.
+        - Optional files:
+          - "config.json": A JSON file containing configuration parameters.
+          - "embeddings.npy": A NumPy file containing precomputed embeddings.
+          - "reduced_embeddings.npy": A NumPy file containing reduced embeddings.
+          - "llm_client.pkl": A serialized LLMClient object (if llm_client is not provided).
+          - "embedding_model.pkl": A serialized embedding model object (if embedding_model is not provided).
+        """
+
+        filepaths = {}
+        for filename in cls._saving_filenames:
+            key = filename.split('.')[0] + "_filepath"
+            try:
+                filepaths[key] = hf_hub_download(repo_id, filename=filename, repo_type="dataset", token=hf_token, **hf_hub_kwargs)
+            except Exception as e:
+                logger.warning(f"Failed to download {filename}: {e}")
+                if filename == "knowledge_base.parquet":
+                    raise ValueError(f"Failed to download {filename}. Cannot load the KnowledgeBase without it.")
+                filepaths[key] = None
+        
+        return cls._load(**filepaths, llm_client=llm_client, embedding_model=embedding_model)
+
     @classmethod
     def from_pandas(cls, df: pd.DataFrame, columns: Optional[Sequence[str]] = None, **kwargs) -> "KnowledgeBase":
         """Create a KnowledgeBase from a pandas DataFrame.
@@ -185,13 +500,35 @@ class KnowledgeBase:
         """
         return cls(data=df, columns=columns, **kwargs)
 
+    def _store_embeddings_inst(self, embeddings_inst: np.ndarray):
+        self._embeddings_inst = embeddings_inst
+        for doc, emb in zip(self._documents, self._embeddings_inst):
+            doc.embeddings = emb
+
+    def _store_reduced_embeddings_inst(self, reduced_embeddings_inst: np.ndarray):
+        self._reduced_embeddings_inst = reduced_embeddings_inst
+        for doc, emb in zip(self._documents, self._reduced_embeddings_inst):
+            doc.reduced_embeddings = emb
+
+    @property
+    def _config(self):
+        if not self._config_inst:
+            self._config_inst = {
+                "columns": self._columns,
+                "chunk_size": self.chunk_size,
+                "min_topic_size": self._min_topic_size,
+                "language": self._language,
+                "seed": self.seed,
+                "embedding_model": getattr(self._embedding_model, "model_name", None)
+            }
+        return self._config_inst
+
     @property
     def _embeddings(self):
         if self._embeddings_inst is None:
             logger.debug("Computing Knowledge Base embeddings.")
-            self._embeddings_inst = np.array(self._embedding_model.embed([doc.content for doc in self._documents]))
-            for doc, emb in zip(self._documents, self._embeddings_inst):
-                doc.embeddings = emb
+            embeddings_inst = np.array(self._embedding_model.embed([doc.content for doc in self._documents]))
+            self._store_embeddings_inst(embeddings_inst)
         return self._embeddings_inst
 
     @property
@@ -205,9 +542,7 @@ class KnowledgeBase:
                 random_state=1234,
                 n_jobs=1,
             )
-            self._reduced_embeddings_inst = reducer.fit_transform(self._embeddings)
-            for doc, emb in zip(self._documents, self._reduced_embeddings_inst):
-                doc.reduced_embeddings = emb
+            self._store_reduced_embeddings_inst(reducer.fit_transform(self._embeddings))
         return self._reduced_embeddings_inst
 
     @property

--- a/giskard/rag/knowledge_base_card_template.md
+++ b/giskard/rag/knowledge_base_card_template.md
@@ -1,0 +1,51 @@
+---
+tags:
+- giskard
+- knowledge-base
+- information-retrieval
+
+task_categories:
+- text-generation
+- text2text-generation
+- question-answering
+- text-retrieval
+---
+
+# Dataset Card for {repo_id}
+> This repository was created using the [giskard](https://github.com/Giskard-AI/giskard) library, an open-source Python framework designed to evaluate and test AI systems. 
+
+This dataset comprises a giskard's `KnowledgeBase` containing {num_items} documents. If embeddings were generated before the saving process, they are included and will be automatically loaded into a vector store when required.
+
+## Usage
+
+You can load this knowledge base using the following code:
+
+```python
+from giskard.rag import KnowledgeBase
+kb = KnowledgeBase.load_from_hf_hub("{repo_id}")
+```
+
+## Configuration
+
+The configuration details for this Knowledge Base (can also be found in the `config.json` file):
+
+```bash
+{config}
+```
+
+---
+
+<h2 style="text-align: center;">
+  <span style="display: inline-flex; align-items: center;">
+    Built with 
+    <a href="https://giskard.ai" target="_blank" style="display: inline-flex;">
+      <img src="https://cdn.prod.website-files.com/601d6f7d0b9c984f07bf10bc/62983fa8ef716259c397a57d_logo.svg" 
+             alt="Giskard Logo" 
+             width="100">
+    </a>
+  </span>
+</h2>
+
+<div style="text-align: center;">
+  <a href="https://github.com/Giskard-AI/giskard" target="_blank" style="display: inline-flex;"> Giskard </a> helps identify performance, bias, and security issues in AI applications, supporting both LLM-based systems like RAG agents and traditional machine learning models for tabular data.
+</div>


### PR DESCRIPTION
## Description

- Adds save and load methods to KnowledgeBase
- Adds save and load methods to KnowledgeBase using hugginface hub
- Adds card template for the newly created dataset on the hub
- Adds a _config property to KnowledgeBase
- Adds a list of file names to be saved to the KnowledgeBase class

## Related Issue

https://github.com/Giskard-AI/giskard/issues/2145

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

It is an improvement as it avoids embeddings to be recomputed.

It is a new feature because we can now save/load to/from disk and hugginface hub.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
