### PR TITLE
fix: remove deprecated scipy.stats.stats imports

### DIFF
--- a/giskard/testing/tests/drift.py
+++ b/giskard/testing/tests/drift.py
@@ -9,8 +9,7 @@ from collections import Counter
 
 import numpy as np
 import pandas as pd
-from scipy.stats import chi2, ks_2samp
-from scipy.stats.stats import Ks_2sampResult, wasserstein_distance
+from scipy.stats import chi2, ks_2samp, wasserstein_distance
 
 from giskard.core.test_result import TestMessage, TestMessageLevel, TestResult
 from giskard.datasets.base import Dataset
@@ -99,7 +98,7 @@ def _calculate_drift_psi(actual_series, reference_series, max_categories):
     return total_psi, pd.DataFrame(output_data)
 
 
-def _calculate_ks(actual_series, reference_series) -> Ks_2sampResult:
+def _calculate_ks(actual_series, reference_series):
     return ks_2samp(reference_series, actual_series)
 
 
@@ -806,7 +805,7 @@ def test_drift_prediction_ks(
         else pd.Series(model.predict(actual_dataset).prediction)
     )
 
-    result: Ks_2sampResult = _calculate_ks(prediction_reference, prediction_actual)
+    result = _calculate_ks(prediction_reference, prediction_actual)
 
     passed = True if threshold is None else bool(result.pvalue >= threshold)
 


### PR DESCRIPTION
## Summary
- Replace deprecated `scipy.stats.stats` imports with `scipy.stats`
- Move `wasserstein_distance` import from `scipy.stats.stats` to `scipy.stats`
- Remove `Ks_2sampResult` type annotation (deprecated in scipy>=1.12)

The `ks_2samp` function returns a result object with `pvalue` and `statistic` attributes, which is sufficient for the existing code.

## Test plan
- Verified that the new imports work with current scipy versions
- Existing drift tests should pass unchanged

Fixes #2198