### PR TITLE
fix(checks): make Suite.append() return self for fluent chaining

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from typing import Any, Generic, TypeVar
 
@@ -38,9 +40,11 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     scenario1 = Scenario("scenario_1").interact("hello")
     scenario2 = Scenario("scenario_2").interact("hi")
 
-    suite = Suite(name="my_suite", target=my_sut)
-    suite.append(scenario1)
-    suite.append(scenario2)
+    suite = (
+        Suite(name="my_suite", target=my_sut)
+        .append(scenario1)
+        .append(scenario2)
+    )
 
     result = await suite.run()
     print(result.pass_rate)
@@ -63,15 +67,21 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
     def append(
         self,
         scenario: Scenario[InputType, OutputType, Trace[Any, Any]],
-    ) -> None:
+    ) -> Suite[InputType, OutputType]:
         """Add a scenario to the suite.
 
         Parameters
         ----------
         scenario : Scenario
             The scenario to add to the suite.
+
+        Returns
+        -------
+        Suite
+            The suite itself, enabling fluent chaining.
         """
         self.scenarios.append(scenario)
+        return self
 
     async def run(
         self,

--- a/libs/giskard-checks/tests/core/test_suite.py
+++ b/libs/giskard-checks/tests/core/test_suite.py
@@ -111,6 +111,25 @@ async def test_suite_result_aggregation():
 
 
 @pytest.mark.asyncio
+async def test_suite_append_chainable(sut1):
+    """Verify that append() returns self so calls can be chained."""
+    scenario1 = Scenario("s1").interact("hello")
+    scenario2 = Scenario("s2").interact("world")
+
+    suite = (
+        Suite(name="chain_suite", target=sut1)
+        .append(scenario1)
+        .append(scenario2)
+    )
+
+    assert isinstance(suite, Suite)
+    assert len(suite.scenarios) == 2
+
+    result = await suite.run()
+    assert result.passed_count == 2
+
+
+@pytest.mark.asyncio
 async def test_suite_callable_target():
     """Verify that suite target can be a callable."""
     scenario = Scenario("s1").interact("hello")


### PR DESCRIPTION
Fixes #2315

`Suite.append()` previously returned `None`, preventing fluent builder patterns. Now returns `self`, enabling:

```python
suite = (
    Suite(name="my_suite", target=my_sut)
    .append(scenario1)
    .append(scenario2)
)
```

Changes:
- `Suite.append()` return type changed from `None` to `Suite[InputType, OutputType]`
- Added `from __future__ import annotations` for forward reference support
- Updated class docstring example to show chaining
- Added `test_suite_append_chainable` test

All existing tests pass.

---
Developed with AI assistance (Claude Code)