### PR TITLE
fix: align generated dataset columns to model's feature_names

### DIFF
--- a/giskard/llm/generators/base.py
+++ b/giskard/llm/generators/base.py
@@ -71,14 +71,76 @@ class _BaseLLMGenerator(BaseGenerator, ABC):
 
         generated = self._parse_output(out)
 
+        df = pd.DataFrame(generated)
+
+        # Ensure column names match the model's feature_names
+        # This handles cases where LLM generates different column names than expected
+        if model.feature_names:
+            df = self._align_columns_to_feature_names(df, model.feature_names)
+
         dataset = Dataset(
-            df=pd.DataFrame(generated),
+            df=df,
             name=self._make_dataset_name(model),
             validation=False,
             column_types=column_types,
         )
 
         return dataset
+
+    def _align_columns_to_feature_names(self, df: pd.DataFrame, feature_names: Sequence[str]) -> pd.DataFrame:
+        """Align DataFrame columns to match the model's feature_names.
+
+        If the generated columns don't match feature_names, attempt to rename them.
+        This handles the case where LLM generates data with different column names
+        than specified in the model's feature_names.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The generated DataFrame.
+        feature_names : Sequence[str]
+            The expected feature names from the model.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with columns aligned to feature_names.
+        """
+        current_columns = list(df.columns)
+
+        # If columns already match, return as-is
+        if set(current_columns) == set(feature_names):
+            return df[list(feature_names)]  # Reorder to match feature_names order
+
+        # If column count matches, assume positional mapping
+        if len(current_columns) == len(feature_names):
+            rename_map = dict(zip(current_columns, feature_names))
+            logger.debug(
+                f"Renaming generated columns to match feature_names: {rename_map}"
+            )
+            return df.rename(columns=rename_map)
+
+        # If we have fewer feature_names than columns, try to find matching columns
+        # or use the first N columns
+        if len(feature_names) < len(current_columns):
+            # First try exact matches
+            matching = [col for col in current_columns if col in feature_names]
+            if set(matching) == set(feature_names):
+                return df[list(feature_names)]
+            # Otherwise, use first N columns and rename
+            columns_to_use = current_columns[: len(feature_names)]
+            rename_map = dict(zip(columns_to_use, feature_names))
+            logger.debug(
+                f"Using first {len(feature_names)} columns and renaming: {rename_map}"
+            )
+            return df[columns_to_use].rename(columns=rename_map)
+
+        # If we have more feature_names than columns, log warning and return as-is
+        logger.warning(
+            f"Generated data has {len(current_columns)} columns but model expects "
+            f"{len(feature_names)} features. Column names may not match."
+        )
+        return df
 
     def _parse_output(self, raw_output: ChatMessage):
         try:

--- a/tests/llm/generators/test_base_llm_generators.py
+++ b/tests/llm/generators/test_base_llm_generators.py
@@ -260,3 +260,90 @@ def test_generator_empty_languages_requirements(Generator, args, kwargs):
 
     assert isinstance(dataset, Dataset)
     assert "### LANGUAGES\nen" in called_prompt
+
+
+@pytest.mark.parametrize(
+    "Generator,args,kwargs",
+    [
+        (LLMBasedDataGenerator, [], {"prompt": "Dummy prompt for {model.name}"}),
+        (ImplausibleDataGenerator, [], {}),
+        (AdversarialDataGenerator, ["demo", "demo"], {}),
+    ],
+)
+def test_generator_aligns_column_names_to_feature_names(Generator, args, kwargs):
+    """Test that generator renames columns to match model's feature_names.
+
+    This tests the fix for issue #2213 where different detectors would generate
+    datasets with inconsistent column names (e.g., 'user_input', 'query', 'user_question')
+    instead of the model's expected feature_names.
+    """
+    llm_client = Mock()
+    # LLM generates columns with different names than feature_names
+    llm_client.complete.side_effect = [
+        ChatMessage(
+            role="assistant",
+            content=json.dumps(
+                {
+                    "inputs": [
+                        {"user_input": "Hello, world!", "user_name": "Alice"},
+                        {"user_input": "How are you?", "user_name": "Bob"},
+                    ]
+                }
+            ),
+        )
+    ]
+
+    model = Mock()
+    # Model expects different column names
+    model.feature_names = ["message", "sender"]
+    model.name = "Mock model for test"
+    model.description = "This is a model for testing purposes"
+
+    generator = Generator(*args, **kwargs, llm_client=llm_client)
+
+    dataset = generator.generate_dataset(model, num_samples=2)
+
+    assert isinstance(dataset, Dataset)
+    assert len(dataset) == 2
+    # Columns should be renamed to match feature_names
+    assert list(dataset.df.columns) == ["message", "sender"]
+    assert dataset.df.iloc[0]["message"] == "Hello, world!"
+    assert dataset.df.iloc[1]["sender"] == "Bob"
+
+
+@pytest.mark.parametrize(
+    "Generator,args,kwargs",
+    [
+        (LLMBasedDataGenerator, [], {"prompt": "Dummy prompt for {model.name}"}),
+        (ImplausibleDataGenerator, [], {}),
+    ],
+)
+def test_generator_preserves_matching_column_names(Generator, args, kwargs):
+    """Test that generator preserves columns when they already match feature_names."""
+    llm_client = Mock()
+    llm_client.complete.side_effect = [
+        ChatMessage(
+            role="assistant",
+            content=json.dumps(
+                {
+                    "inputs": [
+                        {"question": "What is AI?", "context": "tech"},
+                        {"question": "How does ML work?", "context": "science"},
+                    ]
+                }
+            ),
+        )
+    ]
+
+    model = Mock()
+    model.feature_names = ["question", "context"]
+    model.name = "Mock model for test"
+    model.description = "This is a model for testing purposes"
+
+    generator = Generator(*args, **kwargs, llm_client=llm_client)
+
+    dataset = generator.generate_dataset(model, num_samples=2)
+
+    assert isinstance(dataset, Dataset)
+    assert list(dataset.df.columns) == ["question", "context"]
+    assert dataset.df.iloc[0]["question"] == "What is AI?"


### PR DESCRIPTION
## Summary
- Add column name alignment in LLM generators to ensure generated datasets match the model's expected feature_names
- This fixes the KeyError that occurs when different detectors generate datasets with inconsistent column names

## Root Cause
Different LLM-based detectors were generating datasets with different column names:
- sycophancy: `query`
- harmfulness: `user_input`
- stereotypes: `user_input`
- etc.

When a model specifies `feature_names=["message"]`, the `prepare_dataframe()` method fails with KeyError because the generated dataset doesn't contain the expected column names.

## Solution
Add `_align_columns_to_feature_names()` method that:
- Reorders columns if they match feature_names but in different order
- Renames columns if count matches (positional mapping)
- Handles cases with more generated columns than expected features
- Logs warnings for edge cases

## Test plan
- Added unit tests for column alignment functionality
- Existing tests should continue to pass

Fixes #2213