### PR TITLE
Add nested JUnit XML export for SuiteResult

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/export/junit.py
+++ b/libs/giskard-checks/src/giskard/checks/export/junit.py
@@ -1,13 +1,11 @@
 import json
+from collections.abc import Iterator
 from datetime import datetime, timezone
-from io import StringIO
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree as ET
 
-from rich.console import Console
-
-from ..core.result import CheckResult, ScenarioResult, SuiteResult
+from ..core.result import CheckResult, ScenarioResult, SuiteResult, TestCaseResult
 
 
 def _seconds(duration_ms: int) -> str:
@@ -33,159 +31,182 @@ def _check_label(result: CheckResult, fallback: str) -> str:
     return fallback
 
 
-def _iter_checks(scenario: ScenarioResult[Any]):
-    for step_index, step in enumerate(scenario.steps, start=1):
-        for check_index, check in enumerate(step.results, start=1):
-            yield step_index, check_index, check
+def _iter_checks(step: TestCaseResult) -> Iterator[tuple[int, CheckResult]]:
+    for check_index, check in enumerate(step.results, start=1):
+        yield check_index, check
+
+
+def _step_assertions(step: TestCaseResult) -> int:
+    return len(step.results)
 
 
 def _scenario_assertions(scenario: ScenarioResult[Any]) -> int:
-    return sum(len(step.results) for step in scenario.steps)
+    return sum(_step_assertions(step) for step in scenario.steps)
 
 
 def _suite_assertions(result: SuiteResult) -> int:
     return sum(_scenario_assertions(scenario) for scenario in result.results)
 
 
-def _suite_counts(result: SuiteResult) -> tuple[int, int, int, int]:
-    tests = len(result.results)
-    failures = sum(1 for scenario in result.results if scenario.failed)
-    errors = sum(1 for scenario in result.results if scenario.errored)
-    skipped = sum(1 for scenario in result.results if scenario.skipped)
+def _scenario_counts(scenario: ScenarioResult[Any]) -> tuple[int, int, int, int]:
+    tests = len(scenario.steps)
+    failures = sum(1 for step in scenario.steps if step.failed)
+    errors = sum(1 for step in scenario.steps if step.errored)
+    skipped = sum(1 for step in scenario.steps if step.skipped)
     return tests, failures, errors, skipped
 
 
-def _matching_checks(
-    scenario: ScenarioResult[Any],
-    *,
-    failed: bool = False,
-    errored: bool = False,
-    skipped: bool = False,
-) -> list[tuple[int, int, CheckResult]]:
-    matches: list[tuple[int, int, CheckResult]] = []
-    for step_index, check_index, check in _iter_checks(scenario):
-        if failed and check.failed:
-            matches.append((step_index, check_index, check))
-        elif errored and check.errored:
-            matches.append((step_index, check_index, check))
-        elif skipped and check.skipped:
-            matches.append((step_index, check_index, check))
-    return matches
+def _suite_counts(result: SuiteResult) -> tuple[int, int, int, int]:
+    counts = [_scenario_counts(scenario) for scenario in result.results]
+    tests = sum(count[0] for count in counts)
+    failures = sum(count[1] for count in counts)
+    errors = sum(count[2] for count in counts)
+    skipped = sum(count[3] for count in counts)
+    return tests, failures, errors, skipped
 
 
-def _build_detail_text(
-    scenario: ScenarioResult[Any],
-    matches: list[tuple[int, int, CheckResult]],
+def _build_check_detail_text(
+    scenario_name: str,
+    step_index: int,
+    check_index: int,
+    check: CheckResult,
 ) -> str:
+    label = _check_label(check, f"check_{check_index}")
+    status = check.status.value.upper()
+    message = check.message or ""
     lines = [
-        f"scenario={scenario.scenario_name}",
-        "See testcase properties for final_trace and step payloads.",
+        f"scenario={scenario_name}",
+        f"testcase=step_{step_index}",
+        f"check={label}",
+        f"status={status}",
+        f"message={message}",
     ]
-
-    for step_index, check_index, check in matches:
-        label = _check_label(check, f"check_{check_index}")
-        status = check.status.value.upper()
-        message = check.message or ""
-        lines.append(f"[{status}] step_{step_index}.{label}: {message}")
-        if check.details:
-            lines.append(f"details={_to_json(check.details)}")
+    if check.details:
+        lines.append(f"details={_to_json(check.details)}")
 
     return "\n".join(lines)
 
 
-def _append_properties(testcase_el: ET.Element, scenario: ScenarioResult[Any]) -> None:
-    properties_el = ET.SubElement(testcase_el, "properties")
+def _build_step_detail_text(
+    scenario_name: str,
+    step_index: int,
+    checks: list[tuple[int, CheckResult]],
+) -> str:
+    return "\n\n".join(
+        _build_check_detail_text(scenario_name, step_index, check_index, check)
+        for check_index, check in checks
+    )
 
+
+def _append_scenario_properties(
+    testsuite_el: ET.Element, scenario: ScenarioResult[Any]
+) -> None:
+    properties_el = ET.SubElement(testsuite_el, "properties")
     ET.SubElement(
         properties_el,
         "property",
         {"name": "final_trace", "value": _to_json(scenario.final_trace)},
     )
 
-    for step_index, step in enumerate(scenario.steps, start=1):
+    ET.SubElement(
+        properties_el,
+        "property",
+        {"name": "status", "value": scenario.status.value},
+    )
+
+
+def _append_testcase_properties(
+    testcase_el: ET.Element, step: TestCaseResult
+) -> None:
+    properties_el = ET.SubElement(testcase_el, "properties")
+
+    ET.SubElement(
+        properties_el,
+        "property",
+        {"name": "status", "value": step.status.value},
+    )
+
+    ET.SubElement(
+        properties_el,
+        "property",
+        {"name": "result", "value": _to_json(step)},
+    )
+
+    for check_index, check in _iter_checks(step):
+        label = _check_label(check, f"check_{check_index}")
         ET.SubElement(
             properties_el,
             "property",
-            {"name": f"step_{step_index}", "value": _to_json(step)},
+            {"name": f"check_{check_index}.name", "value": label},
+        )
+        ET.SubElement(
+            properties_el,
+            "property",
+            {"name": f"check_{check_index}.status", "value": check.status.value},
         )
 
-        for check_index, check in enumerate(step.results, start=1):
-            for metric in check.metrics:
-                ET.SubElement(
-                    properties_el,
-                    "property",
-                    {
-                        "name": f"step_{step_index}.check_{check_index}.{metric.name}",
-                        "value": str(metric.value),
-                    },
-                )
+        for metric in check.metrics:
+            ET.SubElement(
+                properties_el,
+                "property",
+                {
+                    "name": f"check_{check_index}.{metric.name}",
+                    "value": str(metric.value),
+                },
+            )
 
 
-def _append_status_node(testcase_el: ET.Element, scenario: ScenarioResult[Any]) -> None:
-    if scenario.errored:
-        matches = _matching_checks(scenario, errored=True)
-        first = matches[0][2] if matches else None
-        node = ET.SubElement(
-            testcase_el,
-            "error",
-            {
-                "type": _check_label(first, "error") if first else "error",
-                "message": first.message
-                if first and first.message
-                else "Scenario errored.",
-            },
-        )
-        node.text = _build_detail_text(scenario, matches)
+def _append_status_nodes(
+    testcase_el: ET.Element,
+    scenario_name: str,
+    step_index: int,
+    step: TestCaseResult,
+) -> None:
+    checks = [
+        (check_index, check)
+        for check_index, check in _iter_checks(step)
+        if not check.passed
+    ]
+    if not checks:
         return
 
-    if scenario.failed:
-        matches = _matching_checks(scenario, failed=True)
-        first = matches[0][2] if matches else None
-        node = ET.SubElement(
-            testcase_el,
-            "failure",
-            {
-                "type": _check_label(first, "failure") if first else "failure",
-                "message": first.message
-                if first and first.message
-                else "Scenario failed.",
-            },
-        )
-        node.text = _build_detail_text(scenario, matches)
-        return
+    if step.errored:
+        tag = "error"
+        default_message = "Test case errored."
+        priority_checks = [check for check in checks if check[1].errored]
+    elif step.failed:
+        tag = "failure"
+        default_message = "Test case failed."
+        priority_checks = [check for check in checks if check[1].failed]
+    else:
+        tag = "skipped"
+        default_message = "Test case skipped."
+        priority_checks = [check for check in checks if check[1].skipped]
 
-    if scenario.skipped:
-        matches = _matching_checks(scenario, skipped=True)
-        node = ET.SubElement(testcase_el, "skipped")
-        node.text = _build_detail_text(scenario, matches)
-
-
-def _render_scenario_report(scenario: ScenarioResult[Any]) -> str:
-    buffer = StringIO()
-    console = Console(
-        file=buffer,
-        force_terminal=False,
-        no_color=True,
-        width=120,
+    _, first = priority_checks[0] if priority_checks else checks[0]
+    node = ET.SubElement(
+        testcase_el,
+        tag,
+        {
+            "type": _check_label(first, tag),
+            "message": first.message or default_message,
+        },
     )
-    scenario.print_report(console)
-    return buffer.getvalue().rstrip()
-
-
-def _append_system_out(testcase_el: ET.Element, scenario: ScenarioResult[Any]) -> None:
-    report = _render_scenario_report(scenario)
-    if not report:
-        return
-
-    system_out = ET.SubElement(testcase_el, "system-out")
-    system_out.text = report
+    node.text = _build_step_detail_text(scenario_name, step_index, checks)
 
 
 def to_junit_xml(result: SuiteResult, path: str | Path | None = None) -> str:
+    """Export a suite result as JUnit XML.
+
+    The XML hierarchy follows the Giskard result hierarchy:
+    `SuiteResult` -> `testsuites`, `ScenarioResult` -> `testsuite`,
+    `TestCaseResult` -> `testcase`, and non-passing `CheckResult` values
+    -> `failure`, `error`, or `skipped` nodes.
+    """
     tests, failures, errors, skipped = _suite_counts(result)
 
     root = ET.Element(
-        "testsuite",
+        "testsuites",
         {
             "name": "Test run",
             "tests": str(tests),
@@ -201,19 +222,39 @@ def to_junit_xml(result: SuiteResult, path: str | Path | None = None) -> str:
     )
 
     for scenario in result.results:
-        testcase_el = ET.SubElement(
+        scenario_tests, scenario_failures, scenario_errors, scenario_skipped = (
+            _scenario_counts(scenario)
+        )
+        testsuite_el = ET.SubElement(
             root,
-            "testcase",
+            "testsuite",
             {
                 "name": scenario.scenario_name,
+                "tests": str(scenario_tests),
+                "failures": str(scenario_failures),
+                "errors": str(scenario_errors),
+                "skipped": str(scenario_skipped),
                 "assertions": str(_scenario_assertions(scenario)),
                 "time": _seconds(scenario.duration_ms),
             },
         )
 
-        _append_properties(testcase_el, scenario)
-        _append_status_node(testcase_el, scenario)
-        _append_system_out(testcase_el, scenario)
+        _append_scenario_properties(testsuite_el, scenario)
+
+        for step_index, step in enumerate(scenario.steps, start=1):
+            testcase_el = ET.SubElement(
+                testsuite_el,
+                "testcase",
+                {
+                    "name": f"step_{step_index}",
+                    "classname": scenario.scenario_name,
+                    "assertions": str(_step_assertions(step)),
+                    "time": _seconds(step.duration_ms),
+                },
+            )
+
+            _append_testcase_properties(testcase_el, step)
+            _append_status_nodes(testcase_el, scenario.scenario_name, step_index, step)
 
     tree = ET.ElementTree(root)
     ET.indent(tree, space="  ")

--- a/libs/giskard-checks/tests/export/test_junit.py
+++ b/libs/giskard-checks/tests/export/test_junit.py
@@ -106,7 +106,7 @@ def test_to_junit_xml_builds_valid_xml() -> None:
     xml_string = to_junit_xml(_sample_suite_result())
     root = ET.fromstring(xml_string)
 
-    assert root.tag == "testsuite"
+    assert root.tag == "testsuites"
     assert root.attrib["name"] == "Test run"
     assert root.attrib["tests"] == "4"
     assert root.attrib["failures"] == "1"
@@ -116,8 +116,28 @@ def test_to_junit_xml_builds_valid_xml() -> None:
     assert root.attrib["time"] == "0.420000"
     assert "timestamp" in root.attrib
 
-    testcases = root.findall("testcase")
+    testsuites = root.findall("testsuite")
+    assert [testsuite.attrib["name"] for testsuite in testsuites] == [
+        "scenario_pass",
+        "scenario_fail",
+        "scenario_error",
+        "scenario_skip",
+    ]
+    assert [testsuite.attrib["tests"] for testsuite in testsuites] == [
+        "1",
+        "1",
+        "1",
+        "1",
+    ]
+
+    testcases = root.findall("./testsuite/testcase")
     assert [testcase.attrib["name"] for testcase in testcases] == [
+        "step_1",
+        "step_1",
+        "step_1",
+        "step_1",
+    ]
+    assert [testcase.attrib["classname"] for testcase in testcases] == [
         "scenario_pass",
         "scenario_fail",
         "scenario_error",
@@ -129,10 +149,22 @@ def test_to_junit_xml_includes_properties_and_metrics() -> None:
     xml_string = to_junit_xml(_sample_suite_result())
     root = ET.fromstring(xml_string)
 
-    testcases = {
-        testcase.attrib["name"]: testcase for testcase in root.findall("testcase")
+    testsuites = {
+        testsuite.attrib["name"]: testsuite for testsuite in root.findall("testsuite")
     }
-    pass_case = testcases["scenario_pass"]
+    pass_suite = testsuites["scenario_pass"]
+
+    suite_properties = pass_suite.find("properties")
+    assert suite_properties is not None
+    suite_property_map = {
+        prop.attrib["name"]: prop.attrib["value"]
+        for prop in suite_properties.findall("property")
+    }
+    assert "final_trace" in suite_property_map
+    assert suite_property_map["status"] == "pass"
+
+    pass_case = pass_suite.find("testcase")
+    assert pass_case is not None
 
     properties = pass_case.find("properties")
     assert properties is not None
@@ -142,9 +174,11 @@ def test_to_junit_xml_includes_properties_and_metrics() -> None:
         for prop in properties.findall("property")
     }
 
-    assert "final_trace" in property_map
-    assert "step_1" in property_map
-    assert property_map["step_1.check_1.score"] == "0.95"
+    assert "result" in property_map
+    assert property_map["status"] == "pass"
+    assert property_map["check_1.name"] == "Groundedness"
+    assert property_map["check_1.status"] == "pass"
+    assert property_map["check_1.score"] == "0.95"
 
 
 def test_to_junit_xml_maps_failure_error_and_skip() -> None:
@@ -152,7 +186,8 @@ def test_to_junit_xml_maps_failure_error_and_skip() -> None:
     root = ET.fromstring(xml_string)
 
     testcases = {
-        testcase.attrib["name"]: testcase for testcase in root.findall("testcase")
+        testcase.attrib["classname"]: testcase
+        for testcase in root.findall("./testsuite/testcase")
     }
 
     failure = testcases["scenario_fail"].find("failure")
@@ -177,8 +212,8 @@ def test_to_junit_xml_writes_file(tmp_path: Path) -> None:
     xml_string = to_junit_xml(suite_result, path=output_path)
 
     assert output_path.exists()
-    assert ET.fromstring(xml_string).tag == "testsuite"
-    assert ET.parse(output_path).getroot().tag == "testsuite"
+    assert ET.fromstring(xml_string).tag == "testsuites"
+    assert ET.parse(output_path).getroot().tag == "testsuites"
 
 
 def test_suite_result_convenience_method_matches_function() -> None:
@@ -213,9 +248,14 @@ def test_failed_scenario_with_mixed_check_statuses_is_still_a_failure() -> None:
                                 details={"check_name": "CheckA"},
                             ),
                             CheckResult(
+                                status=CheckStatus.FAIL,
+                                message="second failure",
+                                details={"check_name": "CheckB"},
+                            ),
+                            CheckResult(
                                 status=CheckStatus.SKIP,
                                 message="skipped follow-up",
-                                details={"check_name": "CheckB"},
+                                details={"check_name": "CheckC"},
                             ),
                         ],
                         duration_ms=50,
@@ -229,15 +269,20 @@ def test_failed_scenario_with_mixed_check_statuses_is_still_a_failure() -> None:
     )
 
     root = ET.fromstring(to_junit_xml(suite_result))
-    testcase = root.find("testcase")
+    testcase = root.find("./testsuite/testcase")
 
     assert testcase is not None
-    assert testcase.find("failure") is not None
-    assert testcase.find("skipped") is None
+    failure = testcase.find("failure")
+    assert failure is not None
+    assert len(testcase.findall("failure")) == 1
+    assert len(testcase.findall("error")) == 0
+    assert len(testcase.findall("skipped")) == 0
+    assert "hard failure" in (failure.text or "")
+    assert "second failure" in (failure.text or "")
+    assert "skipped follow-up" in (failure.text or "")
 
-    system_out = testcase.find("system-out")
-    assert system_out is not None
-    assert system_out.text is not None
-    assert system_out.text.strip() != ""
-    assert "final_trace=" not in system_out.text
-    assert "step_1=" not in system_out.text
+    testsuite = root.find("testsuite")
+    assert testsuite is not None
+    assert testsuite.attrib["tests"] == "1"
+    assert testsuite.attrib["failures"] == "1"
+    assert testsuite.attrib["skipped"] == "0"


### PR DESCRIPTION
## Description

Adds native JUnit XML export for `SuiteResult` in `giskard.checks.export.junit`.

The exporter maps Giskard result objects to the JUnit hierarchy:

- `SuiteResult` -> `<testsuites>`
- `ScenarioResult` -> `<testsuite>`
- `TestCaseResult` -> `<testcase>`
- non-passing `CheckResult` values -> `<failure>`, `<error>`, or `<skipped>`

The XML includes timing information, status counts, check messages, final trace/status properties, and check metrics as JUnit properties. It supports both returning the XML string and writing it to a file via `path`.

Tests were updated to verify XML validity, nested structure, status mapping, metrics/properties, file writing, and the `SuiteResult.to_junit_xml()` convenience method.

## Related Issue

Closes #2371

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)
