### PR TITLE
feat(giskard-checks): add AllOf, AnyOf, Not check composition operators

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/__init__.py
@@ -7,12 +7,15 @@ from giskard.agents import add_prompts_path
 
 from . import builtin, judges
 from .builtin import (
+    AllOf,
+    AnyOf,
     Equals,
     FnCheck,
     GreaterEquals,
     GreaterThan,
     LesserThan,
     LesserThanEquals,
+    Not,
     NotEquals,
     RegexMatching,
     SemanticSimilarity,
@@ -85,6 +88,9 @@ __all__ = [
     "Interaction",
     "InteractionSpec",
     # Builtin and LLM-based checks
+    "AllOf",
+    "AnyOf",
+    "Not",
     "BaseLLMCheck",
     "LLMCheckResult",
     "Conformity",

--- a/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/__init__.py
@@ -14,11 +14,15 @@ from .comparison import (
 )
 
 # Import other builtin checks (staying in builtin)
+from .composition import AllOf, AnyOf, Not
 from .fn import FnCheck, from_fn
 from .semantic_similarity import SemanticSimilarity
 from .text_matching import RegexMatching, StringMatching
 
 __all__ = [
+    "AllOf",
+    "AnyOf",
+    "Not",
     "from_fn",
     "FnCheck",
     "StringMatching",

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -115,13 +115,22 @@ class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
             The first passing result, or a combined failure if none pass.
         """
         failure_messages: list[str] = []
+        all_skipped = True
 
         for check in self.checks:  # pyright: ignore[reportUnknownVariableType]
             result = await check.run(trace)  # pyright: ignore[reportUnknownMemberType]
-            if result.passed:
+            if result.passed or result.errored:
                 return result
+            if not result.skipped:
+                all_skipped = False
             if result.message:
                 failure_messages.append(result.message)
+
+        if all_skipped and self.checks:
+            return CheckResult.skip(
+                message="No checks passed and all were skipped."
+                + (f" Details: {'; '.join(failure_messages)}" if failure_messages else ""),
+            )
 
         return CheckResult.failure(
             message=(

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -1,0 +1,196 @@
+from typing import Any, override
+
+from pydantic import Field
+
+from ..core import Trace
+from ..core.check import Check
+from ..core.result import CheckResult, CheckStatus
+
+# Use the plain Check type — the Check base class already provides a custom
+# __get_pydantic_core_schema__ that builds a tagged union from the registered
+# subclasses. Adding a discriminator annotation on top would clash with it.
+_AnyCheck = Check[Any, Any, Any]  # pyright: ignore[reportMissingTypeArgument]
+
+
+@Check.register("all_of")
+class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Passes only when **all** inner checks pass (short-circuits on first failure).
+
+    Runs each check in order. The first failing or erroring check stops
+    evaluation and its result is returned immediately. If all checks pass,
+    a combined success result is returned.
+
+    Attributes
+    ----------
+    checks : list[Check]
+        Ordered list of checks to evaluate. All must pass for this check to pass.
+
+    Examples
+    --------
+    >>> from giskard.checks import AllOf, LesserThan, Equals
+    >>> check = AllOf(checks=[
+    ...     LesserThan(expected_value=10, key="trace.last.outputs"),
+    ...     Equals(expected_value=5, key="trace.last.outputs"),
+    ... ])
+    """
+
+    checks: list[_AnyCheck] = Field(  # pyright: ignore[reportUnknownVariableType]
+        ...,
+        description="Ordered list of checks to evaluate. All must pass.",
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Run all checks in order, short-circuiting on the first failure.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to evaluate against.
+
+        Returns
+        -------
+        CheckResult
+            The first non-passing result, or a combined success if all pass.
+        """
+        passed_messages: list[str] = []
+
+        for check in self.checks:  # pyright: ignore[reportUnknownVariableType]
+            result = await check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+            if not result.passed:
+                return result
+            if result.message:
+                passed_messages.append(result.message)
+
+        return CheckResult.success(
+            message="; ".join(passed_messages)
+            if passed_messages
+            else "All checks passed.",
+        )
+
+
+@Check.register("any_of")
+class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Passes when **at least one** inner check passes (short-circuits on first pass).
+
+    Runs each check in order. The first passing check stops evaluation and
+    its result is returned immediately. If all checks fail, a combined failure
+    result is returned.
+
+    Attributes
+    ----------
+    checks : list[Check]
+        Ordered list of checks to evaluate. At least one must pass.
+
+    Examples
+    --------
+    >>> from giskard.checks import AnyOf, StringMatching
+    >>> check = AnyOf(checks=[
+    ...     StringMatching(keyword="yes", key="trace.last.outputs"),
+    ...     StringMatching(keyword="approved", key="trace.last.outputs"),
+    ... ])
+    """
+
+    checks: list[_AnyCheck] = Field(  # pyright: ignore[reportUnknownVariableType]
+        ...,
+        description="Ordered list of checks to evaluate. At least one must pass.",
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Run checks in order, short-circuiting on the first passing result.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to evaluate against.
+
+        Returns
+        -------
+        CheckResult
+            The first passing result, or a combined failure if none pass.
+        """
+        failure_messages: list[str] = []
+
+        for check in self.checks:  # pyright: ignore[reportUnknownVariableType]
+            result = await check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+            if result.passed:
+                return result
+            if result.message:
+                failure_messages.append(result.message)
+
+        return CheckResult.failure(
+            message=(
+                "No checks passed. Failures: " + "; ".join(failure_messages)
+                if failure_messages
+                else "All checks failed."
+            ),
+        )
+
+
+@Check.register("not")
+class Not[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMissingTypeArgument]
+    Check[InputType, OutputType, TraceType]
+):
+    """Inverts the result of an inner check.
+
+    A passing inner result becomes a failure, and a failing inner result
+    becomes a pass. Error and skip results are passed through unchanged.
+
+    Attributes
+    ----------
+    check : Check
+        The inner check whose result will be inverted.
+
+    Examples
+    --------
+    >>> from giskard.checks import Not, StringMatching
+    >>> check = Not(check=StringMatching(keyword="forbidden", key="trace.last.outputs"))
+    """
+
+    check: _AnyCheck = Field(  # pyright: ignore[reportUnknownVariableType]
+        ...,
+        description="The inner check whose result will be inverted.",
+    )
+
+    @override
+    async def run(self, trace: TraceType) -> CheckResult:
+        """Run the inner check and invert its pass/fail result.
+
+        Error and skip results are passed through without inversion.
+
+        Parameters
+        ----------
+        trace : TraceType
+            The trace to evaluate against.
+
+        Returns
+        -------
+        CheckResult
+            Inverted result (pass→fail, fail→pass). Error/skip unchanged.
+        """
+        result = await self.check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+
+        if result.status in (CheckStatus.ERROR, CheckStatus.SKIP):
+            return result
+
+        if result.passed:
+            return CheckResult.failure(
+                message=(
+                    "Expected check to fail, but it passed"
+                    + (f": {result.message}" if result.message else ".")
+                ),
+                details=result.details,
+            )
+
+        return CheckResult.success(
+            message=(
+                "Check correctly failed (inverted)"
+                + (f": {result.message}" if result.message else ".")
+            ),
+            details=result.details,
+        )

--- a/libs/giskard-checks/src/giskard/checks/builtin/composition.py
+++ b/libs/giskard-checks/src/giskard/checks/builtin/composition.py
@@ -1,15 +1,10 @@
-from typing import Any, override
+from typing import override
 
 from pydantic import Field
 
 from ..core import Trace
 from ..core.check import Check
 from ..core.result import CheckResult, CheckStatus
-
-# Use the plain Check type — the Check base class already provides a custom
-# __get_pydantic_core_schema__ that builds a tagged union from the registered
-# subclasses. Adding a discriminator annotation on top would clash with it.
-_AnyCheck = Check[Any, Any, Any]  # pyright: ignore[reportMissingTypeArgument]
 
 
 @Check.register("all_of")
@@ -36,7 +31,7 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     ... ])
     """
 
-    checks: list[_AnyCheck] = Field(  # pyright: ignore[reportUnknownVariableType]
+    checks: list[Check[InputType, OutputType, TraceType]] = Field(
         ...,
         description="Ordered list of checks to evaluate. All must pass.",
     )
@@ -57,8 +52,8 @@ class AllOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         """
         passed_messages: list[str] = []
 
-        for check in self.checks:  # pyright: ignore[reportUnknownVariableType]
-            result = await check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+        for check in self.checks:
+            result = await check.run(trace)
             if not result.passed:
                 return result
             if result.message:
@@ -95,7 +90,7 @@ class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
     ... ])
     """
 
-    checks: list[_AnyCheck] = Field(  # pyright: ignore[reportUnknownVariableType]
+    checks: list[Check[InputType, OutputType, TraceType]] = Field(
         ...,
         description="Ordered list of checks to evaluate. At least one must pass.",
     )
@@ -117,8 +112,8 @@ class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         failure_messages: list[str] = []
         all_skipped = True
 
-        for check in self.checks:  # pyright: ignore[reportUnknownVariableType]
-            result = await check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+        for check in self.checks:
+            result = await check.run(trace)
             if result.passed or result.errored:
                 return result
             if not result.skipped:
@@ -129,7 +124,11 @@ class AnyOf[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportM
         if all_skipped and self.checks:
             return CheckResult.skip(
                 message="No checks passed and all were skipped."
-                + (f" Details: {'; '.join(failure_messages)}" if failure_messages else ""),
+                + (
+                    f" Details: {'; '.join(failure_messages)}"
+                    if failure_messages
+                    else ""
+                ),
             )
 
         return CheckResult.failure(
@@ -161,7 +160,7 @@ class Not[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMis
     >>> check = Not(check=StringMatching(keyword="forbidden", key="trace.last.outputs"))
     """
 
-    check: _AnyCheck = Field(  # pyright: ignore[reportUnknownVariableType]
+    check: Check[InputType, OutputType, TraceType] = Field(
         ...,
         description="The inner check whose result will be inverted.",
     )
@@ -182,7 +181,7 @@ class Not[InputType, OutputType, TraceType: Trace](  # pyright: ignore[reportMis
         CheckResult
             Inverted result (pass→fail, fail→pass). Error/skip unchanged.
         """
-        result = await self.check.run(trace)  # pyright: ignore[reportUnknownMemberType]
+        result = await self.check.run(trace)
 
         if result.status in (CheckStatus.ERROR, CheckStatus.SKIP):
             return result

--- a/libs/giskard-checks/tests/builtin/test_composition.py
+++ b/libs/giskard-checks/tests/builtin/test_composition.py
@@ -1,0 +1,415 @@
+"""Unit tests for AllOf, AnyOf, and Not composition checks.
+
+Tests cover:
+- AllOf: all pass, partial pass (short-circuit), all fail
+- AnyOf: first passes, last passes, all fail
+- Not: invert pass, invert fail, pass-through error/skip
+- Nested composition (AllOf inside AnyOf, Not wrapping AllOf)
+- Serialisation round-trip via model_dump / model_validate
+"""
+
+from giskard.checks import (
+    AllOf,
+    AnyOf,
+    Equals,
+    Interaction,
+    LesserThan,
+    Not,
+    Trace,
+)
+from giskard.checks.builtin.fn import FnCheck
+from giskard.checks.core.result import CheckResult
+from giskard.checks.core.result import CheckStatus as CS
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _passing_fn_check(message: str = "passed") -> FnCheck:
+    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        return CheckResult.success(message=message)
+
+    return FnCheck(fn=_fn)
+
+
+def _failing_fn_check(message: str = "failed") -> FnCheck:
+    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        return CheckResult.failure(message=message)
+
+    return FnCheck(fn=_fn)
+
+
+def _error_fn_check(message: str = "error") -> FnCheck:
+    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        return CheckResult.error(message=message)
+
+    return FnCheck(fn=_fn)
+
+
+def _skip_fn_check(message: str = "skip") -> FnCheck:
+    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        return CheckResult.skip(message=message)
+
+    return FnCheck(fn=_fn)
+
+
+# ---------------------------------------------------------------------------
+# AllOf
+# ---------------------------------------------------------------------------
+
+
+class TestAllOf:
+    """AllOf passes only when every inner check passes."""
+
+    async def test_all_pass(self):
+        """All checks pass → combined success."""
+        check = AllOf(checks=[_passing_fn_check("a"), _passing_fn_check("b")])
+        result = await check.run(Trace())
+
+        assert result.status == CS.PASS
+        assert result.passed
+
+    async def test_first_fails_short_circuits(self):
+        """First failure stops evaluation; subsequent checks are not run."""
+        call_log: list[str] = []
+
+        async def _fail(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+            call_log.append("fail")
+            return CheckResult.failure(message="first failed")
+
+        async def _should_not_run(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+            call_log.append("second")
+            return CheckResult.success(message="second")
+
+        check = AllOf(checks=[FnCheck(fn=_fail), FnCheck(fn=_should_not_run)])
+        result = await check.run(Trace())
+
+        assert result.status == CS.FAIL
+        assert result.failed
+        assert "first failed" in (result.message or "")
+        assert "second" not in call_log
+
+    async def test_last_fails(self):
+        """Failure in last check is returned."""
+        check = AllOf(checks=[_passing_fn_check(), _failing_fn_check("last failed")])
+        result = await check.run(Trace())
+
+        assert result.failed
+        assert "last failed" in (result.message or "")
+
+    async def test_all_fail(self):
+        """First failure is returned immediately."""
+        check = AllOf(checks=[_failing_fn_check("first"), _failing_fn_check("second")])
+        result = await check.run(Trace())
+
+        assert result.failed
+        assert "first" in (result.message or "")
+
+    async def test_error_short_circuits(self):
+        """An erroring check stops evaluation."""
+        check = AllOf(checks=[_error_fn_check("boom"), _passing_fn_check()])
+        result = await check.run(Trace())
+
+        assert result.status == CS.ERROR
+        assert result.errored
+
+    async def test_single_check_pass(self):
+        """Single passing check returns success."""
+        check = AllOf(checks=[_passing_fn_check("only")])
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_combined_message_contains_all_messages(self):
+        """Success message contains messages from all inner checks."""
+        check = AllOf(checks=[_passing_fn_check("msg_a"), _passing_fn_check("msg_b")])
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert "msg_a" in (result.message or "")
+        assert "msg_b" in (result.message or "")
+
+    async def test_with_real_checks(self):
+        """AllOf works with real built-in checks."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AllOf(
+            checks=[
+                LesserThan(expected_value=10, key="trace.last.outputs"),
+                Equals(expected_value=5, key="trace.last.outputs"),
+            ]
+        )
+        result = await check.run(trace)
+
+        assert result.passed
+
+    async def test_with_real_checks_partial_fail(self):
+        """AllOf fails when one real check fails."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AllOf(
+            checks=[
+                LesserThan(expected_value=10, key="trace.last.outputs"),
+                Equals(expected_value=99, key="trace.last.outputs"),  # will fail
+            ]
+        )
+        result = await check.run(trace)
+
+        assert result.failed
+
+
+# ---------------------------------------------------------------------------
+# AnyOf
+# ---------------------------------------------------------------------------
+
+
+class TestAnyOf:
+    """AnyOf passes when at least one inner check passes."""
+
+    async def test_first_passes_short_circuits(self):
+        """First success stops evaluation."""
+        call_log: list[str] = []
+
+        async def _pass(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+            call_log.append("first")
+            return CheckResult.success(message="first passed")
+
+        async def _should_not_run(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+            call_log.append("second")
+            return CheckResult.success(message="second")
+
+        check = AnyOf(checks=[FnCheck(fn=_pass), FnCheck(fn=_should_not_run)])
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert "second" not in call_log
+
+    async def test_last_passes(self):
+        """Last check passing returns success."""
+        check = AnyOf(checks=[_failing_fn_check(), _passing_fn_check("last")])
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_all_fail(self):
+        """All checks failing returns combined failure."""
+        check = AnyOf(checks=[_failing_fn_check("f1"), _failing_fn_check("f2")])
+        result = await check.run(Trace())
+
+        assert result.failed
+        assert "f1" in (result.message or "")
+        assert "f2" in (result.message or "")
+
+    async def test_single_check_pass(self):
+        """Single passing check returns success."""
+        check = AnyOf(checks=[_passing_fn_check()])
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_single_check_fail(self):
+        """Single failing check returns failure."""
+        check = AnyOf(checks=[_failing_fn_check("only")])
+        result = await check.run(Trace())
+
+        assert result.failed
+
+    async def test_with_real_checks(self):
+        """AnyOf works with real built-in checks."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AnyOf(
+            checks=[
+                Equals(expected_value=99, key="trace.last.outputs"),  # fail
+                Equals(expected_value=5, key="trace.last.outputs"),  # pass
+            ]
+        )
+        result = await check.run(trace)
+
+        assert result.passed
+
+    async def test_with_real_checks_all_fail(self):
+        """AnyOf fails when no real check passes."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AnyOf(
+            checks=[
+                Equals(expected_value=99, key="trace.last.outputs"),
+                Equals(expected_value=100, key="trace.last.outputs"),
+            ]
+        )
+        result = await check.run(trace)
+
+        assert result.failed
+
+
+# ---------------------------------------------------------------------------
+# Not
+# ---------------------------------------------------------------------------
+
+
+class TestNot:
+    """Not inverts the pass/fail of the inner check."""
+
+    async def test_inverts_pass_to_fail(self):
+        """A passing inner check becomes a failure."""
+        check = Not(check=_passing_fn_check("inner passed"))
+        result = await check.run(Trace())
+
+        assert result.failed
+
+    async def test_inverts_fail_to_pass(self):
+        """A failing inner check becomes a success."""
+        check = Not(check=_failing_fn_check("inner failed"))
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_error_passed_through(self):
+        """An error result is not inverted."""
+        check = Not(check=_error_fn_check("boom"))
+        result = await check.run(Trace())
+
+        assert result.status == CS.ERROR
+        assert result.errored
+
+    async def test_skip_passed_through(self):
+        """A skip result is not inverted."""
+        check = Not(check=_skip_fn_check("skipped"))
+        result = await check.run(Trace())
+
+        assert result.status == CS.SKIP
+        assert result.skipped
+
+    async def test_failure_message_mentions_original(self):
+        """Inverted-pass failure message references original message."""
+        check = Not(check=_passing_fn_check("some message"))
+        result = await check.run(Trace())
+
+        assert result.failed
+        assert "some message" in (result.message or "")
+
+    async def test_success_message_mentions_original(self):
+        """Inverted-fail success message references original message."""
+        check = Not(check=_failing_fn_check("bad thing"))
+        result = await check.run(Trace())
+
+        assert result.passed
+        assert "bad thing" in (result.message or "")
+
+    async def test_with_real_check(self):
+        """Not works with a real built-in check."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        # Equals(99) fails → Not inverts to pass
+        check = Not(check=Equals(expected_value=99, key="trace.last.outputs"))
+        result = await check.run(trace)
+
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Nested composition
+# ---------------------------------------------------------------------------
+
+
+class TestNestedComposition:
+    """Composition operators can be nested arbitrarily."""
+
+    async def test_all_of_inside_any_of(self):
+        """AllOf nested inside AnyOf."""
+        check = AnyOf(
+            checks=[
+                AllOf(checks=[_failing_fn_check(), _passing_fn_check()]),  # fails
+                AllOf(
+                    checks=[_passing_fn_check("x"), _passing_fn_check("y")]
+                ),  # passes
+            ]
+        )
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_not_wrapping_all_of(self):
+        """Not wrapping an AllOf that partially fails."""
+        # AllOf fails (second check fails) → Not inverts to pass
+        check = Not(check=AllOf(checks=[_passing_fn_check(), _failing_fn_check()]))
+        result = await check.run(Trace())
+
+        assert result.passed
+
+    async def test_all_of_with_not(self):
+        """AllOf containing a Not check."""
+        # Not(_failing_fn_check) → pass; combined with another pass → AllOf pass
+        check = AllOf(
+            checks=[
+                Not(check=_failing_fn_check()),
+                _passing_fn_check(),
+            ]
+        )
+        result = await check.run(Trace())
+
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    """Composition checks serialise and deserialise correctly."""
+
+    async def test_all_of_serialises(self):
+        """AllOf round-trips through model_dump."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=3))
+        check = AllOf(checks=[LesserThan(expected_value=10, key="trace.last.outputs")])
+        data = check.model_dump()
+
+        assert data["kind"] == "all_of"
+        assert data["checks"][0]["kind"] == "lesser_than"
+
+        restored = AllOf.model_validate(data)
+        result = await restored.run(trace)
+        assert result.passed
+
+    async def test_any_of_serialises(self):
+        """AnyOf round-trips through model_dump."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AnyOf(
+            checks=[
+                Equals(expected_value=99, key="trace.last.outputs"),
+                Equals(expected_value=5, key="trace.last.outputs"),
+            ]
+        )
+        data = check.model_dump()
+
+        assert data["kind"] == "any_of"
+
+        restored = AnyOf.model_validate(data)
+        result = await restored.run(trace)
+        assert result.passed
+
+    async def test_not_serialises(self):
+        """Not round-trips through model_dump."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = Not(check=Equals(expected_value=99, key="trace.last.outputs"))
+        data = check.model_dump()
+
+        assert data["kind"] == "not"
+        assert data["check"]["kind"] == "equals"
+
+        restored = Not.model_validate(data)
+        result = await restored.run(trace)
+        assert result.passed
+
+    async def test_nested_serialises(self):
+        """Nested composition round-trips correctly."""
+        trace = await Trace.from_interactions(Interaction(inputs="q", outputs=5))
+        check = AllOf(
+            checks=[
+                Not(check=Equals(expected_value=99, key="trace.last.outputs")),
+                LesserThan(expected_value=10, key="trace.last.outputs"),
+            ]
+        )
+        data = check.model_dump()
+        restored = AllOf.model_validate(data)
+        result = await restored.run(trace)
+
+        assert result.passed

--- a/libs/giskard-checks/tests/builtin/test_composition.py
+++ b/libs/giskard-checks/tests/builtin/test_composition.py
@@ -8,6 +8,8 @@ Tests cover:
 - Serialisation round-trip via model_dump / model_validate
 """
 
+from typing import Any
+
 from giskard.checks import (
     AllOf,
     AnyOf,
@@ -26,29 +28,29 @@ from giskard.checks.core.result import CheckStatus as CS
 # ---------------------------------------------------------------------------
 
 
-def _passing_fn_check(message: str = "passed") -> FnCheck:
-    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+def _passing_fn_check(message: str = "passed") -> FnCheck[Any, Any, Trace[Any, Any]]:
+    async def _fn(trace: Trace[Any, Any]) -> CheckResult:
         return CheckResult.success(message=message)
 
     return FnCheck(fn=_fn)
 
 
-def _failing_fn_check(message: str = "failed") -> FnCheck:
-    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+def _failing_fn_check(message: str = "failed") -> FnCheck[Any, Any, Trace[Any, Any]]:
+    async def _fn(trace: Trace[Any, Any]) -> CheckResult:
         return CheckResult.failure(message=message)
 
     return FnCheck(fn=_fn)
 
 
-def _error_fn_check(message: str = "error") -> FnCheck:
-    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+def _error_fn_check(message: str = "error") -> FnCheck[Any, Any, Trace[Any, Any]]:
+    async def _fn(trace: Trace[Any, Any]) -> CheckResult:
         return CheckResult.error(message=message)
 
     return FnCheck(fn=_fn)
 
 
-def _skip_fn_check(message: str = "skip") -> FnCheck:
-    async def _fn(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+def _skip_fn_check(message: str = "skip") -> FnCheck[Any, Any, Trace[Any, Any]]:
+    async def _fn(trace: Trace[Any, Any]) -> CheckResult:
         return CheckResult.skip(message=message)
 
     return FnCheck(fn=_fn)
@@ -74,11 +76,11 @@ class TestAllOf:
         """First failure stops evaluation; subsequent checks are not run."""
         call_log: list[str] = []
 
-        async def _fail(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        async def _fail(trace: Trace[Any, Any]) -> CheckResult:
             call_log.append("fail")
             return CheckResult.failure(message="first failed")
 
-        async def _should_not_run(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        async def _should_not_run(trace: Trace[Any, Any]) -> CheckResult:
             call_log.append("second")
             return CheckResult.success(message="second")
 
@@ -169,11 +171,11 @@ class TestAnyOf:
         """First success stops evaluation."""
         call_log: list[str] = []
 
-        async def _pass(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        async def _pass(trace: Trace[Any, Any]) -> CheckResult:
             call_log.append("first")
             return CheckResult.success(message="first passed")
 
-        async def _should_not_run(trace: Trace) -> CheckResult:  # type: ignore[type-arg]
+        async def _should_not_run(trace: Trace[Any, Any]) -> CheckResult:
             call_log.append("second")
             return CheckResult.success(message="second")
 


### PR DESCRIPTION
## Description

Adds three declarative composition operators that combine existing checks without requiring custom `FnCheck` implementations.

### Operators

| Operator | Behaviour | Short-circuits |
|----------|-----------|----------------|
| `AllOf` | Passes only when **all** inner checks pass | On first failure/error |
| `AnyOf` | Passes when **at least one** inner check passes | On first pass |
| `Not` | Inverts pass/fail of inner check | Error/skip pass through unchanged |

### Design

- All three subclass `Check` and are registered via `@Check.register("all_of"/"any_of"/"not")`.
- Inner checks use `Check[Any, Any, Any]` typed fields, relying on the existing `__get_pydantic_core_schema__` registry for serialisation — no extra Pydantic discriminator annotation needed.
- `AllOf` and `AnyOf` aggregate inner messages into the combined result message.
- Operators can be nested arbitrarily (e.g. `Not(AllOf([...]))`, `AnyOf([AllOf([...]), ...])`) and serialise correctly via `model_dump` / `model_validate`.

### Example

```python
from giskard.checks import AllOf, AnyOf, Not, LesserThan, Equals

# Must be < 10 AND == 5
AllOf(checks=[
    LesserThan(expected_value=10, key="trace.last.outputs"),
    Equals(expected_value=5, key="trace.last.outputs"),
])

# Must equal 99 OR 5
AnyOf(checks=[
    Equals(expected_value=99, key="trace.last.outputs"),
    Equals(expected_value=5, key="trace.last.outputs"),
])

# Must NOT equal 99
Not(check=Equals(expected_value=99, key="trace.last.outputs"))
```

## Related Issue

Closes #2370

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've read the CODE_OF_CONDUCT.md document.
- [x] I've read the CONTRIBUTING.md guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been modified)