### PR TITLE
feat(giskard-checks): add AnswerRelevance LLM judge check

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -38,6 +38,7 @@ from .core import (
 )
 from .generators.user import UserSimulator
 from .judges import (
+    AnswerRelevance,
     BaseLLMCheck,
     Conformity,
     Groundedness,
@@ -85,6 +86,7 @@ __all__ = [
     "Interaction",
     "InteractionSpec",
     # Builtin and LLM-based checks
+    "AnswerRelevance",
     "BaseLLMCheck",
     "LLMCheckResult",
     "Conformity",

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -1,7 +1,14 @@
 """Built-in check implementations and helpers."""
 
 # Import judge checks from new location and re-export for backward compatibility
-from ..judges import BaseLLMCheck, Conformity, Groundedness, LLMCheckResult, LLMJudge
+from ..judges import (
+    AnswerRelevance,
+    BaseLLMCheck,
+    Conformity,
+    Groundedness,
+    LLMCheckResult,
+    LLMJudge,
+)
 
 # Import comparison checks (staying in builtin)
 from .comparison import (
@@ -29,6 +36,7 @@ __all__ = [
     "GreaterThan",
     "LesserThanEquals",
     "GreaterEquals",
+    "AnswerRelevance",
     "Groundedness",
     "Conformity",
     "LLMJudge",

--- a/libs/giskard-checks/src/giskard/checks/judges/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/__init__.py
@@ -1,11 +1,13 @@
 """LLM-based judge checks for evaluating interactions."""
 
+from .answer_relevance import AnswerRelevance
 from .base import BaseLLMCheck, LLMCheckResult
 from .conformity import Conformity
 from .groundedness import Groundedness
 from .judge import LLMJudge
 
 __all__ = [
+    "AnswerRelevance",
     "BaseLLMCheck",
     "LLMCheckResult",
     "Conformity",

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -1,4 +1,4 @@
-from typing import override
+from typing import Any, override
 
 from giskard.agents.workflow import TemplateReference
 from giskard.core import provide_not_none
@@ -85,7 +85,7 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
         )
 
     @override
-    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
+    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, Any]:
         """Build template variables from resolved inputs.
 
         Parameters
@@ -99,37 +99,20 @@ class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: igno
             Template variables with ``question``, ``answer``, ``history``, and
             ``context`` keys.
         """
-        question = str(
-            provided_or_resolve(
-                trace,
-                key=self.question_key,
-                value=provide_not_none(self.question),
-            )
+        question = provided_or_resolve(
+            trace,
+            key=self.question_key,
+            value=provide_not_none(self.question),
         )
-        answer = str(
-            provided_or_resolve(
-                trace,
-                key=self.answer_key,
-                value=provide_not_none(self.answer),
-            )
+        answer = provided_or_resolve(
+            trace,
+            key=self.answer_key,
+            value=provide_not_none(self.answer),
         )
-
-        # Build a plain-text summary of prior turns so the judge understands
-        # user intent without being penalised for earlier irrelevant exchanges.
-        history_turns = trace.interactions[:-1] if trace.interactions else []
-        if history_turns:
-            history_lines: list[str] = []
-            for i, interaction in enumerate(history_turns, start=1):
-                history_lines.append(
-                    f"Turn {i}:\n  User: {interaction.inputs}\n  Assistant: {interaction.outputs}"
-                )
-            history = "\n\n".join(history_lines)
-        else:
-            history = ""
 
         return {
             "question": question,
             "answer": answer,
-            "history": history,
+            "history": trace,
             "context": self.context or "",
         }

--- a/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
+++ b/libs/giskard-checks/src/giskard/checks/judges/answer_relevance.py
@@ -1,0 +1,135 @@
+from typing import override
+
+from giskard.agents.workflow import TemplateReference
+from giskard.core import provide_not_none
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.extraction import JSONPathStr, provided_or_resolve
+from .base import BaseLLMCheck
+
+
+@Check.register("answer_relevance")
+class AnswerRelevance[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    BaseLLMCheck[InputType, OutputType, TraceType]
+):
+    """LLM-based check that evaluates whether the model's answer is relevant to the question.
+
+    Uses an LLM to judge if the final answer directly and appropriately addresses the
+    final question, taking into account the full conversation history. This prevents
+    the judge from mis-scoring locally-reasonable answers that are off-topic given
+    prior turns (e.g., a zoology answer to a programming question).
+
+    Only the **current** turn (``question`` / ``answer``) is scored. Prior turns are
+    passed as read-only history so the judge can understand user intent—not to
+    penalise earlier irrelevant exchanges.
+
+    Attributes
+    ----------
+    question : str | None
+        The question to evaluate relevance against. When provided, takes priority
+        over ``question_key``.
+    question_key : JSONPathStr
+        JSONPath expression to extract the question from the trace
+        (default: ``"trace.last.inputs"``).
+    answer : str | None
+        The answer to evaluate. When provided, takes priority over ``answer_key``.
+    answer_key : JSONPathStr
+        JSONPath expression to extract the answer from the trace
+        (default: ``"trace.last.outputs"``).
+    context : str | None
+        Optional domain context that describes the chatbot's purpose or scope
+        (e.g., ``"This is a chatbot that answers questions about programming languages"``).
+        Not extracted from the trace—must be supplied directly when needed.
+
+    Examples
+    --------
+    >>> from giskard.checks import AnswerRelevance, Interaction, Scenario, Trace
+    >>> scenario = (
+    ...     Scenario(name="rag_relevance_multi_turn")
+    ...     .interact(inputs="What is the best language?", outputs="Python")
+    ...     .interact(inputs="What's Python?", outputs="A snake.")
+    ...     .check(AnswerRelevance())
+    ... )
+    """
+
+    question: str | None = Field(
+        default=None,
+        description="The question to evaluate relevance against. Takes priority over question_key.",
+    )
+    question_key: JSONPathStr = Field(
+        default="trace.last.inputs",
+        description="JSONPath to extract the question from the trace.",
+    )
+    answer: str | None = Field(
+        default=None,
+        description="The answer to evaluate. Takes priority over answer_key.",
+    )
+    answer_key: JSONPathStr = Field(
+        default="trace.last.outputs",
+        description="JSONPath to extract the answer from the trace.",
+    )
+    context: str | None = Field(
+        default=None,
+        description=(
+            "Optional domain context describing the chatbot's purpose or scope. "
+            "Not extracted from the trace—supply directly when needed."
+        ),
+    )
+
+    @override
+    def get_prompt(self) -> TemplateReference:
+        return TemplateReference(
+            template_name="giskard.checks::judges/answer_relevance.j2"
+        )
+
+    @override
+    async def get_inputs(self, trace: Trace[InputType, OutputType]) -> dict[str, str]:
+        """Build template variables from resolved inputs.
+
+        Parameters
+        ----------
+        trace : Trace
+            Trace for resolving inputs.
+
+        Returns
+        -------
+        dict[str, str]
+            Template variables with ``question``, ``answer``, ``history``, and
+            ``context`` keys.
+        """
+        question = str(
+            provided_or_resolve(
+                trace,
+                key=self.question_key,
+                value=provide_not_none(self.question),
+            )
+        )
+        answer = str(
+            provided_or_resolve(
+                trace,
+                key=self.answer_key,
+                value=provide_not_none(self.answer),
+            )
+        )
+
+        # Build a plain-text summary of prior turns so the judge understands
+        # user intent without being penalised for earlier irrelevant exchanges.
+        history_turns = trace.interactions[:-1] if trace.interactions else []
+        if history_turns:
+            history_lines: list[str] = []
+            for i, interaction in enumerate(history_turns, start=1):
+                history_lines.append(
+                    f"Turn {i}:\n  User: {interaction.inputs}\n  Assistant: {interaction.outputs}"
+                )
+            history = "\n\n".join(history_lines)
+        else:
+            history = ""
+
+        return {
+            "question": question,
+            "answer": answer,
+            "history": history,
+            "context": self.context or "",
+        }

--- a/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
+++ b/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
@@ -1,0 +1,66 @@
+Your role is to evaluate whether an AI assistant's answer is relevant to the user's question.
+
+You will receive:
+- The current question being evaluated
+- The current answer being evaluated
+- The conversation history that preceded this turn (if any)
+- An optional domain context describing the assistant's intended purpose
+
+## Your Task
+
+Determine whether the **current answer** is relevant to the **current question**, taking into account:
+1. The conversation history to understand the user's intent (topic, domain, follow-ups).
+2. The optional domain context to assess whether the answer falls within scope.
+
+**Only score the current turn.** Prior turns are provided purely so you can understand user intent—do not penalise the answer for irrelevant earlier exchanges.
+
+## Evaluation Criteria
+
+1. **Relevance to question:** The answer must directly address what the current question is asking. An answer about an unrelated topic is not relevant.
+2. **Intent awareness:** If prior turns establish a specific domain or topic (e.g., programming languages), the current answer must respect that context even if the current question is ambiguous (e.g., "What's Python?" after a programming discussion should be answered in a programming context, not zoology).
+3. **Completeness:** A relevant answer should meaningfully address the question. Vague, evasive, or completely off-topic answers are not relevant.
+4. **Scope (if domain context provided):** If a domain context is given, the answer must be appropriate for that domain.
+
+## What is NOT a reason for failure
+
+- The answer is incomplete but still on-topic.
+- The answer is brief but directly addresses the question.
+- Minor factual errors (this check evaluates relevance, not factual accuracy).
+- Prior turns being irrelevant—only the current turn is scored.
+
+## Evaluation Strategy
+
+1. Read the conversation history to understand the user's intent and the topic domain.
+2. Read the current question and interpret it in light of the history.
+3. Evaluate whether the current answer addresses the question in the correct domain/topic.
+4. If a domain context is provided, also assess whether the answer is appropriate for that domain.
+5. Provide a concise reason for your decision.
+
+## Markers
+
+<CONVERSATION HISTORY>
+{% if history %}
+{{ history }}
+{% else %}
+(No prior turns — this is the first interaction.)
+{% endif %}
+</CONVERSATION HISTORY>
+
+<CURRENT QUESTION>
+{{ question }}
+</CURRENT QUESTION>
+
+<CURRENT ANSWER>
+{{ answer }}
+</CURRENT ANSWER>
+
+{% if context %}
+<DOMAIN CONTEXT>
+{{ context }}
+</DOMAIN CONTEXT>
+{% endif %}
+
+---
+
+**Output Format:**
+{{ _instr_output }}

--- a/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
+++ b/libs/giskard-checks/src/giskard/checks/prompts/judges/answer_relevance.j2
@@ -3,7 +3,7 @@ Your role is to evaluate whether an AI assistant's answer is relevant to the use
 You will receive:
 - The current question being evaluated
 - The current answer being evaluated
-- The conversation history that preceded this turn (if any)
+- The conversation history
 - An optional domain context describing the assistant's intended purpose
 
 ## Your Task
@@ -39,11 +39,7 @@ Determine whether the **current answer** is relevant to the **current question**
 ## Markers
 
 <CONVERSATION HISTORY>
-{% if history %}
 {{ history }}
-{% else %}
-(No prior turns — this is the first interaction.)
-{% endif %}
 </CONVERSATION HISTORY>
 
 <CURRENT QUESTION>

--- a/libs/giskard-checks/tests/builtin/test_answer_relevance.py
+++ b/libs/giskard-checks/tests/builtin/test_answer_relevance.py
@@ -1,0 +1,301 @@
+"""Unit tests for the AnswerRelevance check.
+
+Tests cover:
+- Relevant answer passes
+- Off-topic answer fails
+- Multi-turn: answer relevant in programming context passes
+- Multi-turn: zoology answer to programming question fails (key acceptance criterion)
+- Partial relevance (LLM decides)
+- Direct question/answer values take priority over trace extraction
+- Custom key paths
+- Domain context forwarded to template inputs
+- Empty trace (no history) handled gracefully
+"""
+
+import json
+from typing import Any, override
+
+from giskard.agents.chat import Message
+from giskard.agents.generators._types import Response
+from giskard.agents.generators.base import BaseGenerator, GenerationParams
+from giskard.checks import AnswerRelevance, CheckStatus, Interaction, Trace
+from pydantic import Field
+
+
+class MockGenerator(BaseGenerator):
+    passed: bool
+    reason: str | None = None
+    calls: list[list[Message]] = Field(default_factory=list)
+
+    @override
+    async def _call_model(
+        self,
+        messages: list[Message],
+        params: GenerationParams,
+        metadata: dict[str, Any] | None = None,
+    ) -> Response:
+        self.calls.append(messages)
+        return Response(
+            message=Message(
+                role="assistant",
+                content=json.dumps({"passed": self.passed, "reason": self.reason}),
+            ),
+            finish_reason="stop",
+        )
+
+
+class TestAnswerRelevanceBasic:
+    """Basic pass / fail behaviour."""
+
+    async def test_relevant_answer_passes(self):
+        """Directly relevant answer should pass."""
+        generator = MockGenerator(
+            passed=True, reason="Answer directly addresses the question."
+        )
+        check = AnswerRelevance(
+            generator=generator,
+            question="What is the capital of France?",
+            answer="The capital of France is Paris.",
+        )
+        result = await check.run(Trace())
+
+        assert result.status == CheckStatus.PASS
+        assert result.passed
+        assert result.details["reason"] == "Answer directly addresses the question."
+
+    async def test_off_topic_answer_fails(self):
+        """Completely off-topic answer should fail."""
+        generator = MockGenerator(
+            passed=False, reason="Answer is about food, not geography."
+        )
+        check = AnswerRelevance(
+            generator=generator,
+            question="What is the capital of France?",
+            answer="Lasagna is a delicious Italian dish.",
+        )
+        result = await check.run(Trace())
+
+        assert result.status == CheckStatus.FAIL
+        assert result.failed
+        assert result.details["reason"] == "Answer is about food, not geography."
+
+    async def test_llm_called_once(self):
+        """Exactly one LLM call should be made per check run."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(
+            generator=generator,
+            question="What is 2 + 2?",
+            answer="4.",
+        )
+        await check.run(Trace())
+
+        assert len(generator.calls) == 1
+
+
+class TestAnswerRelevanceMultiTurn:
+    """Multi-turn conversation awareness — core acceptance criteria."""
+
+    async def test_multi_turn_zoology_answer_fails(self):
+        """'A snake' answer to 'What's Python?' after programming context should fail.
+
+        This is the canonical acceptance criterion from issue #2338: when the
+        conversation history establishes a programming domain, a zoology answer
+        to 'What's Python?' must be flagged as not relevant.
+        """
+        generator = MockGenerator(
+            passed=False,
+            reason=(
+                "Given the prior programming-language context, 'Python' refers to the "
+                "language, not the reptile. The answer 'A snake' is off-topic."
+            ),
+        )
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What is the best language?", outputs="Python"),
+            Interaction(inputs="What's Python?", outputs="A snake."),
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.FAIL
+        assert result.failed
+
+    async def test_multi_turn_relevant_programming_answer_passes(self):
+        """A correct programming answer in a programming conversation should pass."""
+        generator = MockGenerator(
+            passed=True,
+            reason="Answer correctly describes Python as a programming language.",
+        )
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What is the best language?", outputs="Python"),
+            Interaction(
+                inputs="What's Python?",
+                outputs="Python is a high-level programming language known for its readability.",
+            ),
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.PASS
+        assert result.passed
+
+    async def test_second_turn_irrelevant_does_not_affect_third_turn_score(self):
+        """A prior irrelevant answer must not cause the current relevant answer to fail.
+
+        Issue #2338: 'If a prior message was irrelevant, it should not impact the result.'
+        Only the current turn is scored; history is context, not a penalty.
+        """
+        generator = MockGenerator(
+            passed=True,
+            reason="The answer correctly identifies Python as both a language and an animal.",
+        )
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(
+                inputs="What is the best language?", outputs="You should cook lasagna"
+            ),
+            Interaction(
+                inputs="Is Python a language or an animal?",
+                outputs="It's both — Python is a programming language and also a type of snake.",
+            ),
+        )
+
+        result = await check.run(trace)
+
+        assert result.status == CheckStatus.PASS
+        assert result.passed
+
+    async def test_history_included_in_inputs(self):
+        """Template inputs must include a non-empty history for multi-turn traces."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Turn 1 question", outputs="Turn 1 answer"),
+            Interaction(inputs="Turn 2 question", outputs="Turn 2 answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        history = result.details["inputs"]["history"]
+        assert "Turn 1 question" in history
+        assert "Turn 1 answer" in history
+        # Current turn should NOT appear in history
+        assert "Turn 2 question" not in history
+
+    async def test_single_turn_history_is_empty(self):
+        """With only one interaction, history should be empty string."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Single question", outputs="Single answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        assert result.details["inputs"]["history"] == ""
+
+
+class TestAnswerRelevanceInputResolution:
+    """Direct values vs. trace extraction."""
+
+    async def test_direct_question_and_answer_used(self):
+        """Directly supplied question/answer take priority over trace."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(
+            generator=generator,
+            question="Direct question",
+            answer="Direct answer",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(inputs="Trace question", outputs="Trace answer"),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        assert result.details["inputs"]["question"] == "Direct question"
+        assert result.details["inputs"]["answer"] == "Direct answer"
+
+    async def test_question_and_answer_extracted_from_trace(self):
+        """When no direct values given, question/answer extracted from trace."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(generator=generator)
+        trace = await Trace.from_interactions(
+            Interaction(inputs="What is AI?", outputs="AI is artificial intelligence."),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        assert result.details["inputs"]["question"] == "What is AI?"
+        assert result.details["inputs"]["answer"] == "AI is artificial intelligence."
+
+    async def test_custom_keys(self):
+        """Custom JSONPath keys should resolve correctly."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(
+            generator=generator,
+            question_key="trace.interactions[0].inputs.query",
+            answer_key="trace.interactions[0].outputs.response",
+        )
+        trace = await Trace.from_interactions(
+            Interaction(
+                inputs={"query": "Custom question"},
+                outputs={"response": "Custom answer"},
+            ),
+        )
+
+        result = await check.run(trace)
+
+        assert result.passed
+        assert result.details["inputs"]["question"] == "Custom question"
+        assert result.details["inputs"]["answer"] == "Custom answer"
+
+    async def test_empty_trace_no_crash(self):
+        """Empty trace should not raise — NoMatch values are stringified gracefully."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(generator=generator)
+
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert "No match for key" in result.details["inputs"]["question"]
+        assert "No match for key" in result.details["inputs"]["answer"]
+
+
+class TestAnswerRelevanceDomainContext:
+    """Optional domain context is forwarded to template inputs."""
+
+    async def test_domain_context_included_in_inputs(self):
+        """Supplied domain context must appear in template inputs."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(
+            generator=generator,
+            question="What is Flask?",
+            answer="Flask is a lightweight Python web framework.",
+            context="This is a chatbot that answers questions about Python programming.",
+        )
+
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert result.details["inputs"]["context"] == (
+            "This is a chatbot that answers questions about Python programming."
+        )
+
+    async def test_no_domain_context_is_empty_string(self):
+        """When no domain context is supplied, template input is empty string."""
+        generator = MockGenerator(passed=True, reason=None)
+        check = AnswerRelevance(
+            generator=generator,
+            question="What is Flask?",
+            answer="Flask is a web framework.",
+        )
+
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert result.details["inputs"]["context"] == ""

--- a/libs/giskard-checks/tests/builtin/test_answer_relevance.py
+++ b/libs/giskard-checks/tests/builtin/test_answer_relevance.py
@@ -9,7 +9,8 @@ Tests cover:
 - Direct question/answer values take priority over trace extraction
 - Custom key paths
 - Domain context forwarded to template inputs
-- Empty trace (no history) handled gracefully
+- Full trace passed as template ``history`` (conversation context for the judge)
+- Empty trace handled gracefully (NoMatch when resolving last turn)
 """
 
 import json
@@ -18,8 +19,20 @@ from typing import Any, override
 from giskard.agents.chat import Message
 from giskard.agents.generators._types import Response
 from giskard.agents.generators.base import BaseGenerator, GenerationParams
-from giskard.checks import AnswerRelevance, CheckStatus, Interaction, Trace
+from giskard.checks import AnswerRelevance, CheckResult, CheckStatus, Interaction, Trace
+from giskard.checks.core.extraction import NoMatch
 from pydantic import Field
+
+_EXPECTED_INPUT_KEYS = frozenset({"question", "answer", "history", "context"})
+
+
+def _assert_answer_relevance_inputs(result: CheckResult) -> dict[str, Any]:
+    """Assert every AnswerRelevance run records full template inputs."""
+    assert "inputs" in result.details
+    inputs = result.details["inputs"]
+    assert isinstance(inputs, dict)
+    assert set(inputs.keys()) == _EXPECTED_INPUT_KEYS
+    return inputs
 
 
 class MockGenerator(BaseGenerator):
@@ -62,6 +75,11 @@ class TestAnswerRelevanceBasic:
         assert result.status == CheckStatus.PASS
         assert result.passed
         assert result.details["reason"] == "Answer directly addresses the question."
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is the capital of France?"
+        assert inputs["answer"] == "The capital of France is Paris."
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == ""
 
     async def test_off_topic_answer_fails(self):
         """Completely off-topic answer should fail."""
@@ -78,6 +96,11 @@ class TestAnswerRelevanceBasic:
         assert result.status == CheckStatus.FAIL
         assert result.failed
         assert result.details["reason"] == "Answer is about food, not geography."
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is the capital of France?"
+        assert inputs["answer"] == "Lasagna is a delicious Italian dish."
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == ""
 
     async def test_llm_called_once(self):
         """Exactly one LLM call should be made per check run."""
@@ -87,9 +110,14 @@ class TestAnswerRelevanceBasic:
             question="What is 2 + 2?",
             answer="4.",
         )
-        await check.run(Trace())
+        result = await check.run(Trace())
 
         assert len(generator.calls) == 1
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is 2 + 2?"
+        assert inputs["answer"] == "4."
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == ""
 
 
 class TestAnswerRelevanceMultiTurn:
@@ -119,6 +147,11 @@ class TestAnswerRelevanceMultiTurn:
 
         assert result.status == CheckStatus.FAIL
         assert result.failed
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        assert inputs["question"] == "What's Python?"
+        assert inputs["answer"] == "A snake."
+        assert inputs["context"] == ""
 
     async def test_multi_turn_relevant_programming_answer_passes(self):
         """A correct programming answer in a programming conversation should pass."""
@@ -139,6 +172,14 @@ class TestAnswerRelevanceMultiTurn:
 
         assert result.status == CheckStatus.PASS
         assert result.passed
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        assert inputs["question"] == "What's Python?"
+        assert (
+            inputs["answer"]
+            == "Python is a high-level programming language known for its readability."
+        )
+        assert inputs["context"] == ""
 
     async def test_second_turn_irrelevant_does_not_affect_third_turn_score(self):
         """A prior irrelevant answer must not cause the current relevant answer to fail.
@@ -165,9 +206,17 @@ class TestAnswerRelevanceMultiTurn:
 
         assert result.status == CheckStatus.PASS
         assert result.passed
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        assert inputs["question"] == "Is Python a language or an animal?"
+        assert (
+            inputs["answer"]
+            == "It's both — Python is a programming language and also a type of snake."
+        )
+        assert inputs["context"] == ""
 
-    async def test_history_included_in_inputs(self):
-        """Template inputs must include a non-empty history for multi-turn traces."""
+    async def test_history_in_inputs_is_full_trace(self):
+        """Template inputs pass the full trace as history for the judge."""
         generator = MockGenerator(passed=True, reason=None)
         check = AnswerRelevance(generator=generator)
         trace = await Trace.from_interactions(
@@ -178,14 +227,17 @@ class TestAnswerRelevanceMultiTurn:
         result = await check.run(trace)
 
         assert result.passed
-        history = result.details["inputs"]["history"]
-        assert "Turn 1 question" in history
-        assert "Turn 1 answer" in history
-        # Current turn should NOT appear in history
-        assert "Turn 2 question" not in history
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        assert len(inputs["history"].interactions) == 2
+        assert inputs["history"].interactions[0].inputs == "Turn 1 question"
+        assert inputs["history"].interactions[0].outputs == "Turn 1 answer"
+        assert inputs["question"] == "Turn 2 question"
+        assert inputs["answer"] == "Turn 2 answer"
+        assert inputs["context"] == ""
 
-    async def test_single_turn_history_is_empty(self):
-        """With only one interaction, history should be empty string."""
+    async def test_single_turn_history_is_the_trace(self):
+        """With one interaction, history is the trace containing that turn."""
         generator = MockGenerator(passed=True, reason=None)
         check = AnswerRelevance(generator=generator)
         trace = await Trace.from_interactions(
@@ -195,7 +247,10 @@ class TestAnswerRelevanceMultiTurn:
         result = await check.run(trace)
 
         assert result.passed
-        assert result.details["inputs"]["history"] == ""
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["history"] == trace
+        assert len(trace.interactions) == 1
+        assert inputs["context"] == ""
 
 
 class TestAnswerRelevanceInputResolution:
@@ -216,8 +271,11 @@ class TestAnswerRelevanceInputResolution:
         result = await check.run(trace)
 
         assert result.passed
-        assert result.details["inputs"]["question"] == "Direct question"
-        assert result.details["inputs"]["answer"] == "Direct answer"
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "Direct question"
+        assert inputs["answer"] == "Direct answer"
+        assert inputs["history"] == trace
+        assert inputs["context"] == ""
 
     async def test_question_and_answer_extracted_from_trace(self):
         """When no direct values given, question/answer extracted from trace."""
@@ -230,8 +288,11 @@ class TestAnswerRelevanceInputResolution:
         result = await check.run(trace)
 
         assert result.passed
-        assert result.details["inputs"]["question"] == "What is AI?"
-        assert result.details["inputs"]["answer"] == "AI is artificial intelligence."
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is AI?"
+        assert inputs["answer"] == "AI is artificial intelligence."
+        assert inputs["history"] == trace
+        assert inputs["context"] == ""
 
     async def test_custom_keys(self):
         """Custom JSONPath keys should resolve correctly."""
@@ -251,8 +312,11 @@ class TestAnswerRelevanceInputResolution:
         result = await check.run(trace)
 
         assert result.passed
-        assert result.details["inputs"]["question"] == "Custom question"
-        assert result.details["inputs"]["answer"] == "Custom answer"
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "Custom question"
+        assert inputs["answer"] == "Custom answer"
+        assert inputs["history"] == trace
+        assert inputs["context"] == ""
 
     async def test_empty_trace_no_crash(self):
         """Empty trace should not raise — NoMatch values are stringified gracefully."""
@@ -262,8 +326,13 @@ class TestAnswerRelevanceInputResolution:
         result = await check.run(Trace())
 
         assert result.passed
-        assert "No match for key" in result.details["inputs"]["question"]
-        assert "No match for key" in result.details["inputs"]["answer"]
+        inputs = _assert_answer_relevance_inputs(result)
+        assert isinstance(inputs["question"], NoMatch)
+        assert inputs["question"].key == "trace.last.inputs"
+        assert isinstance(inputs["answer"], NoMatch)
+        assert inputs["answer"].key == "trace.last.outputs"
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == ""
 
 
 class TestAnswerRelevanceDomainContext:
@@ -282,7 +351,11 @@ class TestAnswerRelevanceDomainContext:
         result = await check.run(Trace())
 
         assert result.passed
-        assert result.details["inputs"]["context"] == (
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is Flask?"
+        assert inputs["answer"] == "Flask is a lightweight Python web framework."
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == (
             "This is a chatbot that answers questions about Python programming."
         )
 
@@ -298,4 +371,8 @@ class TestAnswerRelevanceDomainContext:
         result = await check.run(Trace())
 
         assert result.passed
-        assert result.details["inputs"]["context"] == ""
+        inputs = _assert_answer_relevance_inputs(result)
+        assert inputs["question"] == "What is Flask?"
+        assert inputs["answer"] == "Flask is a web framework."
+        assert inputs["history"] == Trace()
+        assert inputs["context"] == ""


### PR DESCRIPTION
## Description

Adds a built-in LLM-based `AnswerRelevance` check that evaluates whether the model's answer is relevant to the user's question, with full multi-turn conversation awareness.

### Key design decisions

**Multi-turn history:** The judge receives the full conversation history (all prior turns) formatted as plain text, so it can resolve ambiguous follow-up questions in the correct domain. The canonical example from the issue:

> Turn 1: "What is the best language?" → "Python"  
> Turn 2: "What's Python?" → "A snake."  

With history, the judge correctly flags "A snake" as off-topic (programming context → not zoology). Without history, it would wrongly pass.

**Only the current turn is scored:** Prior irrelevant exchanges do not penalise the current answer (per issue spec: *"If a prior message was irrelevant, it should not impact the result"*).

**Fields:**
- `question / question_key` — the question to score (direct value or JSONPath, default `trace.last.inputs`)
- `answer / answer_key` — the answer to score (direct value or JSONPath, default `trace.last.outputs`)
- `context` — optional domain context string (e.g. *"This is a chatbot about programming languages"*)

## Related Issue

Closes #2338

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the CODE_OF_CONDUCT.md document.
- [x] I've read the CONTRIBUTING.md guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)