### PR TITLE
feat(telemetry): add optional PostHog analytics to giskard-core and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ pip install giskard
 
 Requires Python 3.12+.
 
+**Telemetry:** Libraries built on `giskard-core` (including `giskard-checks`) may send **optional, aggregated usage analytics** to help improve the product. No prompts, model outputs, or scenario text are included. See [what is collected and how to opt out](libs/giskard-core/README.md#telemetry).
+
 ______________________________________________________________________
 
 Giskard is an open-source Python library for **testing and evaluating agentic systems**. The v3 architecture is a modular set of focused packages — each carrying only the dependencies it needs — built from scratch to wrap anything: an LLM, a black-box agent, or a multi-step pipeline.

--- a/libs/giskard-agents/README.md
+++ b/libs/giskard-agents/README.md
@@ -22,6 +22,10 @@ For development, install with dev dependencies:
 uv add giskard-agents --dev
 ```
 
+## Telemetry
+
+This package depends on `giskard-core`, which may send **optional usage analytics** when imported or when downstream libraries record events. See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for details and how to opt out.
+
 ## Core Concepts
 
 Three basic elements to keep in mind:

--- a/libs/giskard-agents/tests/conftest.py
+++ b/libs/giskard-agents/tests/conftest.py
@@ -4,6 +4,12 @@ import pytest
 from giskard.agents.embeddings import EmbeddingModel
 from giskard.agents.embeddings.base import EmbeddingParams
 from giskard.agents.generators import Generator
+from giskard.core import disable_telemetry
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Disable telemetry for tests."""
+    disable_telemetry()
 
 
 @pytest.fixture

--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -20,6 +20,8 @@ pip install giskard-checks
 
 Requires Python >= 3.12.
 
+**Telemetry:** This package depends on `giskard-core`, which may send **optional, aggregated usage analytics** when you run scenarios, suites, or test cases (no prompts, outputs, or scenario text). See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for what is collected and how to opt out (`DO_NOT_TRACK`, `GISKARD_TELEMETRY_DISABLED`, or `disable_telemetry()`).
+
 **Dependencies:**
 - `pydantic>=2.11.7` - Core data validation and serialization
 - `giskard-agents>=0.3` - LLM integration and workflow management

--- a/libs/giskard-checks/src/giskard/checks/_telemetry_props.py
+++ b/libs/giskard-checks/src/giskard/checks/_telemetry_props.py
@@ -1,0 +1,73 @@
+"""Aggregate, non-identifying properties for PostHog (no names, messages, or content)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from .core.check import Check
+from .core.scenario import Scenario, Step
+
+_DEFAULT_SCENARIO_NAME = "Unnamed Scenario"
+
+
+def check_kind_counts_from_steps(steps: list[Step[Any, Any, Any]]) -> dict[str, int]:
+    kinds = [getattr(c, "kind", "unknown") for step in steps for c in step.checks]
+    return dict(Counter(kinds))
+
+
+def check_kind_counts_from_sequence(
+    checks: list[Check[Any, Any, Any]],
+) -> dict[str, int]:
+    kinds = [getattr(c, "kind", "unknown") for c in checks]
+    return dict(Counter(kinds))
+
+
+def scenario_shape_properties(
+    scenario: Scenario[Any, Any, Any],
+    *,
+    has_target: bool,
+) -> dict[str, Any]:
+    total_interacts = sum(len(s.interacts) for s in scenario.steps)
+    total_checks = sum(len(s.checks) for s in scenario.steps)
+    return {
+        "integration": "giskard-checks",
+        "step_count": len(scenario.steps),
+        "total_interaction_specs": total_interacts,
+        "total_checks": total_checks,
+        "has_target": has_target,
+        "uses_custom_trace_type": scenario.trace_type is not None,
+        "has_scenario_annotations": bool(scenario.annotations),
+        "uses_custom_scenario_name": scenario.name != _DEFAULT_SCENARIO_NAME,
+        "check_kinds": check_kind_counts_from_steps(scenario.steps),
+    }
+
+
+def test_case_shape_properties(
+    *,
+    check_count: int,
+    trace_interaction_count: int,
+    has_trace_annotations: bool,
+    has_test_case_name: bool,
+    check_kinds: dict[str, int],
+) -> dict[str, Any]:
+    return {
+        "integration": "giskard-checks",
+        "check_count": check_count,
+        "trace_interaction_count": trace_interaction_count,
+        "has_trace_annotations": has_trace_annotations,
+        "has_test_case_name": has_test_case_name,
+        "check_kinds": check_kinds,
+    }
+
+
+def suite_shape_properties(
+    *,
+    scenario_count: int,
+    has_target: bool,
+) -> dict[str, Any]:
+    return {
+        "integration": "giskard-checks",
+        "scenario_count": scenario_count,
+        "has_target": has_target,
+    }

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -8,8 +8,15 @@ updated Trace objects via the async generator protocol.
 import time
 from typing import Any, cast
 
-from giskard.core.utils import NOT_PROVIDED, NotProvided
+from giskard.core import (
+    NOT_PROVIDED,
+    NotProvided,
+    scoped_telemetry,
+    telemetry,
+    telemetry_tag,
+)
 
+from .._telemetry_props import scenario_shape_properties
 from ..core import Trace
 from ..core.interaction import Interact
 from ..core.result import CheckResult, ScenarioResult, TestCaseResult
@@ -78,6 +85,7 @@ class ScenarioRunner:
     ```
     """
 
+    @scoped_telemetry
     async def run[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
@@ -110,6 +118,9 @@ class ScenarioRunner:
         """
 
         start_time = time.perf_counter()
+        telemetry_tag("giskard_component", "scenario_runner")
+        telemetry_tag("giskard_operation", "scenario_run")
+
         trace = (
             scenario.trace_type(annotations=scenario.annotations)
             if scenario.trace_type is not None
@@ -121,6 +132,16 @@ class ScenarioRunner:
 
         steps = _build_steps(scenario, target)
         steps_results: list[TestCaseResult] = []
+        has_target = target is not NOT_PROVIDED
+        shape_props = scenario_shape_properties(
+            scenario,
+            has_target=has_target,
+        )
+
+        _ = telemetry.capture(
+            "checks_scenario_run_started",
+            properties=shape_props,
+        )
 
         for step in steps:
             trace = await trace.with_interactions(*step.interacts)
@@ -150,12 +171,24 @@ class ScenarioRunner:
                 steps_results.append(step_result)
 
         end_time = time.perf_counter()
-        return ScenarioResult(
+
+        result = ScenarioResult(
             scenario_name=scenario.name,
             steps=steps_results,
             duration_ms=int((end_time - start_time) * 1000),
             final_trace=trace,
         )
+
+        _ = telemetry.capture(
+            "checks_scenario_run_finished",
+            properties={
+                **shape_props,
+                "outcome_status": result.status.value,
+                "duration_ms": int((end_time - start_time) * 1000),
+            },
+        )
+
+        return result
 
 
 _default_runner = ScenarioRunner()

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -171,11 +171,12 @@ class ScenarioRunner:
                 steps_results.append(step_result)
 
         end_time = time.perf_counter()
+        duration_ms = int((end_time - start_time) * 1000)
 
         result = ScenarioResult(
             scenario_name=scenario.name,
             steps=steps_results,
-            duration_ms=int((end_time - start_time) * 1000),
+            duration_ms=duration_ms,
             final_trace=trace,
         )
 
@@ -184,7 +185,7 @@ class ScenarioRunner:
             properties={
                 **shape_props,
                 "outcome_status": result.status.value,
-                "duration_ms": int((end_time - start_time) * 1000),
+                "duration_ms": duration_ms,
             },
         )
 

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -1,9 +1,11 @@
 import time
 from typing import Any, Generic, Self, TypeVar
 
+from giskard.core import telemetry, telemetry_run_context, telemetry_tag
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
 
+from .._telemetry_props import suite_shape_properties
 from ..core.interaction import Trace
 from ..core.result import ScenarioResult, SuiteResult
 from ..core.scenario import Scenario
@@ -115,20 +117,49 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
         result_v2 = await suite.run(target=my_sut_v2)
         ```
         """
-        start_time = time.perf_counter()
         results: list[ScenarioResult[Trace[Any, Any]]] = []
 
         target = target if not isinstance(target, NotProvided) else self.target
+        has_target = not isinstance(target, NotProvided)
 
-        for scenario in self.scenarios:
-            result = await scenario.run(
-                target=target, return_exception=return_exception
+        with telemetry_run_context():
+            telemetry_tag("giskard_component", "suite")
+            telemetry_tag("giskard_operation", "suite_run")
+
+            _ = telemetry.capture(
+                "checks_suite_run_started",
+                properties=suite_shape_properties(
+                    scenario_count=len(self.scenarios),
+                    has_target=has_target,
+                ),
             )
-            results.append(result)
 
-        end_time = time.perf_counter()
+            start_time = time.perf_counter()
+            for scenario in self.scenarios:
+                result = await scenario.run(
+                    target=target, return_exception=return_exception
+                )
+                results.append(result)
+            end_time = time.perf_counter()
 
-        return SuiteResult(
-            results=results,
-            duration_ms=int((end_time - start_time) * 1000),
-        )
+            suite_result = SuiteResult(
+                results=results,
+                duration_ms=int((end_time - start_time) * 1000),
+            )
+
+            _ = telemetry.capture(
+                "checks_suite_run_finished",
+                properties={
+                    **suite_shape_properties(
+                        scenario_count=len(self.scenarios),
+                        has_target=has_target,
+                    ),
+                    "duration_ms": suite_result.duration_ms,
+                    "passed_count": suite_result.passed_count,
+                    "failed_count": suite_result.failed_count,
+                    "errored_count": suite_result.errored_count,
+                    "skipped_count": suite_result.skipped_count,
+                },
+            )
+
+        return suite_result

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -126,12 +126,13 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             telemetry_tag("giskard_component", "suite")
             telemetry_tag("giskard_operation", "suite_run")
 
+            shape_props = suite_shape_properties(
+                scenario_count=len(self.scenarios),
+                has_target=has_target,
+            )
             _ = telemetry.capture(
                 "checks_suite_run_started",
-                properties=suite_shape_properties(
-                    scenario_count=len(self.scenarios),
-                    has_target=has_target,
-                ),
+                properties=shape_props,
             )
 
             start_time = time.perf_counter()
@@ -150,10 +151,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
             _ = telemetry.capture(
                 "checks_suite_run_finished",
                 properties={
-                    **suite_shape_properties(
-                        scenario_count=len(self.scenarios),
-                        has_target=has_target,
-                    ),
+                    **shape_props,
                     "duration_ms": suite_result.duration_ms,
                     "passed_count": suite_result.passed_count,
                     "failed_count": suite_result.failed_count,

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -70,15 +70,16 @@ class TestCaseRunner:
         check_kinds = check_kind_counts_from_sequence(checks_list)
         trace = test_case.trace
 
+        shape_props = test_case_shape_properties(
+            check_count=len(checks_list),
+            trace_interaction_count=len(trace.interactions),
+            has_trace_annotations=bool(trace.annotations),
+            has_test_case_name=test_case.name is not None,
+            check_kinds=check_kinds,
+        )
         _ = telemetry.capture(
             "checks_test_case_run_started",
-            properties=test_case_shape_properties(
-                check_count=len(checks_list),
-                trace_interaction_count=len(trace.interactions),
-                has_trace_annotations=bool(trace.annotations),
-                has_test_case_name=test_case.name is not None,
-                check_kinds=check_kinds,
-            ),
+            properties=shape_props,
         )
 
         check_results: list[CheckResult] = []
@@ -97,13 +98,7 @@ class TestCaseRunner:
         _ = telemetry.capture(
             "checks_test_case_run_finished",
             properties={
-                **test_case_shape_properties(
-                    check_count=len(checks_list),
-                    trace_interaction_count=len(trace.interactions),
-                    has_trace_annotations=bool(trace.annotations),
-                    has_test_case_name=test_case.name is not None,
-                    check_kinds=check_kinds,
-                ),
+                **shape_props,
                 "outcome_status": tc_result.status.value,
                 "duration_ms": total_duration_ms,
                 "return_exception_mode": return_exception,

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -1,6 +1,12 @@
 import time
 import traceback
 
+from giskard.core import scoped_telemetry, telemetry, telemetry_tag
+
+from .._telemetry_props import (
+    check_kind_counts_from_sequence,
+    test_case_shape_properties,
+)
 from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, TestCaseResult
@@ -50,25 +56,61 @@ class TestCaseRunner:
     def __init__(self):
         pass
 
+    @scoped_telemetry
     async def run[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
         self,
         test_case: TestCase[InputType, OutputType, TraceType],
         return_exception: bool = False,
     ) -> TestCaseResult:
+        telemetry_tag("giskard_component", "test_case_runner")
+        telemetry_tag("giskard_operation", "test_case_run")
+
         start_time = time.perf_counter()
+        checks_list = list(test_case.checks)
+        check_kinds = check_kind_counts_from_sequence(checks_list)
+        trace = test_case.trace
+
+        _ = telemetry.capture(
+            "checks_test_case_run_started",
+            properties=test_case_shape_properties(
+                check_count=len(checks_list),
+                trace_interaction_count=len(trace.interactions),
+                has_trace_annotations=bool(trace.annotations),
+                has_test_case_name=test_case.name is not None,
+                check_kinds=check_kinds,
+            ),
+        )
 
         check_results: list[CheckResult] = []
-        for check in test_case.checks:
+        for check in checks_list:
             result = await _run_check(test_case.trace, check, return_exception)
             check_results.append(result)
 
         end_time = time.perf_counter()
         total_duration_ms = int((end_time - start_time) * 1000)
 
-        return TestCaseResult(
+        tc_result = TestCaseResult(
             results=check_results,
             duration_ms=total_duration_ms,
         )
+
+        _ = telemetry.capture(
+            "checks_test_case_run_finished",
+            properties={
+                **test_case_shape_properties(
+                    check_count=len(checks_list),
+                    trace_interaction_count=len(trace.interactions),
+                    has_trace_annotations=bool(trace.annotations),
+                    has_test_case_name=test_case.name is not None,
+                    check_kinds=check_kinds,
+                ),
+                "outcome_status": tc_result.status.value,
+                "duration_ms": total_duration_ms,
+                "return_exception_mode": return_exception,
+            },
+        )
+
+        return tc_result
 
 
 _default_runner = TestCaseRunner()

--- a/libs/giskard-checks/tests/conftest.py
+++ b/libs/giskard-checks/tests/conftest.py
@@ -1,4 +1,10 @@
 import pytest
+from giskard.core import disable_telemetry
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Disable telemetry for tests."""
+    disable_telemetry()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/libs/giskard-core/README.md
+++ b/libs/giskard-core/README.md
@@ -12,8 +12,41 @@ pip install giskard-core
 
 ## Requirements
 
-- Python >= 3.11
+- Python >= 3.12
 - pydantic >= 2.11.0, < 3
+
+## Telemetry
+
+`giskard-core` includes **optional usage analytics** to help maintainers understand how the libraries are used (versions, environment, coarse feature usage). Analytics are sent to **[PostHog](https://posthog.com)** hosted in the **EU** (`https://eu.i.posthog.com`).
+
+### What we collect
+
+Installed versions of `giskard-core`, `giskard-checks`, and `giskard-agents` (each the package version or `not_installed`), a coarse **environment** label (`ci`, `colab`, `kaggle`, or `local`), and when you run **giskard-checks** flows, aggregated non-content metrics such as step counts, counts of checks by `kind`, booleans (e.g. custom trace type or target present), durations, and pass/fail/skip-style outcomes. **Scenario names, prompts, model outputs, trace content, and exception messages are not sent.**
+
+If an error propagates through the telemetry context, a single event may record **`exception_type`** (the Python class name only), not the exception string or traceback.
+
+### Anonymous identifier
+
+A random **persistent ID** may be stored under `~/.giskard/id` so repeated sessions can be counted without logging in. If the home directory is not writable, a one-off anonymous value is used for that process instead.
+
+### How to disable telemetry
+
+Set any of these environment variables to a truthy value **before** importing `giskard` packages (values are matched case-insensitively; common examples: `1`, `true`, `yes`, `on`):
+
+- `DO_NOT_TRACK`
+- `GISKARD_TELEMETRY_DISABLED`
+
+You can also call `disable_telemetry()` from `giskard.core` at runtime to turn off further sends for that process (for example from test harnesses). That does not remove `~/.giskard/id` if it was already created; use env-based opt-out before import to avoid writing the file.
+
+```python
+from giskard.core import disable_telemetry
+
+disable_telemetry()
+```
+
+### For library authors
+
+The client and helpers are exported from `giskard.core`: `telemetry`, `telemetry_tag`, `telemetry_run_context`, `scoped_telemetry`, and `disable_telemetry`. New events should follow the same rules: **no user strings, secrets, file paths, or model I/O** in analytics payloads.
 
 ## Development
 

--- a/libs/giskard-core/pyproject.toml
+++ b/libs/giskard-core/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
+    "posthog>=7.10.3",
     "pydantic>=2.11.0,<3",
 ]
 

--- a/libs/giskard-core/src/giskard/core/__init__.py
+++ b/libs/giskard-core/src/giskard/core/__init__.py
@@ -13,6 +13,13 @@ from .rate_limiter import (
     BaseRateLimiter,
     MinIntervalRateLimiter,
 )
+from .telemetry import (
+    disable_telemetry,
+    scoped_telemetry,
+    telemetry,
+    telemetry_run_context,
+    telemetry_tag,
+)
 from .utils import NOT_PROVIDED, NotProvided, provide_not_none
 
 LEGACY_GISKARD_PACKAGE_NAME = "giskard"
@@ -43,4 +50,10 @@ __all__ = [
     # Limiter
     "MinIntervalRateLimiter",
     "BaseRateLimiter",
+    # Telemetry
+    "telemetry",
+    "disable_telemetry",
+    "scoped_telemetry",
+    "telemetry_run_context",
+    "telemetry_tag",
 ]

--- a/libs/giskard-core/src/giskard/core/telemetry/__init__.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/__init__.py
@@ -1,0 +1,16 @@
+from posthog import tag as telemetry_tag
+
+from .telemetry import (
+    disable_telemetry,
+    scoped_telemetry,
+    telemetry,
+    telemetry_run_context,
+)
+
+__all__ = [
+    "telemetry",
+    "disable_telemetry",
+    "scoped_telemetry",
+    "telemetry_run_context",
+    "telemetry_tag",
+]

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -81,13 +81,17 @@ def _set_tags() -> None:
         tag(key, value)
 
 
-def _get_or_create_anonymous_id() -> str:
+def _get_or_create_anonymous_id() -> str | None:
     if _should_disable():
-        return "disabled"
+        return None
 
     config_path = Path.home() / ".giskard" / "id"
     if config_path.exists():
-        return config_path.read_text(encoding="utf-8").strip()
+        try:
+            return config_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            # Unreadable path (permissions, race with deletion, etc.): mint ephemeral below.
+            pass
 
     # Generate new persistent ID
     new_id = str(uuid.uuid4())
@@ -135,7 +139,8 @@ def telemetry_run_context() -> Iterator[None]:
     depth_token = _telemetry_run_depth.set(_telemetry_run_depth.get() + 1)
     try:
         with telemetry.new_context(capture_exceptions=False):
-            identify_context(_anonymous_id)
+            if _anonymous_id is not None:
+                identify_context(_anonymous_id)
             _set_tags()
             try:
                 yield

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -1,0 +1,171 @@
+import asyncio
+import contextvars
+import functools
+import os
+import sys
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import cast
+
+from posthog import Posthog, identify_context, tag
+
+_DISABLING_ENV_VARS = [
+    "DO_NOT_TRACK",
+    "GISKARD_TELEMETRY_DISABLED",
+]
+# Common truthy values used in CLI tools and web frameworks
+_TRUTHY_VALUES = {"1", "true", "yes", "on", "t", "y"}
+
+
+def _is_true_str(value: str | None) -> bool:
+    if value is None:
+        return False
+
+    value = value.strip().lower()
+
+    return value in _TRUTHY_VALUES
+
+
+def _should_disable() -> bool:
+    return any(_is_true_str(os.getenv(var)) for var in _DISABLING_ENV_VARS)
+
+
+def _get_lib_version(lib: str) -> str:
+    try:
+        return version(lib)
+    except PackageNotFoundError:
+        return "not_installed"
+
+
+def _get_environment_info() -> str:
+    # Detect CI (standard across GH Actions, GitLab, Jenkins, etc.)
+    is_ci = _is_true_str(os.getenv("CI")) or _is_true_str(os.getenv("TF_BUILD"))
+
+    # Detect Colab
+    is_colab = "google.colab" in sys.modules
+
+    # Detect Kaggle
+    is_kaggle = os.environ.get("KAGGLE_KERNEL_RUN_TYPE") is not None
+
+    if is_ci:
+        return "ci"
+    if is_colab:
+        return "colab"
+    if is_kaggle:
+        return "kaggle"
+    return "local"
+
+
+ENV_INFORMATION: dict[str, str] = {}
+
+
+def _get_env_information() -> dict[str, str]:
+    if not ENV_INFORMATION:
+        ENV_INFORMATION.update(
+            {
+                "giskard_core_version": _get_lib_version("giskard-core"),
+                "giskard_checks_version": _get_lib_version("giskard-checks"),
+                "giskard_agents_version": _get_lib_version("giskard-agents"),
+                "environment": _get_environment_info(),
+            }
+        )
+    return ENV_INFORMATION
+
+
+def _set_tags() -> None:
+    env_information = _get_env_information()
+    for key, value in env_information.items():
+        tag(key, value)
+
+
+def _get_or_create_anonymous_id() -> str:
+    if _should_disable():
+        return "disabled"
+
+    config_path = Path.home() / ".giskard" / "id"
+    if config_path.exists():
+        return config_path.read_text(encoding="utf-8").strip()
+
+    # Generate new persistent ID
+    new_id = str(uuid.uuid4())
+    try:
+        _ = config_path.parent.mkdir(parents=True, exist_ok=True)
+        _ = config_path.write_text(new_id, encoding="utf-8")
+    except OSError:
+        # Fallback for read-only systems
+        return f"anon-{uuid.uuid4()}"
+    return new_id
+
+
+_anonymous_id = _get_or_create_anonymous_id()
+
+telemetry = Posthog(
+    project_api_key="phc_Asp36pe4X5WMqeJ4aMMV4gq5LGdGw69mdYSdEYGpbxm2",  # pragma: allowlist secret
+    host="https://eu.i.posthog.com",
+    disabled=_should_disable(),
+)
+
+
+def disable_telemetry() -> None:
+    """
+    Disable telemetry. Overrides the environment variable settings.
+    """
+    telemetry.disabled = True
+
+
+# Nested ``telemetry_run_context`` / ``scoped_telemetry``: only the outermost
+# scope emits ``giskard_uncaught_exception`` (one event per logical failure).
+_telemetry_run_depth: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "_telemetry_run_depth", default=0
+)
+
+
+@contextmanager
+def telemetry_run_context() -> Iterator[None]:
+    """Open a PostHog context scope for a logical operation (sync or async body).
+
+    Use inside ``async def`` with ``with telemetry_run_context():`` so nested
+    ``scoped_telemetry`` calls get a consistent parent scope. Pair with
+    ``telemetry_tag`` (see ``giskard.core``) to attach non-PII dimensions to
+    child captures.
+    """
+    depth_token = _telemetry_run_depth.set(_telemetry_run_depth.get() + 1)
+    try:
+        with telemetry.new_context(capture_exceptions=False):
+            identify_context(_anonymous_id)
+            _set_tags()
+            try:
+                yield
+            except Exception as e:
+                # Do not send exception text: it may contain user content, secrets, or paths.
+                if _telemetry_run_depth.get() == 1:
+                    _ = telemetry.capture(
+                        "giskard_uncaught_exception",
+                        properties={
+                            "exception_type": type(e).__name__,
+                        },
+                    )
+                raise
+    finally:
+        _telemetry_run_depth.reset(depth_token)
+
+
+def scoped_telemetry[F: Callable[..., object]](func: F) -> F:
+    if asyncio.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: object, **kwargs: object) -> object:
+            with telemetry_run_context():
+                return cast(object, await func(*args, **kwargs))
+
+        return cast(F, async_wrapper)
+
+    @functools.wraps(func)
+    def sync_wrapper(*args: object, **kwargs: object) -> object:
+        with telemetry_run_context():
+            return func(*args, **kwargs)
+
+    return cast(F, sync_wrapper)

--- a/libs/giskard-core/tests/conftest.py
+++ b/libs/giskard-core/tests/conftest.py
@@ -1,3 +1,12 @@
+import pytest
+from giskard.core import disable_telemetry
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Disable telemetry for tests."""
+    disable_telemetry()
+
+
 def pytest_sessionfinish(session, exitstatus):
     # If no tests were collected, set the exit status to 0 to avoid failure.
     # This is a workaround for packages not having any functional tests.

--- a/uv.lock
+++ b/uv.lock
@@ -185,6 +185,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -776,11 +785,15 @@ name = "giskard-core"
 version = "1.0.1b2"
 source = { editable = "libs/giskard-core" }
 dependencies = [
+    { name = "posthog" },
     { name = "pydantic" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.11.0,<3" }]
+requires-dist = [
+    { name = "posthog", specifier = ">=7.10.3" },
+    { name = "pydantic", specifier = ">=2.11.0,<3" },
+]
 
 [[package]]
 name = "griffe"
@@ -1637,6 +1650,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "six" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/48/dcb39417e903af8bc08e144a6adc594178ee42f276a858d570d3164c4262/posthog-7.10.3.tar.gz", hash = "sha256:dc624a07306dc2618dcfa9f9a706086db2efea33bb7ad0048625e5cf60e5401b", size = 187265, upload-time = "2026-04-08T17:43:10.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ec/d0050e82b4be2126f4769612f0ef9734348cb736a23754ea238202285343/posthog-7.10.3-py3-none-any.whl", hash = "sha256:bbaeb45dbfd56143343cf93bf091eb500f9996b95b797f4bf99b42905da54fe7", size = 217019, upload-time = "2026-04-08T17:43:09.305Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

- Send aggregate, non-content metrics from scenario/suite/test-case runs
- Tag context with package versions and coarse environment (ci/colab/kaggle/local)
- Opt out via DO_NOT_TRACK, GISKARD_TELEMETRY_DISABLED, or disable_telemetry()
- Document collection and privacy limits in READMEs; disable telemetry in tests
- Add posthog dependency; EU-hosted PostHog endpoint
