### PR TITLE
implement abstract methods for RagasEmbeddingsWrapper

### DIFF
--- a/giskard/rag/metrics/ragas_metrics.py
+++ b/giskard/rag/metrics/ragas_metrics.py
@@ -75,6 +75,7 @@ class RagasEmbeddingsWrapper(BaseRagasEmbeddings):
     async def aembed_documents(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
         return await self.embedding_model.aembed(texts)
 
+
 class RagasMetric(Metric):
     def __init__(
         self,

--- a/giskard/rag/metrics/ragas_metrics.py
+++ b/giskard/rag/metrics/ragas_metrics.py
@@ -69,6 +69,11 @@ class RagasEmbeddingsWrapper(BaseRagasEmbeddings):
     def embed_documents(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
         return self.embedding_model.embed(texts)
 
+    async def aembed_query(self, text: str) -> Sequence[float]:
+        return await self.embedding_model.aembed([text])[0]
+
+    async def aembed_documents(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        return await self.embedding_model.aembed(texts)
 
 class RagasMetric(Metric):
     def __init__(


### PR DESCRIPTION
## Description

Implement abstract methods aembed_query and aembed_documents for `RagasEmbeddingsWrapper`. These methods are required because the `RagasEmbeddingsWrapper` inherits from the `BaseRagasEmbeddings` class which has these abstract methods.

## Related Issue

This PR is related to [issue number 2177](https://github.com/Giskard-AI/giskard/issues/2177).

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
- [ ] I've updated the `pdm.lock` running `pdm update-lock` (only applicable when `pyproject.toml` has been
  modified)
