### PR TITLE
Allow scenarios to run multiple times

### DIFF
--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -234,7 +234,7 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
     final_trace : TraceType
         Trace state after execution, containing all interactions that occurred.
     multiple_runs : int
-        Configured number of attempts for this scenario execution.
+        Configured number of runs for this scenario execution.
     runs_executed : int
         Number of runs that actually executed.
     status : ScenarioStatus
@@ -255,7 +255,7 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
     final_trace: TraceType = Field(..., description="Final trace state after execution")
     multiple_runs: int = Field(
         default=1,
-        description="Configured number of scenario execution attempts.",
+        description="Configured number of runs for this scenario execution.",
     )
     runs_executed: int = Field(
         default=1,

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -235,10 +235,8 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
         Trace state after execution, containing all interactions that occurred.
     multiple_runs : int
         Configured number of attempts for this scenario execution.
-    attempts_executed : int
-        Number of attempts that actually ran.
-    failed_attempt : int or None
-        One-based attempt number that failed, if execution stopped early.
+    runs_executed : int
+        Number of runs that actually executed.
     status : ScenarioStatus
         Aggregated outcome of the scenario derived from its steps.
     passed : bool
@@ -259,13 +257,9 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
         default=1,
         description="Configured number of scenario execution attempts.",
     )
-    attempts_executed: int = Field(
+    runs_executed: int = Field(
         default=1,
-        description="Number of scenario execution attempts that actually ran.",
-    )
-    failed_attempt: int | None = Field(
-        default=None,
-        description="One-based attempt number that failed, if any.",
+        description="Number of scenario runs that actually executed.",
     )
 
     @computed_field
@@ -330,7 +324,7 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
 
         yield Rule(
             f"{_pluralize(len(self.steps), 'step')} in {self.duration_ms}ms"
-            f" | attempts: {self.attempts_executed}/{self.multiple_runs}",
+            f" | runs: {self.runs_executed}/{self.multiple_runs}",
             style=f"{status['color']} bold",
         )
 

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -234,9 +234,9 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
     final_trace : TraceType
         Trace state after execution, containing all interactions that occurred.
     multiple_runs : int
-        Configured number of runs for this scenario execution.
+        Configured upper bound on full scenario executions for this invocation.
     runs_executed : int
-        Number of runs that actually executed.
+        How many full scenario executions ran before stopping (≤ ``multiple_runs``).
     status : ScenarioStatus
         Aggregated outcome of the scenario derived from its steps.
     passed : bool
@@ -255,11 +255,11 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
     final_trace: TraceType = Field(..., description="Final trace state after execution")
     multiple_runs: int = Field(
         default=1,
-        description="Configured number of runs for this scenario execution.",
+        description="Configured maximum full scenario executions for this invocation.",
     )
     runs_executed: int = Field(
         default=1,
-        description="Number of scenario runs that actually executed.",
+        description="Full scenario executions that ran before stopping (at most multiple_runs).",
     )
 
     @computed_field

--- a/libs/giskard-checks/src/giskard/checks/core/result.py
+++ b/libs/giskard-checks/src/giskard/checks/core/result.py
@@ -233,6 +233,12 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
         Total execution time in milliseconds.
     final_trace : TraceType
         Trace state after execution, containing all interactions that occurred.
+    multiple_runs : int
+        Configured number of attempts for this scenario execution.
+    attempts_executed : int
+        Number of attempts that actually ran.
+    failed_attempt : int or None
+        One-based attempt number that failed, if execution stopped early.
     status : ScenarioStatus
         Aggregated outcome of the scenario derived from its steps.
     passed : bool
@@ -249,6 +255,18 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
     steps: list["TestCaseResult"]  # TODO: rename to test_cases
     duration_ms: int = Field(..., description="Total execution time in milliseconds")
     final_trace: TraceType = Field(..., description="Final trace state after execution")
+    multiple_runs: int = Field(
+        default=1,
+        description="Configured number of scenario execution attempts.",
+    )
+    attempts_executed: int = Field(
+        default=1,
+        description="Number of scenario execution attempts that actually ran.",
+    )
+    failed_attempt: int | None = Field(
+        default=None,
+        description="One-based attempt number that failed, if any.",
+    )
 
     @computed_field
     @property
@@ -311,7 +329,8 @@ class ScenarioResult[TraceType: Trace](BaseResult, frozen=True):  # pyright: ign
             yield repr(self.final_trace)
 
         yield Rule(
-            f"{_pluralize(len(self.steps), 'step')} in {self.duration_ms}ms",
+            f"{_pluralize(len(self.steps), 'step')} in {self.duration_ms}ms"
+            f" | attempts: {self.attempts_executed}/{self.multiple_runs}",
             style=f"{status['color']} bold",
         )
 

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,7 +1,7 @@
 from typing import Any, Self
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from .check import Check
 from .input_generator import InputGenerator
@@ -104,6 +104,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         default=1,
         description="Default number of times to run this scenario before reporting success.",
         ge=1,
+        strict=True,
     )
 
     def __init__(

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -103,16 +103,8 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
     multiple_runs: int = Field(
         default=1,
         description="Default number of times to run this scenario before reporting success.",
+        ge=1,
     )
-
-    @field_validator("multiple_runs", mode="before")
-    @classmethod
-    def _validate_multiple_runs(cls, value: object) -> int:
-        if not isinstance(value, int) or isinstance(value, bool):
-            raise ValueError("multiple_runs must be an integer greater than or equal to 1")
-        if value < 1:
-            raise ValueError("multiple_runs must be greater than or equal to 1")
-        return value
 
     def __init__(
         self,

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -263,11 +263,13 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         return_exception: bool = False,
         multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:
-        """Execute the scenario steps sequentially with shared trace.
+        """Execute the scenario via the default runner, with optional multiple runs.
 
-        Each step is executed in order:
-        - Interaction specs update the shared trace
-        - Checks validate the current trace and stop execution on failure
+        Each run executes all steps in order with a trace shared across those
+        steps: interaction specs update the trace, then checks validate it and
+        stop that run on failure. When more than one run is configured, each run
+        uses a fresh trace. Execution stops early on the first non-passing run
+        (FAIL, ERROR, or SKIP).
 
         Parameters
         ----------
@@ -282,7 +284,7 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         Returns
         -------
         ScenarioResult
-            Results from executing the scenario.
+            Results from the last run executed, including multi-run metadata.
         """
         # Lazy import to avoid circular dependency
         from ..scenarios.runner import get_runner

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -73,7 +73,10 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         inferred from the components. Useful when using custom trace subclasses
         with additional computed fields or methods.
     multiple_runs : int
-        Default number of times to run the scenario before reporting success.
+        Default upper bound on how many times to execute the full scenario (each
+        execution uses a fresh trace). Each run must pass for the next to run;
+        execution stops on the first non-passing run (FAIL, ERROR, or SKIP). This
+        is not a "retry until one success" mode.
     """
 
     name: str = Field(
@@ -102,7 +105,11 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
     )
     multiple_runs: int = Field(
         default=1,
-        description="Default number of times to run this scenario before reporting success.",
+        description=(
+            "Default maximum number of full scenario executions (fresh trace per run). "
+            "Each run must pass overall for another to run; stops on first non-passing run. "
+            "Not a retry-until-success loop."
+        ),
         ge=1,
         strict=True,
     )
@@ -267,9 +274,11 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
 
         Each run executes all steps in order with a trace shared across those
         steps: interaction specs update the trace, then checks validate it and
-        stop that run on failure. When more than one run is configured, each run
-        uses a fresh trace. Execution stops early on the first non-passing run
-        (FAIL, ERROR, or SKIP).
+        stop that run on failure. When more than one run is configured, the
+        scenario is executed up to that many times, with a fresh trace each time.
+        Each run must pass overall for the next to run. Execution stops early on
+        the first non-passing run (FAIL, ERROR, or SKIP). Multi-run is not
+        equivalent to retrying until a single passing outcome.
 
         Parameters
         ----------
@@ -278,8 +287,8 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         return_exception : bool
             If True, return results even when exceptions occur instead of raising.
         multiple_runs : int | None
-            Optional run-level repeat count. When provided, it overrides the
-            scenario-level `multiple_runs` value.
+            Optional cap on full scenario executions. When provided, it overrides
+            the scenario-level `multiple_runs` value.
 
         Returns
         -------

--- a/libs/giskard-checks/src/giskard/checks/core/scenario.py
+++ b/libs/giskard-checks/src/giskard/checks/core/scenario.py
@@ -1,7 +1,7 @@
 from typing import Any, Self
 
 from giskard.core.utils import NOT_PROVIDED, NotProvided
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .check import Check
 from .input_generator import InputGenerator
@@ -72,6 +72,8 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         Optional custom trace type to use. If not provided, the trace type will be
         inferred from the components. Useful when using custom trace subclasses
         with additional computed fields or methods.
+    multiple_runs : int
+        Default number of times to run the scenario before reporting success.
     """
 
     name: str = Field(
@@ -98,6 +100,19 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         default=NOT_PROVIDED,
         description="Scenario-level target SUT that will be used to replace NOT_PROVIDED outputs.",
     )
+    multiple_runs: int = Field(
+        default=1,
+        description="Default number of times to run this scenario before reporting success.",
+    )
+
+    @field_validator("multiple_runs", mode="before")
+    @classmethod
+    def _validate_multiple_runs(cls, value: object) -> int:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError("multiple_runs must be an integer greater than or equal to 1")
+        if value < 1:
+            raise ValueError("multiple_runs must be greater than or equal to 1")
+        return value
 
     def __init__(
         self,
@@ -253,12 +268,23 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
             | NotProvided
         ) = NOT_PROVIDED,
         return_exception: bool = False,
+        multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:
         """Execute the scenario steps sequentially with shared trace.
 
         Each step is executed in order:
         - Interaction specs update the shared trace
         - Checks validate the current trace and stop execution on failure
+
+        Parameters
+        ----------
+        target : ProviderType | NotProvided
+            Optional target override used to replace `NOT_PROVIDED` interaction outputs.
+        return_exception : bool
+            If True, return results even when exceptions occur instead of raising.
+        multiple_runs : int | None
+            Optional run-level repeat count. When provided, it overrides the
+            scenario-level `multiple_runs` value.
 
         Returns
         -------
@@ -269,4 +295,9 @@ class Scenario[InputType, OutputType, TraceType: Trace](BaseModel):  # pyright: 
         from ..scenarios.runner import get_runner
 
         runner = get_runner()
-        return await runner.run(self, target=target, return_exception=return_exception)
+        return await runner.run(
+            self,
+            target=target,
+            return_exception=return_exception,
+            multiple_runs=multiple_runs,
+        )

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -87,6 +87,10 @@ class ScenarioRunner:
     The runner handles exceptions from checks by converting them into
     `CheckResult.error` objects and stopping execution.
 
+    For a `multiple_runs` setting greater than 1, the full scenario is executed
+    at most that many times (fresh trace per attempt); each attempt must pass
+    for the next to run, otherwise execution stops with that attempt's result.
+
     Examples
     --------
     ```python
@@ -191,10 +195,12 @@ class ScenarioRunner:
         return_exception: bool = False,
         multiple_runs: int | None = None,
     ) -> ScenarioResult[TraceType]:
-        """Execute a scenario multiple times until success or failure.
+        """Execute a scenario up to N times, stopping on the first non-passing run.
 
-        Each run is executed independently with a fresh trace. Execution stops
-        early on the first non-passing run (FAIL, ERROR, or SKIP).
+        Each run is executed independently with a fresh trace. The scenario is
+        run at most ``multiple_runs`` times when every run passes; otherwise
+        execution stops on the first run whose outcome is not PASS (FAIL, ERROR,
+        or SKIP). This is not a "retry until success" strategy.
 
         Parameters
         ----------
@@ -205,13 +211,13 @@ class ScenarioRunner:
         return_exception : bool
             If True, return results even when exceptions occur instead of raising.
         multiple_runs : int | None
-            Optional run-level repeat count. When provided, it overrides the
-            scenario-level `multiple_runs` value.
+            Optional cap on full scenario executions. When provided, it overrides
+            the scenario-level `multiple_runs` value.
 
         Returns
         -------
         ScenarioResult
-            Results from the final run executed, updated with multi-run metadata.
+            Results from the last run executed, updated with multi-run metadata.
         """
 
         configured_runs = (

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -214,7 +214,9 @@ class ScenarioRunner:
             Results from the final run executed, updated with multi-run metadata.
         """
 
-        configured_runs = _validate_multiple_runs(multiple_runs) or scenario.multiple_runs
+        configured_runs = (
+            _validate_multiple_runs(multiple_runs) or scenario.multiple_runs
+        )
         start_time = time.perf_counter()
         last_result: ScenarioResult[TraceType] | None = None
 
@@ -237,7 +239,7 @@ class ScenarioRunner:
                 )
 
         if last_result is None:  # Defensive: configured_runs validation prevents this.
-            raise RuntimeError("Scenario did not execute any attempts")
+            raise RuntimeError("Scenario did not execute any runs")
 
         end_time = time.perf_counter()
         return last_result.model_copy(

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -25,6 +25,16 @@ from ..core.testcase import TestCase
 from ..core.types import ProviderType
 
 
+def _validate_multiple_runs(value: int | None) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("multiple_runs must be an integer greater than or equal to 1")
+    if value < 1:
+        raise ValueError("multiple_runs must be greater than or equal to 1")
+    return value
+
+
 def _build_steps[InputType, OutputType, TraceType: Trace[Any, Any]](
     scenario: Scenario[InputType, OutputType, TraceType],
     target: (
@@ -86,7 +96,7 @@ class ScenarioRunner:
     """
 
     @scoped_telemetry
-    async def run[InputType, OutputType, TraceType: Trace[Any, Any]](
+    async def _run_once[InputType, OutputType, TraceType: Trace[Any, Any]](
         self,
         scenario: Scenario[InputType, OutputType, TraceType],
         target: (
@@ -96,27 +106,6 @@ class ScenarioRunner:
         ) = NOT_PROVIDED,
         return_exception: bool = False,
     ) -> ScenarioResult[TraceType]:
-        """Execute a scenario's steps sequentially with shared Trace.
-
-        Each step is executed in order:
-        - Interaction specs update the shared trace
-        - Checks validate the current trace and stop execution on failure
-
-        Execution stops on the first failing check; remaining steps are not executed.
-
-        Parameters
-        ----------
-        scenario : Scenario
-            The scenario to execute.
-        return_exception : bool
-            If True, return results even when exceptions occur instead of raising.
-
-        Returns
-        -------
-        ScenarioResult
-            Results from executing the scenario.
-        """
-
         start_time = time.perf_counter()
         telemetry_tag("giskard_component", "scenario_runner")
         telemetry_tag("giskard_operation", "scenario_run")
@@ -190,6 +179,74 @@ class ScenarioRunner:
         )
 
         return result
+
+    async def run[InputType, OutputType, TraceType: Trace[Any, Any]](
+        self,
+        scenario: Scenario[InputType, OutputType, TraceType],
+        target: (
+            ProviderType[[InputType], OutputType]
+            | ProviderType[[InputType, TraceType], OutputType]
+            | NotProvided
+        ) = NOT_PROVIDED,
+        return_exception: bool = False,
+        multiple_runs: int | None = None,
+    ) -> ScenarioResult[TraceType]:
+        """Execute a scenario multiple times until success or failure.
+
+        Each run is executed independently with a fresh trace. Execution stops
+        early on the first non-passing run (FAIL, ERROR, or SKIP).
+
+        Parameters
+        ----------
+        scenario : Scenario
+            The scenario to execute.
+        target : ProviderType | NotProvided
+            Optional target override used to replace `NOT_PROVIDED` interaction outputs.
+        return_exception : bool
+            If True, return results even when exceptions occur instead of raising.
+        multiple_runs : int | None
+            Optional run-level repeat count. When provided, it overrides the
+            scenario-level `multiple_runs` value.
+
+        Returns
+        -------
+        ScenarioResult
+            Results from the final run executed, updated with multi-run metadata.
+        """
+
+        configured_runs = _validate_multiple_runs(multiple_runs) or scenario.multiple_runs
+        start_time = time.perf_counter()
+        last_result: ScenarioResult[TraceType] | None = None
+
+        for attempt in range(1, configured_runs + 1):
+            result = await self._run_once(
+                scenario,
+                target=target,
+                return_exception=return_exception,
+            )
+            last_result = result
+
+            if not result.passed:
+                end_time = time.perf_counter()
+                return result.model_copy(
+                    update={
+                        "duration_ms": int((end_time - start_time) * 1000),
+                        "multiple_runs": configured_runs,
+                        "runs_executed": attempt,
+                    }
+                )
+
+        if last_result is None:  # Defensive: configured_runs validation prevents this.
+            raise RuntimeError("Scenario did not execute any attempts")
+
+        end_time = time.perf_counter()
+        return last_result.model_copy(
+            update={
+                "duration_ms": int((end_time - start_time) * 1000),
+                "multiple_runs": configured_runs,
+                "runs_executed": configured_runs,
+            }
+        )
 
 
 _default_runner = ScenarioRunner()

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -423,8 +423,7 @@ class TestScenarioEdgeCases:
         assert calls == 3
         assert result.passed
         assert result.multiple_runs == 3
-        assert result.attempts_executed == 3
-        assert result.failed_attempt is None
+        assert result.runs_executed == 3
         assert result.steps[0].results[0].message == "attempt 3 passed"
 
     async def test_run_level_multiple_runs_overrides_scenario_default(self):
@@ -445,8 +444,7 @@ class TestScenarioEdgeCases:
         assert calls == 2
         assert result.passed
         assert result.multiple_runs == 2
-        assert result.attempts_executed == 2
-        assert result.failed_attempt is None
+        assert result.runs_executed == 2
 
     async def test_scenario_runner_multiple_runs_override(self):
         """ScenarioRunner.run accepts a run-level multiple_runs override."""
@@ -463,8 +461,7 @@ class TestScenarioEdgeCases:
         assert calls == 2
         assert result.passed
         assert result.multiple_runs == 2
-        assert result.attempts_executed == 2
-        assert result.failed_attempt is None
+        assert result.runs_executed == 2
 
     async def test_multiple_runs_stops_on_first_failure(self):
         """Repeated execution short-circuits on the first failed attempt."""
@@ -484,8 +481,7 @@ class TestScenarioEdgeCases:
         assert calls == 2
         assert result.failed
         assert result.multiple_runs == 5
-        assert result.attempts_executed == 2
-        assert result.failed_attempt == 2
+        assert result.runs_executed == 2
         assert result.steps[0].results[0].message == "attempt 2 failed"
 
     async def test_multiple_runs_uses_independent_trace_per_attempt(self):

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -19,6 +19,7 @@ from giskard.checks import (
     Trace,
     from_fn,
 )
+from giskard.checks.scenarios.runner import ScenarioRunner
 
 # Mock Components for Testing
 
@@ -405,6 +406,118 @@ class TestScenarioNormalCases:
 
 class TestScenarioEdgeCases:
     """Test edge cases for scenarios."""
+
+    async def test_scenario_level_multiple_runs_repeats_until_all_pass(self):
+        """Scenario-level multiple_runs controls the number of attempts."""
+        calls = 0
+
+        def check_fn(trace: Trace[str, str]) -> CheckResult:
+            nonlocal calls
+            calls += 1
+            return CheckResult.success(message=f"attempt {calls} passed")
+
+        result = await (
+            Scenario("scenario_retries", multiple_runs=3).check(from_fn(check_fn)).run()
+        )
+
+        assert calls == 3
+        assert result.passed
+        assert result.multiple_runs == 3
+        assert result.attempts_executed == 3
+        assert result.failed_attempt is None
+        assert result.steps[0].results[0].message == "attempt 3 passed"
+
+    async def test_run_level_multiple_runs_overrides_scenario_default(self):
+        """Run-level multiple_runs takes precedence over the scenario default."""
+        calls = 0
+
+        def check_fn(trace: Trace[str, str]) -> CheckResult:
+            nonlocal calls
+            calls += 1
+            return CheckResult.success()
+
+        result = await (
+            Scenario("run_override", multiple_runs=5)
+            .check(from_fn(check_fn))
+            .run(multiple_runs=2)
+        )
+
+        assert calls == 2
+        assert result.passed
+        assert result.multiple_runs == 2
+        assert result.attempts_executed == 2
+        assert result.failed_attempt is None
+
+    async def test_scenario_runner_multiple_runs_override(self):
+        """ScenarioRunner.run accepts a run-level multiple_runs override."""
+        calls = 0
+
+        def check_fn(trace: Trace[str, str]) -> CheckResult:
+            nonlocal calls
+            calls += 1
+            return CheckResult.success()
+
+        scenario = Scenario("runner_override", multiple_runs=4).check(from_fn(check_fn))
+        result = await ScenarioRunner().run(scenario, multiple_runs=2)
+
+        assert calls == 2
+        assert result.passed
+        assert result.multiple_runs == 2
+        assert result.attempts_executed == 2
+        assert result.failed_attempt is None
+
+    async def test_multiple_runs_stops_on_first_failure(self):
+        """Repeated execution short-circuits on the first failed attempt."""
+        calls = 0
+
+        def check_fn(trace: Trace[str, str]) -> CheckResult:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                return CheckResult.failure(message="attempt 2 failed")
+            return CheckResult.success(message=f"attempt {calls} passed")
+
+        result = await (
+            Scenario("stop_on_failure", multiple_runs=5).check(from_fn(check_fn)).run()
+        )
+
+        assert calls == 2
+        assert result.failed
+        assert result.multiple_runs == 5
+        assert result.attempts_executed == 2
+        assert result.failed_attempt == 2
+        assert result.steps[0].results[0].message == "attempt 2 failed"
+
+    async def test_multiple_runs_uses_independent_trace_per_attempt(self):
+        """Each attempt starts from a fresh trace."""
+        observed_lengths: list[int] = []
+
+        def check_fn(trace: Trace[str, str]) -> CheckResult:
+            observed_lengths.append(len(trace.interactions))
+            return CheckResult.success()
+
+        result = await (
+            Scenario("fresh_trace", multiple_runs=3)
+            .interact("hello", "world")
+            .check(from_fn(check_fn))
+            .run()
+        )
+
+        assert result.passed
+        assert observed_lengths == [1, 1, 1]
+        assert len(result.final_trace.interactions) == 1
+
+    @pytest.mark.parametrize("value", [0, -1, "2", 1.5, True])
+    def test_scenario_multiple_runs_validation_errors(self, value):
+        """Scenario-level multiple_runs rejects invalid values."""
+        with pytest.raises(ValueError, match="multiple_runs"):
+            Scenario("invalid", multiple_runs=value)
+
+    @pytest.mark.parametrize("value", [0, -1, "2", 1.5, True])
+    async def test_run_multiple_runs_validation_errors(self, value):
+        """Run-level multiple_runs rejects invalid values."""
+        with pytest.raises(ValueError, match="multiple_runs"):
+            await Scenario("invalid_run").run(multiple_runs=value)
 
     async def test_scenario_with_empty_sequence(self):
         """Test scenario with empty sequence."""
@@ -1056,15 +1169,18 @@ class TestScenarioExtendAndSerialization:
     async def test_scenario_model_dump_validate_roundtrip(self):
         """Scenario with steps can be serialized and deserialized."""
         scenario = (
-            Scenario("serialize_test")
+            Scenario("serialize_test", multiple_runs=2)
             .interact("Hello", "Hi")
             .check(Equals(expected_value="Hi", key="trace.last.outputs"))
         )
         serialized = scenario.model_dump()
+        assert serialized["multiple_runs"] == 2
         restored = Scenario.model_validate(serialized)
+        assert restored.multiple_runs == 2
         result = await restored.run()
         assert result.passed
         assert result.scenario_name == "serialize_test"
+        assert result.multiple_runs == 2
 
     async def test_scenario_with_steps_constructor(self):
         """Scenario can be built with explicit Step objects."""

--- a/libs/giskard-checks/tests/core/test_scenario.py
+++ b/libs/giskard-checks/tests/core/test_scenario.py
@@ -407,8 +407,8 @@ class TestScenarioNormalCases:
 class TestScenarioEdgeCases:
     """Test edge cases for scenarios."""
 
-    async def test_scenario_level_multiple_runs_repeats_until_all_pass(self):
-        """Scenario-level multiple_runs controls the number of attempts."""
+    async def test_scenario_level_multiple_runs_executes_all_when_each_passes(self):
+        """When each run passes, scenario-level multiple_runs runs that many full executions."""
         calls = 0
 
         def check_fn(trace: Trace[str, str]) -> CheckResult:


### PR DESCRIPTION
## Description

Adds `multiple_runs` support for scenarios so flaky or generator-driven scenarios can be executed repeatedly before reporting success.

The repeat count can be configured at the scenario level with `Scenario(..., multiple_runs=n)` or overridden per execution with `Scenario.run(..., multiple_runs=n)` / `ScenarioRunner.run(..., multiple_runs=n)`. Each attempt runs independently with a fresh trace, and execution stops early on the first non-passing attempt.

Scenario results now include repeat metadata:

- configured `multiple_runs`
- `attempts_executed`
- `failed_attempt` when execution stops early

## Related Issue

Closes #2398

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)