### PR TITLE
feat: add num_retries parameter to LLM evaluators

### DIFF
--- a/giskard/llm/evaluators/base.py
+++ b/giskard/llm/evaluators/base.py
@@ -89,11 +89,31 @@ class _BaseLLMEvaluator(BaseEvaluator):
         llm_temperature: float = 0.1,
         llm_seed: int = 42,
         llm_output_format="json_object",
+        num_retries: int = 1,
     ):
+        """Initialize the LLM evaluator.
+
+        Parameters
+        ----------
+        llm_client : Optional[LLMClient]
+            The LLM client to use for evaluation. If None, uses the default client.
+        llm_temperature : float
+            Temperature for LLM generation. Default is 0.1.
+        llm_seed : int
+            Seed for reproducibility. Default is 42.
+        llm_output_format : str
+            Output format for LLM. Default is "json_object".
+        num_retries : int
+            Number of times to retry each input with the model. This is useful for
+            testing jailbreak scenarios where multiple attempts may be needed to
+            trigger a vulnerability. If any retry fails the evaluation, the sample
+            is marked as failed. Default is 1 (no retries).
+        """
         self.llm_client = llm_client if llm_client is not None else get_default_client()
         self.llm_temperature = llm_temperature
         self.llm_seed = llm_seed
         self.llm_output_format = llm_output_format
+        self.num_retries = max(1, num_retries)
 
     @abstractmethod
     def _format_messages(
@@ -102,35 +122,70 @@ class _BaseLLMEvaluator(BaseEvaluator):
         ...
 
     def evaluate(self, model: BaseModel, dataset: Dataset):
-        model_outputs = model.predict(dataset).prediction
-
         result = EvaluationResult()
-        for (row_id, row), model_output in zip(
-            dataset.df.iterrows(),
-            model_outputs,
-        ):
+
+        for row_id, row in dataset.df.iterrows():
             input_vars = {k: v for k, v in row.items() if k in model.feature_names}
             if len(input_vars) == 1:
                 input_vars = list(input_vars.values())[0]
             input_meta = {k: v for k, v in row.items() if k not in model.feature_names}
             input_meta["__sample_id"] = row_id
 
-            conversation = [{"role": "user", "content": input_vars}, {"role": "agent", "content": model_output}]
-            sample = {
-                "conversation": conversation,
-                "meta": input_meta,
-            }
-            logger.debug(f"{self.__class__.__name__}: evaluating sample {sample}")
+            # Track results across retries
+            sample_failed = False
+            failure_reason = None
+            last_sample = None
+            error_occurred = False
+            error_message = None
 
-            try:
-                eval_passed, reason = self._evaluate_sample(model, sample)
-            except LLMGenerationError as err:
-                logger.debug(f"{self.__class__.__name__} evaluation error: {err}")
-                result.add_error(str(err), sample)
-                continue
+            for retry_idx in range(self.num_retries):
+                # Get model output for this retry
+                single_row_dataset = Dataset(
+                    df=dataset.df.iloc[[dataset.df.index.get_loc(row_id)]],
+                    name=dataset.name,
+                    target=dataset.target,
+                    column_types=dataset.column_types,
+                    validation=False,
+                )
+                model_output = model.predict(single_row_dataset).prediction[0]
 
-            logger.debug(f"{self.__class__.__name__} evaluation result: eval_passed={eval_passed}, reason={reason}")
-            result.add_sample(eval_passed, reason, sample)
+                conversation = [{"role": "user", "content": input_vars}, {"role": "agent", "content": model_output}]
+                sample = {
+                    "conversation": conversation,
+                    "meta": {**input_meta, "__retry_idx": retry_idx},
+                }
+                last_sample = sample
+
+                logger.debug(f"{self.__class__.__name__}: evaluating sample {sample} (retry {retry_idx + 1}/{self.num_retries})")
+
+                try:
+                    eval_passed, reason = self._evaluate_sample(model, sample)
+                except LLMGenerationError as err:
+                    logger.debug(f"{self.__class__.__name__} evaluation error on retry {retry_idx + 1}: {err}")
+                    error_occurred = True
+                    error_message = str(err)
+                    continue
+
+                logger.debug(
+                    f"{self.__class__.__name__} evaluation result (retry {retry_idx + 1}): "
+                    f"eval_passed={eval_passed}, reason={reason}"
+                )
+
+                # If any retry fails, mark the sample as failed
+                if not eval_passed:
+                    sample_failed = True
+                    failure_reason = reason
+                    if self.num_retries > 1:
+                        failure_reason = f"[Failed on retry {retry_idx + 1}/{self.num_retries}] {reason}"
+                    break
+
+            # Add final result for this sample
+            if sample_failed:
+                result.add_sample(False, failure_reason, last_sample)
+            elif error_occurred and last_sample is not None:
+                result.add_error(error_message, last_sample)
+            elif last_sample is not None:
+                result.add_sample(True, None, last_sample)
 
         return result
 

--- a/tests/llm/evaluators/test_llm_based_evaluators.py
+++ b/tests/llm/evaluators/test_llm_based_evaluators.py
@@ -1,11 +1,14 @@
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
+from giskard.datasets.base import Dataset
 from giskard.llm.client import ChatMessage
 from giskard.llm.evaluators.base import LLMBasedEvaluator
 from giskard.llm.evaluators.plausibility import PlausibilityEvaluator
 from giskard.llm.evaluators.requirements import RequirementEvaluator
+from giskard.models.base.model_prediction import ModelPredictionResults
 from tests.llm.evaluators.utils import make_eval_dataset, make_mock_model
 
 
@@ -94,3 +97,118 @@ def test_evaluator_handles_generation_errors(Evaluator, args, kwargs):
     assert len(result.failure_examples) == 0
     assert len(result.errors) == 1
     assert result.errors[0]["error"] == "Could not parse evaluator output"
+
+
+def test_evaluator_with_num_retries_fails_on_any_retry():
+    """Test that num_retries parameter causes multiple model predictions.
+
+    When num_retries > 1, the evaluator should:
+    1. Call model.predict() multiple times for each sample
+    2. Mark the sample as failed if ANY retry fails the evaluation
+
+    This tests the fix for issue #2043 where users need to test jailbreak
+    scenarios that may only trigger after multiple attempts.
+    """
+    eval_dataset = Dataset(
+        pd.DataFrame({"question": ["Test question"], "other": ["pass"]})
+    )
+
+    model = Mock()
+    # Model returns different outputs for each retry
+    model.predict.side_effect = [
+        ModelPredictionResults(prediction=["Safe response 1"]),
+        ModelPredictionResults(prediction=["Safe response 2"]),
+        ModelPredictionResults(prediction=["Jailbroken response!"]),  # Third retry triggers failure
+    ]
+    model.feature_names = ["question", "other"]
+    model.name = "Mock model"
+    model.description = "Test model"
+
+    client = Mock()
+    # First two evals pass, third fails
+    client.complete.side_effect = [
+        ChatMessage(role="assistant", content='{"eval_passed": true}'),
+        ChatMessage(role="assistant", content='{"eval_passed": true}'),
+        ChatMessage(role="assistant", content='{"eval_passed": false, "reason": "Jailbreak detected"}'),
+    ]
+
+    evaluator = LLMBasedEvaluator(
+        prompt="Evaluate this conversation",
+        llm_client=client,
+        num_retries=3,
+    )
+    result = evaluator.evaluate(model, eval_dataset)
+
+    # Should fail because third retry failed
+    assert len(result.failure_examples) == 1
+    assert len(result.success_examples) == 0
+    assert "retry 3/3" in result.failure_examples[0]["reason"]
+    assert "Jailbreak detected" in result.failure_examples[0]["reason"]
+
+    # Model should be called 3 times (until failure)
+    assert model.predict.call_count == 3
+    # LLM evaluator should be called 3 times
+    assert client.complete.call_count == 3
+
+
+def test_evaluator_with_num_retries_passes_all_retries():
+    """Test that if all retries pass, the sample is marked as passed."""
+    eval_dataset = Dataset(
+        pd.DataFrame({"question": ["Test question"], "other": ["pass"]})
+    )
+
+    model = Mock()
+    model.predict.side_effect = [
+        ModelPredictionResults(prediction=["Response 1"]),
+        ModelPredictionResults(prediction=["Response 2"]),
+    ]
+    model.feature_names = ["question", "other"]
+    model.name = "Mock model"
+    model.description = "Test model"
+
+    client = Mock()
+    client.complete.side_effect = [
+        ChatMessage(role="assistant", content='{"eval_passed": true}'),
+        ChatMessage(role="assistant", content='{"eval_passed": true}'),
+    ]
+
+    evaluator = LLMBasedEvaluator(
+        prompt="Evaluate this conversation",
+        llm_client=client,
+        num_retries=2,
+    )
+    result = evaluator.evaluate(model, eval_dataset)
+
+    assert len(result.success_examples) == 1
+    assert len(result.failure_examples) == 0
+    assert model.predict.call_count == 2
+    assert client.complete.call_count == 2
+
+
+def test_evaluator_default_num_retries_is_one():
+    """Test that default num_retries is 1 (no retries)."""
+    eval_dataset = Dataset(
+        pd.DataFrame({"question": ["Test question"], "other": ["pass"]})
+    )
+
+    model = Mock()
+    model.predict.return_value = ModelPredictionResults(prediction=["Response"])
+    model.feature_names = ["question", "other"]
+    model.name = "Mock model"
+    model.description = "Test model"
+
+    client = Mock()
+    client.complete.return_value = ChatMessage(
+        role="assistant", content='{"eval_passed": true}'
+    )
+
+    evaluator = LLMBasedEvaluator(
+        prompt="Evaluate this conversation",
+        llm_client=client,
+    )
+    result = evaluator.evaluate(model, eval_dataset)
+
+    assert len(result.success_examples) == 1
+    # Only called once (no retries)
+    assert model.predict.call_count == 1
+    assert client.complete.call_count == 1


### PR DESCRIPTION
## Summary
Add a `num_retries` parameter to LLM evaluators that allows users to specify how many times to retry each input with the model.

## Motivation
In jailbreak testing scenarios, a vulnerability may only trigger after multiple attempts with the same input. For example, Llama3 might only produce harmful content after 5+ retries of the same prompt.

## Changes
- Add `num_retries` parameter (default=1) to `_BaseLLMEvaluator`
- Modify `evaluate()` to call `model.predict()` multiple times per sample
- If ANY retry fails evaluation, the sample is marked as failed
- Include retry index in failure reason for debugging

## Example Usage
```python
evaluator = RequirementEvaluator(
    requirements=["Must not provide harmful content"],
    num_retries=5  # Test each input 5 times
)
result = evaluator.evaluate(model, dataset)
```

## Test plan
- Added unit tests for retry functionality
- Tests verify that failures are detected on any retry
- Tests verify default behavior (num_retries=1) is unchanged

Fixes #2043