### PR TITLE
build(security): ignore pygments CVE-2026-4539 in pip-audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,9 @@ typecheck: ## Run type checking with basedpyright
 	uv tool run basedpyright --level error .
 
 security: ## Check for security vulnerabilities
-	uv run pip-audit --skip-editable
+	# TODO: Remove --ignore-vuln CVE-2026-4539 flag when patch exists for pygments
+	# This is a low severity redos vulnerability: https://www.cve.org/CVERecord?id=CVE-2026-4539
+	uv run pip-audit --skip-editable --ignore-vuln CVE-2026-4539
 
 generate-licenses: ## Generate licenses
 	uv tool run licensecheck --license MIT \


### PR DESCRIPTION
pip-audit fails until pygments ships a fix for this low-severity ReDoS issue. Since all pygments versions are affected and there's no patch we can't do much right now. (Added TODO note to remove --ignore-vuln once a patch is released)