### PR TITLE
feat: reexport resolve at root level

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -34,6 +34,7 @@ from .core import (
     TestCase,
     TestCaseResult,
     Trace,
+    resolve,
 )
 from .generators.user import UserSimulator
 from .judges import (
@@ -79,6 +80,7 @@ __all__ = [
     "TestCase",
     "TestCaseResult",
     "Trace",
+    "resolve",
     "Interact",
     "Interaction",
     "InteractionSpec",

--- a/libs/giskard-checks/src/giskard/checks/core/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/core/__init__.py
@@ -1,4 +1,5 @@
 from .check import Check
+from .extraction import resolve
 from .interaction import Interact, Interaction, InteractionSpec, Trace
 from .result import (
     CheckResult,
@@ -26,4 +27,5 @@ __all__ = [
     "SuiteResult",
     "TestCaseResult",
     "TestCase",
+    "resolve",
 ]


### PR DESCRIPTION
Reexports `resolve` at the root level of `giskard.checks` as requested.

Currently users have to do `from giskard.checks.core.extraction import resolve`. 
This change allows `from giskard.checks import resolve`.

Fixes #2310