### PR TITLE
fix(security)!: drop support for templating in conformity rules

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -21,10 +21,9 @@ pip install giskard-checks
 Requires Python >= 3.12.
 
 **Dependencies:**
-- `pydantic>=2.11.7` - Core data validation and serialization
-- `giskard-agents>=0.3` - LLM integration and workflow management
+- `pydantic>=2.12` - Core data validation and serialization
+- `giskard-agents>=1.0.0a1` - LLM integration, workflows, and bundled prompt templates
 - `jsonpath-ng>=1.7.0` - JSONPath expressions for data extraction
-- `jinja2>=3.1.6` - Template engine for LLM prompts
 
 Quickstart
 ----------

--- a/libs/giskard-checks/src/giskard/checks/judges/conformity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/conformity.py
@@ -1,12 +1,15 @@
 from typing import override
 
 from giskard.agents.workflow import TemplateReference
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 from pydantic import Field
 
 from ..core import Trace
 from ..core.check import Check
 from .base import BaseLLMCheck
+
+# Sandboxed Jinja2 for user-supplied `rule` strings (mitigates template sandbox escapes).
+_conformity_rule_env = SandboxedEnvironment(autoescape=False)
 
 
 @Check.register("conformity")
@@ -56,7 +59,7 @@ class Conformity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[re
     @override
     async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
         """Build template variables from the trace."""
-        formatted_rule = Template(self.rule).render(trace=trace)
+        formatted_rule = _conformity_rule_env.from_string(self.rule).render(trace=trace)
 
         interaction_json = "{}"
         if trace.interactions:

--- a/libs/giskard-checks/src/giskard/checks/judges/conformity.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/conformity.py
@@ -1,71 +1,57 @@
-from typing import override
+from typing import Any, override
 
 from giskard.agents.workflow import TemplateReference
-from jinja2.sandbox import SandboxedEnvironment
 from pydantic import Field
 
 from ..core import Trace
 from ..core.check import Check
 from .base import BaseLLMCheck
 
-# Sandboxed Jinja2 for user-supplied `rule` strings (mitigates template sandbox escapes).
-_conformity_rule_env = SandboxedEnvironment(autoescape=False)
-
 
 @Check.register("conformity")
 class Conformity[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
     BaseLLMCheck[InputType, OutputType, TraceType]
 ):
-    """LLM-based check that validates interactions conform to a given rule.
+    """LLM-based check that validates a trace against a given rule.
 
-    This check supports **dynamic rules** by using Jinja2 templating on the `rule`
-    string. The entire `Trace` object is exposed to the rule template,
-    allowing users to inject trace fields like interactions, inputs, outputs, or metadata.
+    The `rule` is plain text: it is passed to the bundled prompt as-is (not
+    evaluated as its own template). The full `Trace` is supplied separately to
+    that prompt so the model can judge outputs and metadata against the rule.
 
-    Uses an LLM to determine if an interaction (inputs, outputs, and metadata)
-    conforms to a specified rule or requirement.
+    Uses an LLM to determine whether the trace's outputs and metadata conform
+    to the rule.
 
     Attributes
     ----------
     rule : str
-        The rule statement to evaluate against the interaction.
-        This string can contain Jinja2 placeholders (e.g., `{{ trace.last.outputs }}`).
+        The rule statement to evaluate against the trace (literal text).
 
-        Note: In Jinja2 templates and JSONPath expressions, prefer `trace.last` over
-        `trace.interactions[-1]` for better readability.
     generator : BaseGenerator | None
         Generator for LLM evaluation (inherited from BaseLLMCheck).
 
     Examples
     --------
     >>> from giskard.agents.generators import Generator
-    >>> from giskard.checks import Interaction, Trace, Conformity
-    >>> # Example of a dynamic rule accessing a field in the output object
+    >>> from giskard.checks import Conformity
     >>> check = Conformity(
-    ...     rule="The response should contain the keywords '{{ trace.last.inputs.keywords }}' and be polite.",
-    ...     generator=Generator(model="openai/gpt-4o")
+    ...     rule="The last response should be polite.",
+    ...     generator=Generator(model="openai/gpt-5-mini")
     ... )
     """
 
     rule: str = Field(
-        ..., description="The rule statement to evaluate against the interaction"
+        ..., description="The rule statement to evaluate against the trace (plain text)"
     )
 
     @override
     def get_prompt(self) -> TemplateReference:
-        """Return the Jinja2 template name for conformity evaluation."""
+        """Return the bundled prompt template for conformity evaluation."""
         return TemplateReference(template_name="giskard.checks::judges/conformity.j2")
 
     @override
-    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
+    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, Any]:
         """Build template variables from the trace."""
-        formatted_rule = _conformity_rule_env.from_string(self.rule).render(trace=trace)
-
-        interaction_json = "{}"
-        if trace.interactions:
-            interaction_json = trace.interactions[-1].model_dump_json()
-
         return {
-            "rule": formatted_rule,
-            "interaction": interaction_json,
+            "rule": self.rule,
+            "trace": trace,
         }

--- a/libs/giskard-checks/src/giskard/checks/prompts/judges/conformity.j2
+++ b/libs/giskard-checks/src/giskard/checks/prompts/judges/conformity.j2
@@ -2,40 +2,43 @@ Your role is to evaluate whether an interaction conforms to a given rule or requ
 
 You will receive:
 - A rule statement to evaluate against
-- An interaction containing inputs, outputs, and optionally metadata
+- A trace containing inputs, outputs, and optionally metadata
 
-Your task is to determine if the interaction conforms to the specified rule. The interaction should be evaluated holistically, considering all available information (inputs, outputs, and metadata if present).
+**What to evaluate:** Judge **only** the **outputs** and **metadata** in the trace against the rule. **Inputs** are provided **for reference** so you can interpret what was asked and evaluate whether the outputs (and metadata, if present) satisfy the rule. Do not treat inputs as something to pass or fail for conformity.
+
+Your task is to determine if the outputs and metadata conform to the specified rule, using inputs solely as supporting context.
 
 ## Evaluation Criteria
 
-1. **Rule Compliance:** The interaction should demonstrate adherence to the stated rule. This includes:
+1. **Rule Compliance:** Assess outputs and metadata against the stated rule:
    - The outputs should align with the rule requirements
-   - The inputs should be appropriate for the rule context
    - Any metadata should support or be consistent with the rule
+   - Use inputs only to understand the request and ground your judgment of outputs and metadata
 
-2. **Contextual Understanding:** Consider the full context of the interaction:
-   - How the inputs relate to the rule
-   - Whether the outputs appropriately address the rule
+2. **Contextual Understanding:** Use the full trace for context, but keep the verdict focused on outputs and metadata:
+   - How the inputs clarify what was expected (reference only)
+   - Whether the outputs appropriately satisfy the rule
    - If metadata provides relevant context for rule evaluation
 
-3. **Completeness:** The interaction should provide sufficient information to evaluate rule compliance:
-   - Missing critical information may indicate non-conformity
+3. **Completeness:** Outputs and metadata should provide sufficient information to evaluate rule compliance:
+   - Missing or unusable outputs may indicate non-conformity
    - Incomplete responses that don't address the rule should be flagged
 
-4. **Consistency:** All parts of the interaction should work together to support rule compliance:
-   - No contradictions between inputs, outputs, and metadata
-   - Coherent behavior throughout the interaction
+4. **Consistency:** Outputs and metadata should be coherent with the rule:
+   - No contradictions between outputs and metadata where both apply
+   - Coherent behavior in what you are evaluating (outputs and metadata)
 
 ## Evaluation Strategy
 
 1. Carefully read the rule statement and understand what it requires.
-2. Examine the interaction components (inputs, outputs, metadata if present).
-3. Determine if the interaction as a whole demonstrates compliance with the rule.
-4. Consider both explicit and implicit requirements of the rule.
-5. Provide a clear reason for your evaluation decision.
+2. Read the inputs for reference to understand the scenario and expectations.
+3. Examine **outputs** and **metadata** (if present) as the objects of evaluation.
+4. Determine whether those outputs and metadata demonstrate compliance with the rule.
+5. Consider both explicit and implicit requirements of the rule.
+6. Provide a clear reason for your evaluation decision.
 
 ## Markers
-Markers <INTERACTION>...</INTERACTION> indicate the interaction. Everything inside a marker belongs to that category.
+Markers <TRACE>...</TRACE> indicate the trace. Everything inside a marker belongs to that category.
 
 -------------------
 
@@ -44,9 +47,9 @@ Markers <INTERACTION>...</INTERACTION> indicate the interaction. Everything insi
 
 -------------------
 
-< INTERACTION >
-{{ interaction }}
-</ INTERACTION >
+< TRACE >
+{{ trace }}
+</ TRACE >
 
 -------------------
 

--- a/libs/giskard-checks/tests/builtin/test_conformity.py
+++ b/libs/giskard-checks/tests/builtin/test_conformity.py
@@ -1,10 +1,12 @@
 import json
 from typing import Any, override
 
+import pytest
 from giskard.agents.chat import Message
 from giskard.agents.generators._types import Response
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.checks import CheckStatus, Conformity, Interaction, Trace
+from jinja2.sandbox import SecurityError
 from pydantic import Field
 
 
@@ -104,3 +106,33 @@ async def test_empty_interactions_uses_empty_json() -> None:
     assert result.status == CheckStatus.PASS
     assert "inputs" in result.details
     assert result.details["inputs"]["interaction"] == "{}"
+
+
+async def test_rule_template_sandbox_blocks_subclass_enumeration() -> None:
+    """Dynamic rules must not escape Jinja2 to introspect Python (GHSA-style SSTI)."""
+    generator = MockGenerator(passed=True, reason=None)
+    conformity = Conformity(
+        generator=generator,
+        rule="{{ ''.__class__.__mro__[1].__subclasses__() | length }}",
+    )
+    trace = Trace(
+        interactions=[Interaction(inputs="hello", outputs="world")],
+    )
+    with pytest.raises(SecurityError):
+        await conformity.get_inputs(trace)
+
+
+async def test_rule_template_sandbox_blocks_rce_payload() -> None:
+    """Dynamic rules must not reach builtins / OS via template attribute chains."""
+    generator = MockGenerator(passed=True, reason=None)
+    rule = (
+        "{{ self.__init__.__globals__"
+        "['__builtins__']['__import__']('os')"
+        ".popen('id').read() }}"
+    )
+    conformity = Conformity(generator=generator, rule=rule)
+    trace = Trace(
+        interactions=[Interaction(inputs="hello", outputs="world")],
+    )
+    with pytest.raises(SecurityError):
+        await conformity.get_inputs(trace)

--- a/libs/giskard-checks/tests/builtin/test_conformity.py
+++ b/libs/giskard-checks/tests/builtin/test_conformity.py
@@ -1,12 +1,10 @@
 import json
 from typing import Any, override
 
-import pytest
 from giskard.agents.chat import Message
 from giskard.agents.generators._types import Response
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
 from giskard.checks import CheckStatus, Conformity, Interaction, Trace
-from jinja2.sandbox import SecurityError
 from pydantic import Field
 
 
@@ -54,85 +52,32 @@ async def test_run_returns_failure() -> None:
     assert len(generator.calls) == 1
 
 
-async def test_rule_templating() -> None:
-    generator = MockGenerator(passed=True, reason=None)
-    conformity = Conformity(
-        generator=generator,
-        rule="The response should contain '{{ trace.interactions[-1].outputs.response }}'",
-    )
-    result = await conformity.run(
-        Trace(
-            interactions=[
-                Interaction(inputs={"query": "Hello"}, outputs={"response": "Hello"})
-            ]
-        )
-    )
-
-    assert result.status == CheckStatus.PASS
-    assert result.details["reason"] is None
-
-    assert len(generator.calls) == 1
-    # Verify that the rule was templated correctly in the inputs
-    # The formatted rule should contain "Hello" instead of the template placeholder
-    assert "rule" in result.details["inputs"]
-    assert "Hello" in result.details["inputs"]["rule"]
-
-
-async def test_interaction_json_in_inputs() -> None:
+async def test_trace_in_result_details_inputs() -> None:
     generator = MockGenerator(passed=True, reason=None)
     conformity = Conformity(generator=generator, rule="Test rule")
     interaction = Interaction(
         inputs={"query": "What is AI?"}, outputs={"response": "AI is..."}
     )
-    result = await conformity.run(Trace(interactions=[interaction]))
+    trace = Trace(interactions=[interaction])
+    result = await conformity.run(trace)
 
     assert result.status == CheckStatus.PASS
     assert "inputs" in result.details
-    assert "interaction" in result.details["inputs"]
+    assert result.details["inputs"]["rule"] == "Test rule"
+    assert "trace" in result.details["inputs"]
 
-    # Verify interaction is serialized as JSON
-    interaction_json = result.details["inputs"]["interaction"]
-    assert isinstance(interaction_json, str)
-    parsed = json.loads(interaction_json)
-    assert parsed["inputs"]["query"] == "What is AI?"
-    assert parsed["outputs"]["response"] == "AI is..."
+    stored_trace = result.details["inputs"]["trace"]
+    assert stored_trace is trace
 
 
-async def test_empty_interactions_uses_empty_json() -> None:
+async def test_empty_trace_in_result_details_inputs() -> None:
     generator = MockGenerator(passed=True, reason=None)
     conformity = Conformity(generator=generator, rule="Test rule")
-    result = await conformity.run(Trace())
+    trace = Trace()
+    result = await conformity.run(trace)
 
     assert result.status == CheckStatus.PASS
     assert "inputs" in result.details
-    assert result.details["inputs"]["interaction"] == "{}"
-
-
-async def test_rule_template_sandbox_blocks_subclass_enumeration() -> None:
-    """Dynamic rules must not escape Jinja2 to introspect Python (GHSA-style SSTI)."""
-    generator = MockGenerator(passed=True, reason=None)
-    conformity = Conformity(
-        generator=generator,
-        rule="{{ ''.__class__.__mro__[1].__subclasses__() | length }}",
-    )
-    trace = Trace(
-        interactions=[Interaction(inputs="hello", outputs="world")],
-    )
-    with pytest.raises(SecurityError):
-        await conformity.get_inputs(trace)
-
-
-async def test_rule_template_sandbox_blocks_rce_payload() -> None:
-    """Dynamic rules must not reach builtins / OS via template attribute chains."""
-    generator = MockGenerator(passed=True, reason=None)
-    rule = (
-        "{{ self.__init__.__globals__"
-        "['__builtins__']['__import__']('os')"
-        ".popen('id').read() }}"
-    )
-    conformity = Conformity(generator=generator, rule=rule)
-    trace = Trace(
-        interactions=[Interaction(inputs="hello", outputs="world")],
-    )
-    with pytest.raises(SecurityError):
-        await conformity.get_inputs(trace)
+    assert result.details["inputs"]["rule"] == "Test rule"
+    stored_trace = result.details["inputs"]["trace"]
+    assert stored_trace is trace


### PR DESCRIPTION
### Description

This PR updates the conformity check in two ways:
- BREAKING CHANGE: it drops jinja2 templating for the conformity rules, to remove any possible abuse via SSTI which led to a security vulnerability if rules were exposed to untrusted users.
- Updates the check to use the full trace rather than the last interaction.
