### PR TITLE
fix(deps): declare regex on giskard-checks

### DIFF
--- a/libs/giskard-checks/pyproject.toml
+++ b/libs/giskard-checks/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "jinja2>=3.1.6,<4",
     "giskard-core>=1.0.0a1",
     "numpy>=2.4.1,<3",
+    "regex>=2026.1.15",
     "rich>=14.2.0,<15",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "giskard-core>=1.0.0a1",
     "giskard-agents>=1.0.0a1",
     "giskard-checks>=1.0.0a1",
-    "regex>=2026.1.15",
 ]
 requires-python = ">=3.12"
 

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,6 @@ dependencies = [
     { name = "giskard-agents" },
     { name = "giskard-checks" },
     { name = "giskard-core" },
-    { name = "regex" },
 ]
 
 [package.dev-dependencies]
@@ -714,7 +713,6 @@ requires-dist = [
     { name = "giskard-agents", editable = "libs/giskard-agents" },
     { name = "giskard-checks", editable = "libs/giskard-checks" },
     { name = "giskard-core", editable = "libs/giskard-core" },
-    { name = "regex", specifier = ">=2026.1.15" },
 ]
 
 [package.metadata.requires-dev]
@@ -768,6 +766,7 @@ dependencies = [
     { name = "jsonpath-ng" },
     { name = "numpy" },
     { name = "pydantic" },
+    { name = "regex" },
     { name = "rich" },
 ]
 
@@ -779,6 +778,7 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },
     { name = "numpy", specifier = ">=2.4.1,<3" },
     { name = "pydantic", specifier = ">=2.12,<3" },
+    { name = "regex", specifier = ">=2026.1.15" },
     { name = "rich", specifier = ">=14.2.0,<15" },
 ]
 


### PR DESCRIPTION
## Description

Move the `regex` PyPI dependency from the root `giskard` metapackage to `giskard-checks`, where it is imported (`text_matching.py` / regex matching check). The root package still pulls it in transitively via `giskard-checks`. `uv.lock` was refreshed.

## Related Issue

N/A

## Type of Change

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Giskard-AI/ai-inspector/blob/master/CONTRIBUTING.md) guide.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in NumPy format for all the methods and classes that I created or modified.
- [x] I've updated the `uv.lock` running `uv lock` (only applicable when `pyproject.toml` has been
  modified)


Made with [Cursor](https://cursor.com)