### PR TITLE
fix(giskard-checks): bound RegexMatching with regex timeout to mitigate ReDoS

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -326,15 +326,12 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
 ):
     r"""Check that validates if a regex pattern matches within text.
 
-    This check performs pattern matching with the PyPI :mod:`regex` engine
-    (``regex.search``), which is largely compatible with the :mod:`re` module
-    but supports a per-call timeout to mitigate ReDoS. Matching runs in a
-    worker thread so the async event loop is not blocked for the full
-    ``match_timeout_seconds`` budget.
+    Matching uses the PyPI :mod:`regex` package, which is largely compatible
+    with Python's standard :mod:`re` module.
 
     The matching process:
     1. Extracts text and pattern (from provided values or trace)
-    2. Compiles and searches with a bounded-time ``regex.search(..., timeout=...)``
+    2. Searches the text for the pattern
 
     Attributes
     ----------
@@ -349,8 +346,7 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
     pattern_key : JSONPathStr | None
         JSONPath expression to extract pattern from trace.
     match_timeout_seconds : float
-        Maximum time allowed for compiling and searching (passed to
-        ``regex.search``). If exceeded, matching aborts and the check fails.
+        Upper bound on how long matching may take before the check raises an error.
 
     Examples
     --------
@@ -409,11 +405,7 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
     match_timeout_seconds: float = Field(
         default=2.0,
         gt=0,
-        description=(
-            "Maximum seconds for regex compilation and search (ReDoS mitigation), "
-            "enforced by the regex engine. Matching runs in a thread pool so the "
-            "event loop stays responsive."
-        ),
+        description="Maximum time allowed for matching, in seconds.",
     )
 
     @model_validator(mode="after")
@@ -468,7 +460,7 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         try:
             matched = regex.search(pattern, text, timeout=self.match_timeout_seconds)
         except TimeoutError:
-            return CheckResult.failure(
+            return CheckResult.error(
                 message=(
                     f"Regex matching exceeded the time limit of "
                     f"{self.match_timeout_seconds} second(s) "

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -459,15 +459,6 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
 
         try:
             matched = regex.search(pattern, text, timeout=self.match_timeout_seconds)
-        except TimeoutError:
-            return CheckResult.error(
-                message=(
-                    f"Regex matching exceeded the time limit of "
-                    f"{self.match_timeout_seconds} second(s) "
-                    f"(possible ReDoS or very large input)."
-                ),
-                details=details,
-            )
         except regex.error as e:
             return CheckResult.failure(
                 message=f"Invalid regex pattern '{pattern}': {str(e)}",

--- a/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/text_matching.py
@@ -5,10 +5,10 @@ This module provides checks for text matching:
 - RegexMatching: Regular expression pattern matching
 """
 
-import re
 from abc import ABC, abstractmethod
 from typing import Any, Self, override
 
+import regex
 from giskard.core import provide_not_none
 from pydantic import Field, model_validator
 
@@ -326,14 +326,15 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
 ):
     r"""Check that validates if a regex pattern matches within text.
 
-    This check performs regex pattern matching using standard Python re module.
-    The pattern is matched against the raw text without any normalization,
-    giving users full control through regex syntax.
+    This check performs pattern matching with the PyPI :mod:`regex` engine
+    (``regex.search``), which is largely compatible with the :mod:`re` module
+    but supports a per-call timeout to mitigate ReDoS. Matching runs in a
+    worker thread so the async event loop is not blocked for the full
+    ``match_timeout_seconds`` budget.
 
     The matching process:
     1. Extracts text and pattern (from provided values or trace)
-    2. Compiles regex pattern
-    3. Checks if pattern matches anywhere in the text using re.search()
+    2. Compiles and searches with a bounded-time ``regex.search(..., timeout=...)``
 
     Attributes
     ----------
@@ -347,6 +348,9 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         The regex pattern to search for. Either this or pattern_key must be provided.
     pattern_key : JSONPathStr | None
         JSONPath expression to extract pattern from trace.
+    match_timeout_seconds : float
+        Maximum time allowed for compiling and searching (passed to
+        ``regex.search``). If exceeded, matching aborts and the check fails.
 
     Examples
     --------
@@ -402,6 +406,15 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         default=None,
         description="JSONPath expression to extract the pattern from the trace.",
     )
+    match_timeout_seconds: float = Field(
+        default=2.0,
+        gt=0,
+        description=(
+            "Maximum seconds for regex compilation and search (ReDoS mitigation), "
+            "enforced by the regex engine. Matching runs in a thread pool so the "
+            "event loop stays responsive."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_pattern_or_pattern_key(self) -> Self:
@@ -452,20 +465,29 @@ class RegexMatching[InputType, OutputType, TraceType: Trace](  # pyright: ignore
         # Extract successful values
         text, pattern, details = result[0], result[1], result[2]
 
-        # Try to compile and match
         try:
-            if re.search(pattern, text):
-                return CheckResult.success(
-                    message=f"Text matches the regex pattern '{pattern}'.",
-                    details=details,
-                )
-            else:
-                return CheckResult.failure(
-                    message=f"Text does not match the regex pattern '{pattern}'.",
-                    details=details,
-                )
-        except re.error as e:
+            matched = regex.search(pattern, text, timeout=self.match_timeout_seconds)
+        except TimeoutError:
+            return CheckResult.failure(
+                message=(
+                    f"Regex matching exceeded the time limit of "
+                    f"{self.match_timeout_seconds} second(s) "
+                    f"(possible ReDoS or very large input)."
+                ),
+                details=details,
+            )
+        except regex.error as e:
             return CheckResult.failure(
                 message=f"Invalid regex pattern '{pattern}': {str(e)}",
                 details=details,
             )
+
+        if matched:
+            return CheckResult.success(
+                message=f"Text matches the regex pattern '{pattern}'.",
+                details=details,
+            )
+        return CheckResult.failure(
+            message=f"Text does not match the regex pattern '{pattern}'.",
+            details=details,
+        )

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -369,7 +369,7 @@ async def test_regex_redos_bounded_by_timeout() -> None:
         match_timeout_seconds=0.5,
     )
     result = await check.run(Trace())
-    assert result.status == CheckStatus.FAIL
+    assert result.status == CheckStatus.ERROR
     assert result.message is not None
     assert result.message.startswith(
         "Regex matching exceeded the time limit of 0.5 second(s)"

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -362,15 +362,11 @@ async def test_missing_text_in_trace() -> None:
 
 @pytest.mark.timeout(15)
 async def test_regex_redos_bounded_by_timeout() -> None:
-    """Pathological pattern + input must not block the check past match_timeout_seconds."""
+    """Pathological pattern + input must not run past match_timeout_seconds."""
     check = RegexMatching(
         text="x" * 80_000 + "b",
         pattern="(x+)+$",
         match_timeout_seconds=0.5,
     )
-    result = await check.run(Trace())
-    assert result.status == CheckStatus.ERROR
-    assert result.message is not None
-    assert result.message.startswith(
-        "Regex matching exceeded the time limit of 0.5 second(s)"
-    )
+    with pytest.raises(TimeoutError):
+        _ = await check.run(Trace())

--- a/libs/giskard-checks/tests/builtin/test_regex_matching.py
+++ b/libs/giskard-checks/tests/builtin/test_regex_matching.py
@@ -358,3 +358,19 @@ async def test_missing_text_in_trace() -> None:
     assert result.status == CheckStatus.FAIL
     assert result.message is not None
     assert "no value found for text" in result.message.lower()
+
+
+@pytest.mark.timeout(15)
+async def test_regex_redos_bounded_by_timeout() -> None:
+    """Pathological pattern + input must not block the check past match_timeout_seconds."""
+    check = RegexMatching(
+        text="x" * 80_000 + "b",
+        pattern="(x+)+$",
+        match_timeout_seconds=0.5,
+    )
+    result = await check.run(Trace())
+    assert result.status == CheckStatus.FAIL
+    assert result.message is not None
+    assert result.message.startswith(
+        "Regex matching exceeded the time limit of 0.5 second(s)"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "giskard-core>=1.0.0a1",
     "giskard-agents>=1.0.0a1",
     "giskard-checks>=1.0.0a1",
+    "regex>=2026.1.15",
 ]
 requires-python = ">=3.12"
 

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,7 @@ dependencies = [
     { name = "giskard-agents" },
     { name = "giskard-checks" },
     { name = "giskard-core" },
+    { name = "regex" },
 ]
 
 [package.dev-dependencies]
@@ -704,6 +705,7 @@ requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
     { name = "giskard-checks", editable = "libs/giskard-checks" },
     { name = "giskard-core", editable = "libs/giskard-core" },
+    { name = "regex", specifier = ">=2026.1.15" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description

Replace stdlib `re.search` with `regex.search(..., timeout=...)`.
Add `match_timeout_seconds` and a ReDoS regression test.

