### PR TITLE
fix Discord Sever badge in docs page

### DIFF
--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -29,5 +29,5 @@ Hope your day's going well. :)
 <div class="social social--sidebar" style="margin-top: 1em; display: flex; justify-content: center; gap: 8px">
     <div class="github-stars github-stars--sidebar"></div>
     <div><a href="https://discord.gg/ABvfpbu69R"><img
-            src="https://dcbadge.vercel.app/api/server/ABvfpbu69R?style=flat-square"/></a></div>
+            src="https://dcbadge.limes.pink/api/server/https://discord.gg/ABvfpbu69R?style=flat-square"/></a></div>
 </div>


### PR DESCRIPTION
## Description

[DCBadge](https://github.com/gitlimes/dcbadge) has changed their API link. This PR updates the Discord Server Badge link in Giskard Docs to use the new API.

## Related Issue

[GSK-4493](https://linear.app/giskard/issue/GSK-4493/fix-discord-icon-in-giskard-docs)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
