### PR TITLE
chore(analytics): add GeoIP disabling option

### DIFF
--- a/libs/giskard-checks/README.md
+++ b/libs/giskard-checks/README.md
@@ -20,7 +20,7 @@ pip install giskard-checks
 
 Requires Python >= 3.12.
 
-**Telemetry:** This package depends on `giskard-core`, which may send **optional, aggregated usage analytics** when you run scenarios, suites, or test cases (no prompts, outputs, or scenario text). See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for what is collected and how to opt out (`DO_NOT_TRACK`, `GISKARD_TELEMETRY_DISABLED`, or `disable_telemetry()`).
+**Telemetry:** This package depends on `giskard-core`, which may send **optional, aggregated usage analytics** when you run scenarios, suites, or test cases (no prompts, outputs, or scenario text). See **[Telemetry](../giskard-core/README.md#telemetry)** in the `giskard-core` README for what is collected and how to opt out (`DO_NOT_TRACK`, `GISKARD_TELEMETRY_DISABLED`, `GISKARD_TELEMETRY_DISABLE_GEOIP`, or `disable_telemetry()`).
 
 **Dependencies:**
 - `pydantic>=2.12` - Core data validation and serialization

--- a/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/runner.py
@@ -12,7 +12,7 @@ from giskard.core import (
     NOT_PROVIDED,
     NotProvided,
     scoped_telemetry,
-    telemetry,
+    telemetry_capture,
     telemetry_tag,
 )
 
@@ -138,7 +138,7 @@ class ScenarioRunner:
             has_target=has_target,
         )
 
-        _ = telemetry.capture(
+        telemetry_capture(
             "checks_scenario_run_started",
             properties=shape_props,
         )
@@ -180,7 +180,7 @@ class ScenarioRunner:
             final_trace=trace,
         )
 
-        _ = telemetry.capture(
+        telemetry_capture(
             "checks_scenario_run_finished",
             properties={
                 **shape_props,

--- a/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
+++ b/libs/giskard-checks/src/giskard/checks/scenarios/suite.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any, Generic, Self, TypeVar
 
-from giskard.core import telemetry, telemetry_run_context, telemetry_tag
+from giskard.core import telemetry_capture, telemetry_run_context, telemetry_tag
 from giskard.core.utils import NOT_PROVIDED, NotProvided
 from pydantic import BaseModel, Field
 
@@ -130,7 +130,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
                 scenario_count=len(self.scenarios),
                 has_target=has_target,
             )
-            _ = telemetry.capture(
+            telemetry_capture(
                 "checks_suite_run_started",
                 properties=shape_props,
             )
@@ -148,7 +148,7 @@ class Suite(BaseModel, Generic[InputType, OutputType]):
                 duration_ms=int((end_time - start_time) * 1000),
             )
 
-            _ = telemetry.capture(
+            telemetry_capture(
                 "checks_suite_run_finished",
                 properties={
                     **shape_props,

--- a/libs/giskard-checks/src/giskard/checks/testing/runner.py
+++ b/libs/giskard-checks/src/giskard/checks/testing/runner.py
@@ -1,7 +1,7 @@
 import time
 import traceback
 
-from giskard.core import scoped_telemetry, telemetry, telemetry_tag
+from giskard.core import scoped_telemetry, telemetry_capture, telemetry_tag
 
 from .._telemetry_props import (
     check_kind_counts_from_sequence,
@@ -77,7 +77,7 @@ class TestCaseRunner:
             has_test_case_name=test_case.name is not None,
             check_kinds=check_kinds,
         )
-        _ = telemetry.capture(
+        telemetry_capture(
             "checks_test_case_run_started",
             properties=shape_props,
         )
@@ -95,7 +95,7 @@ class TestCaseRunner:
             duration_ms=total_duration_ms,
         )
 
-        _ = telemetry.capture(
+        telemetry_capture(
             "checks_test_case_run_finished",
             properties={
                 **shape_props,

--- a/libs/giskard-core/README.md
+++ b/libs/giskard-core/README.md
@@ -44,6 +44,14 @@ from giskard.core import disable_telemetry
 disable_telemetry()
 ```
 
+### GeoIP
+
+When telemetry is **enabled**, PostHog may apply **GeoIP** enrichment to events (server-side location metadata used in dashboards). That enrichment is **off** whenever telemetry is fully disabled (see above) or when you call `disable_telemetry()`.
+
+To **keep usage analytics** but **disable GeoIP only**, set this environment variable to a truthy value **before** importing Giskard packages (same matching rules as in [How to disable telemetry](#how-to-disable-telemetry)):
+
+- `GISKARD_TELEMETRY_DISABLE_GEOIP`
+
 ### For library authors
 
 The client and helpers are exported from `giskard.core`: `telemetry`, `telemetry_tag`, `telemetry_run_context`, `scoped_telemetry`, and `disable_telemetry`. New events should follow the same rules: **no user strings, secrets, file paths, or model I/O** in analytics payloads.

--- a/libs/giskard-core/src/giskard/core/__init__.py
+++ b/libs/giskard-core/src/giskard/core/__init__.py
@@ -17,6 +17,7 @@ from .telemetry import (
     disable_telemetry,
     scoped_telemetry,
     telemetry,
+    telemetry_capture,
     telemetry_run_context,
     telemetry_tag,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "telemetry",
     "disable_telemetry",
     "scoped_telemetry",
+    "telemetry_capture",
     "telemetry_run_context",
     "telemetry_tag",
 ]

--- a/libs/giskard-core/src/giskard/core/telemetry/__init__.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/__init__.py
@@ -4,6 +4,7 @@ from .telemetry import (
     disable_telemetry,
     scoped_telemetry,
     telemetry,
+    telemetry_capture,
     telemetry_run_context,
 )
 
@@ -11,6 +12,7 @@ __all__ = [
     "telemetry",
     "disable_telemetry",
     "scoped_telemetry",
+    "telemetry_capture",
     "telemetry_run_context",
     "telemetry_tag",
 ]

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -102,7 +102,8 @@ def _get_or_create_anonymous_id() -> str | None:
     except FileExistsError:
         # Lost the race; another process just wrote its ID. Read theirs.
         try:
-            return config_path.read_text(encoding="utf-8").strip()
+            content = config_path.read_text(encoding="utf-8").strip()
+            return content if content else f"anon-{uuid.uuid4()}"
         except OSError:
             return f"anon-{uuid.uuid4()}"
     except OSError:

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -10,7 +10,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import cast
 
-from posthog import Posthog, identify_context, tag
+from posthog import Posthog, identify_context, set_context_session, tag
 
 _DISABLING_ENV_VARS = [
     "DO_NOT_TRACK",
@@ -93,18 +93,32 @@ def _get_or_create_anonymous_id() -> str | None:
             # Unreadable path (permissions, race with deletion, etc.): mint ephemeral below.
             pass
 
-    # Generate new persistent ID
+    # Atomically create the file so concurrent first-run processes converge on one ID
+    # rather than each persisting a different UUID.
     new_id = str(uuid.uuid4())
     try:
-        _ = config_path.parent.mkdir(parents=True, exist_ok=True)
-        _ = config_path.write_text(new_id, encoding="utf-8")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(config_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        # Lost the race; another process just wrote its ID. Read theirs.
+        try:
+            return config_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return f"anon-{uuid.uuid4()}"
     except OSError:
-        # Fallback for read-only systems
+        # Read-only system, etc.
         return f"anon-{uuid.uuid4()}"
+    try:
+        _ = os.write(fd, new_id.encode("utf-8"))
+    finally:
+        os.close(fd)
     return new_id
 
 
 _anonymous_id = _get_or_create_anonymous_id()
+# Distinguishes events from different invocations on the same machine in PostHog
+# dashboards, while _anonymous_id keeps them all linked to the same user.
+_process_session_id = str(uuid.uuid4())
 
 telemetry = Posthog(
     project_api_key="phc_Asp36pe4X5WMqeJ4aMMV4gq5LGdGw69mdYSdEYGpbxm2",  # pragma: allowlist secret
@@ -120,42 +134,65 @@ def disable_telemetry() -> None:
     telemetry.disabled = True
 
 
-# Nested ``telemetry_run_context`` / ``scoped_telemetry``: only the outermost
-# scope emits ``giskard_uncaught_exception`` (one event per logical failure).
-_telemetry_run_depth: contextvars.ContextVar[int] = contextvars.ContextVar(
-    "_telemetry_run_depth", default=0
+# Tracks whether we are currently inside any telemetry scope.
+# Used so that nested telemetry_run_context / scoped_telemetry emit
+# giskard_uncaught_exception only once per logical failure, and so
+# telemetry_capture can drop events that would otherwise be "personless".
+_in_telemetry_scope: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_in_telemetry_scope", default=False
 )
+
+
+def telemetry_capture(
+    event: str, *, properties: dict[str, object] | None = None
+) -> None:
+    """Capture a telemetry event, dropping it if no telemetry_run_context is active.
+
+    Outside a context, PostHog assigns a random per-event UUID and marks the event
+    "personless" — disconnecting it from the persistent anonymous ID and inflating
+    user counts in the dashboard. Drop those events instead so future regressions
+    don't pollute analytics.
+
+    Parameters
+    ----------
+    event : str
+        The event name to capture.
+    properties : dict[str, object] or None
+        Optional event properties, passed through to PostHog unchanged.
+    """
+    if not _in_telemetry_scope.get():
+        return
+    _ = telemetry.capture(event, properties=properties)
 
 
 @contextmanager
 def telemetry_run_context() -> Iterator[None]:
     """Open a PostHog context scope for a logical operation (sync or async body).
 
-    Use inside ``async def`` with ``with telemetry_run_context():`` so nested
-    ``scoped_telemetry`` calls get a consistent parent scope. Pair with
-    ``telemetry_tag`` (see ``giskard.core``) to attach non-PII dimensions to
-    child captures.
+    Use as a with-statement inside an async def so nested scoped_telemetry calls
+    share a consistent parent scope. Pair with telemetry_tag (from giskard.core)
+    to attach non-PII dimensions to child captures.
     """
-    depth_token = _telemetry_run_depth.set(_telemetry_run_depth.get() + 1)
+    is_outermost = not _in_telemetry_scope.get()
+    token = _in_telemetry_scope.set(True)
     try:
         with telemetry.new_context(capture_exceptions=False):
             if _anonymous_id is not None:
                 identify_context(_anonymous_id)
+            set_context_session(_process_session_id)
             _set_tags()
             try:
                 yield
             except Exception as e:
                 # Do not send exception text: it may contain user content, secrets, or paths.
-                if _telemetry_run_depth.get() == 1:
-                    _ = telemetry.capture(
+                if is_outermost:
+                    telemetry_capture(
                         "giskard_uncaught_exception",
-                        properties={
-                            "exception_type": type(e).__name__,
-                        },
+                        properties={"exception_type": type(e).__name__},
                     )
                 raise
     finally:
-        _telemetry_run_depth.reset(depth_token)
+        _in_telemetry_scope.reset(token)
 
 
 def scoped_telemetry[F: Callable[..., object]](func: F) -> F:

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -124,6 +124,7 @@ telemetry = Posthog(
     project_api_key="phc_Asp36pe4X5WMqeJ4aMMV4gq5LGdGw69mdYSdEYGpbxm2",  # pragma: allowlist secret
     host="https://eu.i.posthog.com",
     disabled=_should_disable(),
+    disable_geoip=_should_disable(),
 )
 
 

--- a/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
+++ b/libs/giskard-core/src/giskard/core/telemetry/telemetry.py
@@ -16,6 +16,9 @@ _DISABLING_ENV_VARS = [
     "DO_NOT_TRACK",
     "GISKARD_TELEMETRY_DISABLED",
 ]
+_DISABLE_GEOIP_ENV_VARS = [
+    "GISKARD_TELEMETRY_DISABLE_GEOIP",
+]
 # Common truthy values used in CLI tools and web frameworks
 _TRUTHY_VALUES = {"1", "true", "yes", "on", "t", "y"}
 
@@ -31,6 +34,12 @@ def _is_true_str(value: str | None) -> bool:
 
 def _should_disable() -> bool:
     return any(_is_true_str(os.getenv(var)) for var in _DISABLING_ENV_VARS)
+
+
+def _should_disable_geoip() -> bool:
+    return _should_disable() or any(
+        _is_true_str(os.getenv(var)) for var in _DISABLE_GEOIP_ENV_VARS
+    )
 
 
 def _get_lib_version(lib: str) -> str:
@@ -125,7 +134,7 @@ telemetry = Posthog(
     project_api_key="phc_Asp36pe4X5WMqeJ4aMMV4gq5LGdGw69mdYSdEYGpbxm2",  # pragma: allowlist secret
     host="https://eu.i.posthog.com",
     disabled=_should_disable(),
-    disable_geoip=_should_disable(),
+    disable_geoip=_should_disable_geoip(),
 )
 
 
@@ -134,6 +143,7 @@ def disable_telemetry() -> None:
     Disable telemetry. Overrides the environment variable settings.
     """
     telemetry.disabled = True
+    telemetry.disable_geoip = True
 
 
 # Tracks whether we are currently inside any telemetry scope.


### PR DESCRIPTION
## Description

This PR updates the telemetry client call, making possible to dynamically disable GeoIP data (before it was always disabled).