### PR TITLE
build(security): use GitHub App token for release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,13 @@ jobs:
             exit 1
           fi
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -135,20 +142,20 @@ jobs:
       - name: Push to main
         if: ${{ github.event.inputs.dry_run == 'false' && github.ref_name == 'main' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
           git push origin main
 
       - name: Create tag
         if: ${{ github.event.inputs.dry_run == 'false' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
           git tag "$TAG"
           git push origin "$TAG"
 


### PR DESCRIPTION
## Summary

- Add `actions/create-github-app-token` step to generate a short-lived token from the `giskard-oss-release` GitHub App
- Use the app token (instead of `github.token`) for pushing version bump commits and tags to `main`, bypassing branch protection
- Token is scoped to `Contents: write` only, expires in 1 hour, and is not persisted on disk

## Prerequisites

- [x] GitHub App `giskard-oss-release` created (ID: `3190683`)
- [x] App added to `main` branch protection bypass list
- [x] `RELEASE_APP_ID` variable set in `release` environment
- [x] `RELEASE_APP_PRIVATE_KEY` secret set in `release` environment

## After merging

- [ ] Delete `RELEASE_PAT_TOKEN` from org secrets
- [ ] Run a dry-run release to verify the flow works


Made with [Cursor](https://cursor.com)