### PR TITLE
feat: add checkpointing to testset generation

### DIFF
--- a/giskard/rag/testset_generation.py
+++ b/giskard/rag/testset_generation.py
@@ -1,6 +1,8 @@
 from typing import Optional, Sequence, Union
 
 import itertools
+import logging
+from pathlib import Path
 
 from ..utils.analytics_collector import analytics
 from .knowledge_base import KnowledgeBase
@@ -16,6 +18,8 @@ from .question_generators import (
 from .question_generators.utils import maybe_tqdm
 from .testset import QATestset
 
+logger = logging.getLogger(__name__)
+
 
 def generate_testset(
     knowledge_base: KnowledgeBase,
@@ -23,6 +27,8 @@ def generate_testset(
     question_generators: Optional[Union[QuestionGenerator, Sequence[QuestionGenerator]]] = None,
     language: Optional[str] = "en",
     agent_description: Optional[str] = "This agent is a chatbot that answers question from users.",
+    checkpoint_path: Optional[str] = None,
+    checkpoint_every: int = 10,
 ) -> QATestset:
     """Generate a testset from a knowledge base.
 
@@ -39,6 +45,13 @@ def generate_testset(
         The language to use for question generation. The default is "en" to generate questions in english.
     agent_description : str, optional
         Description of the agent to be evaluated. This will be used in the prompt for question generation to get more fitting questions.
+    checkpoint_path : str, optional
+        Path to save intermediate results during generation. If provided, progress will be saved
+        periodically and can be resumed if generation fails. If the file exists, generation will
+        resume from the checkpoint. Default is None (no checkpointing).
+    checkpoint_every : int, optional
+        Number of questions to generate before saving a checkpoint. Default is 10.
+        Only used when checkpoint_path is provided.
 
     Returns
     -------
@@ -62,11 +75,30 @@ def generate_testset(
     # Ensure topics are computed and documents populated (@TODO: remove this)
     _ = knowledge_base.topics
 
-    # Generate questions
+    # Load existing checkpoint if available
+    questions = []
+    num_existing = 0
+    if checkpoint_path and Path(checkpoint_path).exists():
+        try:
+            existing_testset = QATestset.load(checkpoint_path)
+            questions = list(existing_testset.samples)
+            num_existing = len(questions)
+            logger.info(f"Resuming from checkpoint: {num_existing} questions already generated")
+        except Exception as e:
+            logger.warning(f"Failed to load checkpoint from {checkpoint_path}: {e}. Starting fresh.")
+            questions = []
+            num_existing = 0
 
+    # Calculate remaining questions to generate
+    num_remaining = max(0, num_questions - num_existing)
+    if num_remaining == 0:
+        logger.info(f"Checkpoint already contains {num_existing} questions, nothing to generate")
+        return QATestset(questions)
+
+    # Generate questions
     # @TODO: fix this ugly way to distribute the questions across generators
     generator_num_questions = [
-        num_questions // len(question_generators) + (1 if i < num_questions % len(question_generators) else 0)
+        num_remaining // len(question_generators) + (1 if i < num_remaining % len(question_generators) else 0)
         for i in range(len(question_generators))
     ]
 
@@ -82,11 +114,32 @@ def generate_testset(
         ]
     )
 
-    questions = list(maybe_tqdm(main_generator, total=num_questions, desc="Generating questions"))
-
-    for question in questions:
+    # Generate questions with checkpointing
+    generated_since_checkpoint = 0
+    for question in maybe_tqdm(main_generator, total=num_remaining, desc="Generating questions"):
+        # Add topic metadata
         topic_id = knowledge_base[question.metadata["seed_document_id"]].topic_id
         question.metadata["topic"] = knowledge_base.topics[topic_id]
+
+        questions.append(question)
+        generated_since_checkpoint += 1
+
+        # Save checkpoint periodically
+        if checkpoint_path and generated_since_checkpoint >= checkpoint_every:
+            try:
+                QATestset(questions).save(checkpoint_path)
+                logger.debug(f"Checkpoint saved: {len(questions)} questions")
+                generated_since_checkpoint = 0
+            except Exception as e:
+                logger.warning(f"Failed to save checkpoint: {e}")
+
+    # Save final checkpoint
+    if checkpoint_path and generated_since_checkpoint > 0:
+        try:
+            QATestset(questions).save(checkpoint_path)
+            logger.info(f"Final checkpoint saved: {len(questions)} questions")
+        except Exception as e:
+            logger.warning(f"Failed to save final checkpoint: {e}")
 
     analytics.track(
         "raget:testset-generation",
@@ -96,6 +149,8 @@ def generate_testset(
             "agent_description": agent_description,
             "question_generators": [qg.__class__.__name__ for qg in question_generators],
             "knowledge_base_size": len(knowledge_base._documents),
+            "resumed_from_checkpoint": num_existing > 0,
+            "num_resumed": num_existing,
         },
     )
     return QATestset(questions)

--- a/tests/rag/test_testset_generator.py
+++ b/tests/rag/test_testset_generator.py
@@ -191,3 +191,106 @@ def test_question_generation_fail(caplog):
         )
     assert len(testset.to_pandas()) == 2
     assert "Encountered error in question generation" in caplog.text
+
+
+def test_testset_checkpointing(tmp_path):
+    """Test that checkpointing saves progress during generation.
+
+    This tests the fix for issue #2022 where all progress was lost
+    if testset generation failed midway through.
+    """
+    checkpoint_file = tmp_path / "checkpoint.jsonl"
+
+    knowledge_base = MagicMock()
+    knowledge_base._document_index = {"0": Mock(topic_id=0), "1": Mock(topic_id=1)}
+    knowledge_base.__getitem__ = lambda obj, idx: getattr(obj, "_document_index")[idx]
+    knowledge_base.topics = ["Cheese", "Ski"]
+
+    question_generator = Mock()
+    question_generator.generate_questions.return_value = [q1, q2]
+
+    # Generate with checkpointing
+    test_set = generate_testset(
+        knowledge_base=knowledge_base,
+        num_questions=2,
+        question_generators=question_generator,
+        checkpoint_path=str(checkpoint_file),
+        checkpoint_every=1,
+    )
+
+    assert len(test_set) == 2
+    assert checkpoint_file.exists()
+
+    # Verify checkpoint contains the data
+    from giskard.rag import QATestset
+    loaded = QATestset.load(str(checkpoint_file))
+    assert len(loaded) == 2
+
+
+def test_testset_resume_from_checkpoint(tmp_path, caplog):
+    """Test that generation can resume from a checkpoint."""
+    checkpoint_file = tmp_path / "checkpoint.jsonl"
+
+    knowledge_base = MagicMock()
+    knowledge_base._document_index = {"0": Mock(topic_id=0), "1": Mock(topic_id=1)}
+    knowledge_base.__getitem__ = lambda obj, idx: getattr(obj, "_document_index")[idx]
+    knowledge_base.topics = ["Cheese", "Ski"]
+
+    # First, create a partial checkpoint manually
+    from giskard.rag import QATestset
+    initial_questions = [q1]
+    # Add topic metadata as generate_testset would
+    initial_questions[0].metadata["topic"] = "Ski"
+    QATestset(initial_questions).save(str(checkpoint_file))
+
+    # Now generate with resume - should only generate 1 more question
+    question_generator = Mock()
+    question_generator.generate_questions.return_value = [q2]
+
+    with caplog.at_level(logging.INFO, logger="giskard.rag"):
+        test_set = generate_testset(
+            knowledge_base=knowledge_base,
+            num_questions=2,
+            question_generators=question_generator,
+            checkpoint_path=str(checkpoint_file),
+        )
+
+    assert len(test_set) == 2
+    assert "Resuming from checkpoint: 1 questions already generated" in caplog.text
+    # Generator should be asked for only 1 question (2 - 1 existing)
+    question_generator.generate_questions.assert_called_once()
+    call_kwargs = question_generator.generate_questions.call_args[1]
+    assert call_kwargs["num_questions"] == 1
+
+
+def test_testset_checkpoint_complete(tmp_path, caplog):
+    """Test that generation skips if checkpoint already has all questions."""
+    checkpoint_file = tmp_path / "checkpoint.jsonl"
+
+    knowledge_base = MagicMock()
+    knowledge_base._document_index = {"0": Mock(topic_id=0), "1": Mock(topic_id=1)}
+    knowledge_base.__getitem__ = lambda obj, idx: getattr(obj, "_document_index")[idx]
+    knowledge_base.topics = ["Cheese", "Ski"]
+
+    # Create a complete checkpoint
+    from giskard.rag import QATestset
+    complete_questions = [q1, q2]
+    for q in complete_questions:
+        topic_id = knowledge_base[q.metadata["seed_document_id"]].topic_id
+        q.metadata["topic"] = knowledge_base.topics[topic_id]
+    QATestset(complete_questions).save(str(checkpoint_file))
+
+    question_generator = Mock()
+
+    with caplog.at_level(logging.INFO, logger="giskard.rag"):
+        test_set = generate_testset(
+            knowledge_base=knowledge_base,
+            num_questions=2,
+            question_generators=question_generator,
+            checkpoint_path=str(checkpoint_file),
+        )
+
+    assert len(test_set) == 2
+    assert "nothing to generate" in caplog.text
+    # Generator should NOT be called since we have all questions
+    question_generator.generate_questions.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `checkpoint_path` and `checkpoint_every` parameters to `generate_testset()`
- Save progress periodically during generation and resume from checkpoint if interrupted

Fixes #2022