### PR TITLE
feat: re-export resolve at giskard.checks level

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -34,6 +34,7 @@ from .core import (
     TestCase,
     TestCaseResult,
     Trace,
+    resolve,
 )
 from .generators.user import UserSimulator
 from .judges import (
@@ -110,4 +111,6 @@ __all__ = [
     # Settings
     "set_default_generator",
     "get_default_generator",
+    # Extraction
+    "resolve",
 ]

--- a/libs/giskard-checks/src/giskard/checks/core/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/core/__init__.py
@@ -1,4 +1,5 @@
 from .check import Check
+from .extraction import resolve
 from .interaction import Interact, Interaction, InteractionSpec, Trace
 from .result import (
     CheckResult,
@@ -26,4 +27,5 @@ __all__ = [
     "SuiteResult",
     "TestCaseResult",
     "TestCase",
+    "resolve",
 ]


### PR DESCRIPTION
## Summary

Closes #2310

Re-exports `resolve` from `giskard.checks.core.extraction` at two levels:

- `giskard.checks.core` — added import and `__all__` entry
- `giskard.checks` — added import and `__all__` entry

This allows:
```python
from giskard.checks import resolve
```
instead of:
```python
from giskard.checks.core.extraction import resolve
```

## Changes

- `libs/giskard-checks/src/giskard/checks/core/__init__.py` — import `resolve` from `.extraction`, add to `__all__`
- `libs/giskard-checks/src/giskard/checks/__init__.py` — import `resolve` from `.core`, add to `__all__`